### PR TITLE
Remove old lastcond variable.

### DIFF
--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -87,8 +87,6 @@ class TinyMongoCollection(object):
             else:
                 allcond=allcond & (theop(self.query[akey],avalue))
             cnt+=1
-        if not allcond is None:self.lastcond = allcond
-        else:self.lastcond={}
         return allcond
         
     def update(self,query,data,argsdict={},**kwargs):


### PR DESCRIPTION
We no longer need lastcond anymore because we are no longer reusing queries.  We could keep it just in case we needed it later though.
Started from #3.