### PR TITLE
issue #47 implementation: drop collection

### DIFF
--- a/tests/test_tinymongo.py
+++ b/tests/test_tinymongo.py
@@ -119,6 +119,18 @@ def test_initialize_collection(collection):
     assert collection['mongo'].count() == 100
 
 
+def test_drop_collection(collection):
+    c = collection['tiny'].find({})
+
+    # assert True for successful drop
+    assert collection.drop() is True
+    assert c.drop() is True
+
+    # assert False because collection does not exist anymore
+    assert collection.drop() is False
+    assert c.drop() is False
+
+
 def test_find_with_filter_named_parameter(collection):
     c = collection['tiny'].find(filter={})
     assert c.count() == 100

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -149,6 +149,19 @@ class TinyMongoCollection(object):
         """
         return self.find().count()
 
+    def drop(self, **kwargs):
+        """
+        Removes a collection from the database.
+        **kwargs only because of the optional "writeConcern" field, but does nothing in the TinyDB database.
+        :return: Returns True when successfully drops a collection. Returns False when collection to drop does not
+        exist.
+        """
+        if self.table:
+            self.parent.purge_table(self.tablename)
+            return True
+        else:
+            return False
+
     def insert(self, docs, *args, **kwargs):
         """Backwards compatibility with insert"""
         if isinstance(docs, list):


### PR DESCRIPTION
The `drop()` method for a collection model implemented (see this [MongoDB reference](https://docs.mongodb.com/manual/reference/method/db.collection.drop/)).

There's this TODO on line 35: `todo: the 'drop()' function from pymongo should work in future revisions`

I don't think it's necessary to have the `drop()` at that line. I think it's better to keep `delete_many()`, because it's about emptying a collection, not deleting it.

Should I remove the TODO line?