### PR TITLE
Update setup.py for exact tinydb dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ setup(
         'Programming Language :: Python :: 3.7'
     ],
     install_requires=[
-        'tinydb>=3.2.1',
-        'tinydb_serialization>=1.0.4',
+        'tinydb==3.2.1',
+        'tinydb_serialization==1.0.4',
         'pymongo>=3.4.0'
     ],
     tests_require=[


### PR DESCRIPTION
Hi, I've installed tinymongo today and had an error.
This is because there are newer versions of tinydb and tinydb_serialization which are not backwards compatible.
In order for one to be able to just pip install and use your package, I have updated the dependencies in the setup.py to be fixed version (instead of >=).

If you want you can accept this pull request.

Thank you for your repository, it is helpful to me :),
Elad Levy.