### PR TITLE
added 'ugly' support for mongoDB '$regex' query condition

### DIFF
--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -266,6 +266,14 @@ class TinyMongoCollection(object):
                 conditions = (
                     q[prev_key] != value
                 ) if not conditions else (conditions & (q[prev_key] != value))
+            elif key == u'$regex':
+                value = value.replace('\\\\\\', '|||')
+                value = value.replace('\\\\', '|||')
+                regex = value.replace('\\', '')
+                regex = regex.replace('|||', '\\')
+                conditions = (
+                    where(prev_key).matches(regex)
+                ) if not conditions else (conditions & (where(prev_key).matches(regex)))
             elif key in ['$and', '$or']:
                 pass
             else:


### PR DESCRIPTION
flask_admin.contrib.pymongo.filters.FilterLike appends '$regex' with unicoded/re.escape'd regular expression/search term. This commit would work for me, improvements welcome :)