### PR TITLE
FIxes #33 - requirement.txt sourcing inside wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def parse_md_to_rst(file):
 
 
 with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
+    REQUIREMENTS = f.read().splitlines()
 
 
 setup(
@@ -39,5 +39,6 @@ setup(
     keywords=['mongodb', 'drop-in', 'database', 'tinydb'],
     long_description=parse_md_to_rst("README.md"),
     classifiers=[],
-    install_requires=requirements
+    package_data={'':['requirements.txt', 'README.md', 'LICENSE.txt']},
+    install_requires=REQUIREMENTS
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def parse_md_to_rst(file):
 
 
 with open('requirements.txt') as f:
-    REQUIREMENTS = f.read().splitlines()
+    requirements = f.read().splitlines()
 
 
 setup(
@@ -39,6 +39,5 @@ setup(
     keywords=['mongodb', 'drop-in', 'database', 'tinydb'],
     long_description=parse_md_to_rst("README.md"),
     classifiers=[],
-    package_data={'':['requirements.txt', 'README.md', 'LICENSE.txt']},
-    install_requires=REQUIREMENTS
+    install_requires=requirements
 )


### PR DESCRIPTION
Though I'd prefer not to source `requirements.txt` raw, this should be a drop-in replacement without messing with setup.py more directly.

Builds passing: https://travis-ci.org/lockefox/tinymongo/builds/220723767

Fixes #33 