### PR TITLE
count() method for the TinyMongoCollection class

### DIFF
--- a/tests/test_tinymongo.py
+++ b/tests/test_tinymongo.py
@@ -114,7 +114,9 @@ def test_initialize_collection(collection):
 
     assert count == 100
     assert c.count() == 100
+    assert collection['tiny'].count() == 100
     assert collection['mongo'].find({}).count() == 100
+    assert collection['mongo'].count() == 100
 
 
 def test_find_with_filter_named_parameter(collection):
@@ -299,6 +301,7 @@ def test_ne(collection):
     for item in c:
         assert item['countStr'] != '50'
 
+
 def test_regex(collection):
     """
     Testing the regex query
@@ -322,7 +325,8 @@ def test_regex(collection):
     assert c[1]['count'] == 25
     assert c[4]['count'] == 65
     assert c[7]['count'] == 95
-    
+
+
 def test_in(collection):
     """
     Testing the $in query with list of values as parameter
@@ -484,6 +488,7 @@ def test_or(collection):
     """
     c = collection['tiny'].find({"$or": [{"count": {"$lt": 10}}, {"count": {"$gte": 90}}]})
     assert c.count() == 20
+
 
 def test_not(collection):
     """

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -142,6 +142,13 @@ class TinyMongoCollection(object):
         """
         self.table = self.parent.tinydb.table(self.tablename)
 
+    def count(self):
+        """
+        Counts the documents in the collection.
+        :return: Integer representing the number of documents in the collection.
+        """
+        return self.find().count()
+
     def insert(self, docs, *args, **kwargs):
         """Backwards compatibility with insert"""
         if isinstance(docs, list):


### PR DESCRIPTION
As per MongoDB specification, the Collection model also has the count() method (`collection.count()`), which is the same as `collection.find().count()`.

See the reference manual: [https://docs.mongodb.com/manual/reference/method/db.collection.count/](https://docs.mongodb.com/manual/reference/method/db.collection.count/) 