### PR TITLE
Change 'query' named paramater for 'filter' in find() and find_one()

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -84,6 +84,11 @@ def test_initialize_collection(collection):
     assert c.count() == 100
 
 
+def test_find_with_filter_named_parameter(collection):
+    c = collection.find(filter={})
+    assert c.count() == 100
+
+
 def test_greater_than(collection):
     """
     Testing the greater than operator
@@ -182,6 +187,11 @@ def test_find_one(collection):
     """
     c = collection.find_one({'count': 3})
 
+    assert c['countStr'] == '3'
+
+
+def test_find_one_with_filter_named_parameter(collection):
+    c = collection.find_one(filter={'count': 3})
     assert c['countStr'] == '3'
 
 

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -231,7 +231,7 @@ class TinyMongoCollection(object):
         # todo: return result with result.matched_count and result.modified_count
         return True
 
-    def find(self, query=None):
+    def find(self, filter=None):
         u"""
         Finds all matching results
 
@@ -241,11 +241,11 @@ class TinyMongoCollection(object):
         if self.table is None:
             self.build_table()
 
-        allcond = self.parse_query(query)
+        allcond = self.parse_query(filter)
 
         return TinyMongoCursor(self.table.search(allcond))
 
-    def find_one(self, query=None):
+    def find_one(self, filter=None):
         u"""
         Finds one matching query element
 
@@ -256,7 +256,7 @@ class TinyMongoCollection(object):
         if self.table is None:
             self.build_table()
 
-        allcond = self.parse_query(query)
+        allcond = self.parse_query(filter)
 
         return self.table.get(allcond)
 


### PR DESCRIPTION
In pymongo this paramater is called 'filter'. As it is a named
parameter, it should be expected to be used explicitly naming the
parameter name, so the name must be preserved.

Solves #22