### PR TITLE
Invalid TinyDB request in find_one

### DIFF
--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -110,7 +110,7 @@ class TinyMongoCollection(object):
     def find_one(self,query={},fields={}):
         if self.table is None:self.buildTable()
         allcond = self.parseQuery(query)
-        if allcond is None:return self.table.get({})
+        if allcond is None:return self.table.get(eid=1)
         return self.table.get(allcond)
         
     def count(self):


### PR DESCRIPTION
TinyDB `get()` expects a query instead of a dictionary.  Also, when getting multiple matches, it will return a random item (https://tinydb.readthedocs.io/en/latest/usage.html#retrieving-data).

The solutions that I can see are either to:

1. Select all elements from the table, then get the first one from the list (this pull request).
2. Or, we can make a query that selects all, like `Query()["_id"].exists()`.  I don't know if this would return the fist item every time, or a random one.