### PR TITLE
Add storage backend support and fix CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/tests/test_multi_write.py
+++ b/tests/test_multi_write.py
@@ -1,8 +1,6 @@
 import os
 import multiprocessing as mp
-import time
 import shutil
-import random
 
 import tinymongo as tm
 

--- a/tests/test_storage_backends.py
+++ b/tests/test_storage_backends.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import tinymongo as tm
 

--- a/tests/test_tinymongo.py
+++ b/tests/test_tinymongo.py
@@ -89,8 +89,8 @@ def test_initialize_db():
 
     :return:
     """
-    tiny_client = tm.TinyMongoClient(db_name)
-    another_client = tm.TinyMongoClient(db_name)
+    tm.TinyMongoClient(db_name)
+    tm.TinyMongoClient(db_name)
     assert True
 
 
@@ -431,7 +431,7 @@ def test_update_one_set(collection):
     """
     cu = collection['tiny'].update_one({'count': 3}, {'$set': {'countStr': 'three'}})
     # cu.raw_result contains the updated ids
-    assert len(cu.raw_result) is 1  # only one is updated
+    assert len(cu.raw_result) == 1  # only one is updated
 
     c = collection['tiny'].find_one({'count': 3})
     assert c['countStr'] == 'three'

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -8,7 +8,6 @@ from functools import reduce
 import logging
 import os
 from math import ceil
-from operator import itemgetter
 from uuid import uuid1
 
 from tinydb import Query, TinyDB, where


### PR DESCRIPTION
## Summary
- add optional storage backend support and related tests
- keep TinyDB JSON as the default storage backend
- fix CI lint failures in tests and tinymongo imports
- update docs to remove fork wording and correct backend/default storage notes
- update setup.cfg metadata key to avoid setuptools deprecation

## Verification
- .venv/bin/python -m pytest -q
- .venv/bin/python -m ruff check .
- .venv/bin/python -m build
- .venv/bin/python -m twine check dist/*