### PR TITLE
Improvements on serializers, now it allows adding middlewares

### DIFF
--- a/tinymongo/serializers.py
+++ b/tinymongo/serializers.py
@@ -11,12 +11,12 @@ except ImportError:
 class DateTimeSerializer(Serializer):
     OBJ_CLASS = datetime
 
-    def __init__(self, format='%Y-%m-%dT%H:%M:%S', *args, **kwargs):
-        super(DateTimeSerializer, self).__init__(*args, **kwargs)
-        self._format = format
+    def __init__(self, dateformat='%Y-%m-%dT%H:%M:%S', *args, **kwargs):
+        # super(DateTimeSerializer, self).__init__(*args, **kwargs)
+        self._format = dateformat
 
     def encode(self, obj):
         return obj.strftime(self._format)
 
     def decode(self, s):
-        return datetime.strptime(s, self._format)
+        return self.OBJ_CLASS.strptime(s, self._format)

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -25,14 +25,40 @@ logger = logging.getLogger(__name__)
 
 class TinyMongoClient(object):
     """Represents the Tiny `db` client"""
-    def __init__(self, foldername=u"tinydb", storage=None):
+    def __init__(self, foldername=u"tinydb"):
         """Initialize container folder"""
         self._foldername = foldername
-        self._storage = storage or TinyDB.DEFAULT_STORAGE
         try:
             os.mkdir(foldername)
         except OSError as x:
             logger.info('{}'.format(x))
+
+    @property
+    def _storage(self):
+        """By default return Tiny.DEFAULT_STORAGE and can be overwritten to
+        return custom storages and middlewares.
+
+            class CustomClient(TinyMongoClient):
+                @property
+                def _storage(self):
+                    return CachingMiddleware(OtherMiddleware(JSONMiddleware))
+
+        This property is also useful to define Serializers using required
+        `tinydb-serialization` module.
+
+            from tinymongo.serializers import DateTimeSerializer
+            from tinydb_serialization import SerializationMiddleware
+            class CustomClient(TinyMongoClient):
+                @property
+                def _storage(self):
+                    serialization = SerializationMiddleware()
+                    serialization.register_serializer(
+                        DateTimeSerializer(), 'TinyDate')
+                    # register other custom serializers
+                    return serialization
+
+        """
+        return TinyDB.DEFAULT_STORAGE
 
     def __getitem__(self, key):
         """Gets a new or existing database based in key"""


### PR DESCRIPTION
- I have found a problem on my previous implementation, it was using the same storage for every table so i created a `@property` to return a new instance for every table.
- Now users have to subclass `TinyMongoClient` and override the `_storage` property to return custom storages and middlewares.
- Now it allows more flexibility to control the middleware construction