### PR TITLE
adding README to MANIFEST for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements.txt
+include README.md


### PR DESCRIPTION
README.md is required by setup.py to install via pip

Now should be fixed for pypi