### PR TITLE
Count function on collection should get all documents

### DIFF
--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -115,7 +115,7 @@ class TinyMongoCollection(object):
         
     def count(self):
         if self.table is None:self.buildTable()
-        return self.table.count(self.lastcond)
+        return len(self.table)
         
         
 class TinyMongoCursor(object):


### PR DESCRIPTION
The tinymongo count function on a collection currently returns a count based on the last query (if I understand the code correctly). The [pymongo specs on counting](http://api.mongodb.com/python/current/tutorial.html#counting) state that count run on a collection returns all of the documents in a collection. We could use `len(table)` instead to get the length of the whole collection.  This would be the same as we do for a cursor ([Count Function in Cursor](https://github.com/schapman1974/tinymongo/blob/8a077101b689c5e18db7d0f155577eb59a44b6a3/tinymongo/tinymongo.py#L159)).