### PR TITLE
Add table-native backends, CLI, benchmarks, and PyMongo compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 ## [1.0.0] - 2026-06-19
 
 ### Added
-- Default Parquet v2 storage backend using `pyarrow` for improved performance and reliability.
+- TinyDB JSON remains the default storage backend.
+- Optional Parquet v2, SQLite, and DuckDB storage backends.
+- `tinymongo` CLI with inspect, list, export, import, and migrate commands.
+- Opt-in integration stress tests for concurrent multi-process writes.
 - Atomic multi-writer file operations with temp-file replace and optional advisory locking via `portalocker`.
 - Comprehensive Mongo-like query coverage and new tests for `$and`, `$or`, `$not`, `$in`, `$all`, nested document queries, and concurrency.
+- Additional update operator support for `$set`, `$unset`, `$inc`, `$push`, `$pull`, and `$addToSet`.
+- Lightweight in-memory collection index APIs for repeated equality lookups.
 - GitHub Actions CI workflow for Python 3.9, 3.10, and 3.11.
 - Optional `uv` extra support via `uvicorn`.
 - A new benchmark harness comparing Parquet storage to TinyDB JSON storage.
@@ -18,3 +23,4 @@
 
 ### Fixed
 - Parquet writer compatibility issues with older `pyarrow` versions.
+- Stale documentation that incorrectly described Parquet as the default backend.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include requirements.txt
 include README.md
+recursive-include examples *.py
+recursive-include tests *.py *.json

--- a/README.md
+++ b/README.md
@@ -36,9 +36,35 @@ compilers or tools besides those contained within Python itself.
 # Project notes
 
 - **Default storage:** TinyMongo uses TinyDB's default JSON storage unless another backend is selected.
-- **Optional storage backends:** Parquet v2, SQLite, and DuckDB backends are available by passing `backend="parquet"`, `backend="sqlite"`, or `backend="duckdb"` to `TinyMongoClient`.
+- **Optional storage backends:** Parquet v2, SQLite, and DuckDB backends are available.
 - **Concurrency:** writes use atomic temp-file replace and optional advisory locks (`portalocker`) to reduce corruption risk under concurrent writers.
 - **Tests & CI:** a GitHub Actions workflow is included at `.github/workflows/ci.yml` to run unit tests and linters across Python versions. See `requirements-dev.txt` for dev dependencies.
+
+
+# Backend options
+
+TinyMongo defaults to TinyDB's JSON storage:
+
+```python
+    from tinymongo import TinyMongoClient
+
+    connection = TinyMongoClient("/path/to/folder")
+```
+
+You can select another backend with the `backend` argument:
+
+```python
+    parquet_connection = TinyMongoClient("/path/to/folder", backend="parquet")
+    sqlite_connection = TinyMongoClient("/path/to/folder", backend="sqlite")
+    duckdb_connection = TinyMongoClient("/path/to/folder", backend="duckdb")
+```
+
+Available backends:
+
+- `tinydb` or `json`: TinyDB's default JSON storage. This is the default and writes `.json` files.
+- `parquet` or `parquetv2`: Parquet v2 storage backed by `pyarrow`. This writes `.parquet` files.
+- `sqlite`: SQLite storage using Python's standard `sqlite3` module. This writes `.sqlite` files.
+- `duckdb`: DuckDB storage. Install `duckdb` before using this backend. This writes `.duckdb` files.
 
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ This
 is a pure python distribution and - thus - should require no external
 compilers or tools besides those contained within Python itself.
 
-# Notes for this fork
+# Project notes
 
-- **Default storage:** this fork uses Parquet v2 files by default (via `pyarrow`) for improved I/O performance and reliability. If `pyarrow` is not available, it falls back to TinyDB's default JSON storage.
+- **Default storage:** TinyMongo uses TinyDB's default JSON storage unless another backend is selected.
+- **Optional storage backends:** Parquet v2, SQLite, and DuckDB backends are available by passing `backend="parquet"`, `backend="sqlite"`, or `backend="duckdb"` to `TinyMongoClient`.
 - **Concurrency:** writes use atomic temp-file replace and optional advisory locks (`portalocker`) to reduce corruption risk under concurrent writers.
 - **Tests & CI:** a GitHub Actions workflow is included at `.github/workflows/ci.yml` to run unit tests and linters across Python versions. See `requirements-dev.txt` for dev dependencies.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ attempt to add an interface familiar to those currently using pymongo.
 
 # Status
 
-Unit testing is currently being worked on and functionality is being
-added to the library.  Current coverage is 93%.  Current builds tested
-on Python versions 2.7 and 3.3+.
+TinyMongo targets modern Python 3 and is tested in GitHub Actions on
+Python 3.9, 3.10, and 3.11.
 
 # Installation
 
@@ -39,6 +38,34 @@ compilers or tools besides those contained within Python itself.
 - **Optional storage backends:** Parquet v2, SQLite, and DuckDB backends are available.
 - **Concurrency:** writes use atomic temp-file replace and optional advisory locks (`portalocker`) to reduce corruption risk under concurrent writers.
 - **Tests & CI:** a GitHub Actions workflow is included at `.github/workflows/ci.yml` to run unit tests and linters across Python versions. See `requirements-dev.txt` for dev dependencies.
+
+
+# PyMongo-style import
+
+TinyMongo exposes `MongoClient`, `ASCENDING`, and `DESCENDING` aliases so small
+PyMongo-style scripts can be tried against local file-backed storage by changing
+the import:
+
+```python
+import tinymongo as pymongo
+
+client = pymongo.MongoClient(
+    "mongodb://localhost:27017",
+    serverSelectionTimeoutMS=2000,
+    tinymongo_folder="/path/to/folder",
+)
+users = client.app.users
+users.insert_one({"email": "ada@example.com", "score": 7})
+users.update_one({"email": "ada@example.com"}, {"$inc": {"score": 1}})
+rows = list(users.find({}).sort("score", pymongo.DESCENDING))
+```
+
+This is intended for the supported TinyMongo subset of PyMongo operations, not
+for server features such as authentication, replica sets, aggregation pipelines,
+sessions, or network connections. MongoDB URIs, host names, ports, and common
+connection kwargs are accepted and ignored so existing code can be tried locally.
+Set `TINYMONGO_HOME` or pass `tinymongo_folder=` to choose where TinyMongo stores
+files. See `examples/pymongo_dropin.py` for a runnable example.
 
 
 # Backend options
@@ -65,6 +92,117 @@ Available backends:
 - `parquet` or `parquetv2`: Parquet v2 storage backed by `pyarrow`. This writes `.parquet` files.
 - `sqlite`: SQLite storage using Python's standard `sqlite3` module. This writes `.sqlite` files.
 - `duckdb`: DuckDB storage. Install `duckdb` before using this backend. This writes `.duckdb` files.
+
+| Backend | Dependency | Best fit | Notes |
+| --- | --- | --- | --- |
+| `tinydb` / `json` | TinyDB | Default local JSON files | Human-readable and simplest to inspect. |
+| `parquet` / `parquetv2` | `pyarrow` | Columnar file workflows | Useful when downstream tools already consume Parquet. |
+| `sqlite` | Python standard library | Single-file durability | Good default alternative for users who want a database container file. |
+| `duckdb` | `duckdb` | Analytics-oriented local data | Useful when DuckDB is already part of the project stack. |
+
+Local load-test results for these backends are documented in
+[docs/BENCHMARKS.md](docs/BENCHMARKS.md).
+
+
+# Command line tools
+
+The package installs a `tinymongo` command for inspecting and moving data:
+
+```bash
+tinymongo inspect ./tinydb
+tinymongo list-dbs ./tinydb
+tinymongo list-collections ./tinydb my_tiny_database
+tinymongo export ./tinydb my_tiny_database users -o users.json
+tinymongo import ./tinydb my_tiny_database users users.json --mode replace
+tinymongo migrate ./tinydb ./sqlite-db --to-backend sqlite
+```
+
+Use `--backend` with `inspect`, `list-dbs`, `list-collections`, `export`, and
+`import` when reading or writing a non-default backend:
+
+```bash
+tinymongo inspect ./sqlite-db --backend sqlite
+tinymongo export ./parquet-db app users --backend parquet -o users.json
+```
+
+
+# Integration and stress testing
+
+Unit tests exclude integration stress tests by default. Run the normal suite with:
+
+```bash
+pytest
+```
+
+Run local integration stress tests explicitly with:
+
+```bash
+pytest -m integration
+```
+
+The concurrent write stress tests are configurable with environment variables:
+
+```bash
+TINYMONGO_INTEGRATION_PROCS=32 \
+TINYMONGO_INTEGRATION_WRITES_PER_PROC=100 \
+pytest -m integration tests/integration/test_concurrent_writes.py
+```
+
+That default bulk-write run produces 3,200 concurrent writes. For a larger local
+run:
+
+```bash
+TINYMONGO_INTEGRATION_PROCS=64 \
+TINYMONGO_INTEGRATION_WRITES_PER_PROC=250 \
+pytest -m integration tests/integration/test_concurrent_writes.py
+```
+
+The single-insert smoke test can be tuned separately:
+
+```bash
+TINYMONGO_INTEGRATION_SINGLE_PROCS=16 \
+TINYMONGO_INTEGRATION_SINGLE_WRITES_PER_PROC=100 \
+pytest -m integration tests/integration/test_concurrent_writes.py
+```
+
+Use `TINYMONGO_INTEGRATION_BACKEND=sqlite` or another supported backend to run
+the same integration tests against a non-default backend.
+
+
+# Mongo compatibility
+
+TinyMongo intentionally implements a practical subset of PyMongo's collection
+API. It supports common inserts, finds, updates, deletes, sorting, pagination,
+and collection counting. Query support includes equality, nested document paths,
+`$gt`, `$gte`, `$lt`, `$lte`, `$ne`, `$nin`, `$in`, `$all`, `$and`, `$or`,
+`$not`, `$regex`, and `$exists`.
+
+Update support includes replacement-style updates plus `$set`, `$unset`, `$inc`,
+`$push`, `$pull`, and `$addToSet`.
+
+Collections also expose lightweight in-memory equality indexes:
+
+```python
+    collection.create_index("email")
+    collection.find({"email": "person@example.com"})
+    collection.list_indexes()
+    collection.drop_index("email")
+```
+
+Indexes are scoped to the active collection object and are rebuilt from stored
+documents as needed. They are a convenience for repeated equality lookups, not a
+durable query-planner feature.
+
+TinyMongo includes PyMongo-shaped contract tests that run application code with
+`import pymongo` redirected to TinyMongo:
+
+```bash
+pytest tests/test_pymongo_contract.py tests/test_pymongo_dropin.py
+```
+
+PyMongo's full upstream driver test suite targets a real MongoDB server and
+driver internals, so it is not expected to pass against TinyMongo. The contract
+tests are the supported compatibility boundary for local file-backed usage.
 
 
 # Examples

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,62 @@
+# Storage Backend Load Test Results
+
+These numbers are local benchmark results from the TinyMongo storage load
+benchmark. They are useful for comparing relative behavior on this machine, not
+for making universal performance claims.
+
+## Methodology
+
+Command:
+
+```bash
+.venv/bin/python tests/benchmarks/bench_storage.py \
+  --docs 1000 \
+  --queries 200 \
+  --json-output /tmp/tinymongo-storage-load-1000.json
+```
+
+Workload:
+
+- Insert 1,000 documents with `insert_many`.
+- Read all documents once with `find({})`.
+- Run 200 point lookups with `find_one({"_id": ...})`.
+- Update 10% of documents with `update_many({"group": "g1"}, {"$inc": {"i": 1}})`.
+- Delete 10% of documents with `delete_many({"group": "g2"})`.
+- Measure final storage size on disk.
+
+Environment:
+
+- Date: 2026-07-03
+- Python: local project virtualenv
+- `pyarrow`: 21.0.0
+- `duckdb`: 1.4.5
+- `portalocker`: 3.2.0
+
+During Parquet runs, `pyarrow` printed macOS sandbox warnings about CPU cache
+metadata lookup. The benchmark completed successfully.
+
+## Results
+
+| Backend | Insert docs/s | Read docs/s | Avg point lookup ms | p95 point lookup ms | Update s | Delete s | Size KiB |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| tinydb | 15,941 | 465,965 | 1.280 | 1.442 | 0.302 | 0.286 | 66.4 |
+| parquet | 76,685 | 436,284 | 1.746 | 1.931 | 0.684 | 0.715 | 16.6 |
+| sqlite | 105,547 | 491,592 | 1.397 | 1.542 | 0.465 | 0.427 | 72.0 |
+| duckdb | 13,260 | 140,301 | 6.751 | 7.327 | 2.240 | 2.186 | 1,036.0 |
+
+## Notes
+
+- SQLite had the fastest bulk insert rate in this run.
+- Parquet produced the smallest file and strong bulk insert throughput.
+- TinyDB JSON remained competitive for reads and point lookups at this size.
+- DuckDB worked correctly but had the largest file and slowest point lookup,
+  update, and delete times in this TinyDB-storage-wrapper workload.
+- A 5,000-document full matrix was intentionally not used for the chart because
+  DuckDB delete performance made it too slow for a quick local documentation
+  benchmark.
+
+Regenerate the chart with:
+
+```bash
+.venv/bin/python tests/benchmarks/bench_storage.py
+```

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,8 @@ This guide helps you migrate from earlier `tinymongo` versions to `1.0.0`.
 - The package now uses `pyproject.toml` for packaging metadata.
 - Default storage remains TinyDB JSON storage.
 - Parquet v2, SQLite, and DuckDB are available as optional storage backends.
+- A `tinymongo` CLI is available for inspecting, exporting, importing, and migrating data.
+- Common update operators and lightweight in-memory equality indexes are supported.
 - Concurrent writes are safer due to atomic file replace and optional file locks.
 - Optional `uv` extras are available for dependency-managed ASGI usage.
 
@@ -28,4 +30,6 @@ pip install .[uv]
 - The default storage uses TinyDB JSON storage.
 - Parquet storage requires `pyarrow`; DuckDB storage requires `duckdb`.
 - Select optional storage backends with `TinyMongoClient(path, backend="parquet")`, `backend="sqlite"`, or `backend="duckdb"`.
+- Use `tinymongo migrate SOURCE TARGET --to-backend sqlite` to copy existing TinyDB JSON data into another backend.
+- In-memory indexes created with `collection.create_index("field")` are scoped to the active collection object and are rebuilt from stored documents as needed.
 - For local development, install `requirements-dev.txt` and run `pytest -q`.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -5,7 +5,8 @@ This guide helps you migrate from earlier `tinymongo` versions to `1.0.0`.
 ## Key changes
 
 - The package now uses `pyproject.toml` for packaging metadata.
-- Default storage is now Parquet v2 (`pyarrow`) instead of TinyDB JSON files.
+- Default storage remains TinyDB JSON storage.
+- Parquet v2, SQLite, and DuckDB are available as optional storage backends.
 - Concurrent writes are safer due to atomic file replace and optional file locks.
 - Optional `uv` extras are available for dependency-managed ASGI usage.
 
@@ -24,6 +25,7 @@ pip install .[uv]
 
 ## Notes
 
-- The default storage uses Parquet and requires `pyarrow`.
-- If `pyarrow` is not installed, `tinymongo` falls back to TinyDB JSON storage.
+- The default storage uses TinyDB JSON storage.
+- Parquet storage requires `pyarrow`; DuckDB storage requires `duckdb`.
+- Select optional storage backends with `TinyMongoClient(path, backend="parquet")`, `backend="sqlite"`, or `backend="duckdb"`.
 - For local development, install `requirements-dev.txt` and run `pytest -q`.

--- a/examples/pymongo_dropin.py
+++ b/examples/pymongo_dropin.py
@@ -1,0 +1,42 @@
+"""PyMongo-style usage backed by TinyMongo.
+
+Change only the import line to try local file-backed storage:
+
+    import tinymongo as pymongo
+
+The rest of this file intentionally uses common PyMongo names.
+"""
+
+import tempfile
+
+import tinymongo as pymongo
+
+
+def run_example(path=None):
+    db_path = path or tempfile.mkdtemp(prefix="tinymongo-pymongo-dropin-")
+    client = pymongo.MongoClient(
+        "mongodb://localhost:27017",
+        serverSelectionTimeoutMS=2000,
+        tinymongo_folder=db_path,
+    )
+    users = client.app.users
+
+    users.delete_many({})
+    users.create_index("email")
+    users.insert_many(
+        [
+            {"_id": 1, "email": "ada@example.com", "name": "Ada", "score": 7},
+            {"_id": 2, "email": "grace@example.com", "name": "Grace", "score": 9},
+        ]
+    )
+    users.update_one({"email": "ada@example.com"}, {"$inc": {"score": 1}})
+
+    rows = list(users.find({"score": {"$gte": 8}}).sort("score", pymongo.DESCENDING))
+    users.delete_one({"_id": 1})
+    client.close()
+    return rows
+
+
+if __name__ == "__main__":
+    for row in run_example():
+        print(row)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 Homepage = "https://github.com/schapman1974/tinymongo"
 Source = "https://github.com/schapman1974/tinymongo"
 
+[project.scripts]
+tinymongo = "tinymongo.cli:main"
+
 [tool.black]
 line-length = 88
 
@@ -40,7 +43,10 @@ python_version = 3.8
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-q"
+addopts = "-q -m 'not integration'"
+markers = [
+  "integration: opt-in integration and stress tests that may be slower or resource intensive",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -51,4 +57,3 @@ include-package-data = true
 
 [project.optional-dependencies]
 uv = ["uvicorn>=0.23.0"]
-

--- a/tests/benchmarks/bench_storage.py
+++ b/tests/benchmarks/bench_storage.py
@@ -1,50 +1,176 @@
-import time
-import shutil
+"""Local load benchmark for TinyMongo storage backends.
+
+This is intentionally not a pytest test. Run it directly when you want local
+performance numbers for README/docs updates.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import json
 import os
-from tinydb import TinyDB
-from tinydb.storages import JSONStorage
+import shutil
+import statistics
+import tempfile
+import time
 
 import tinymongo as tm
 
 
-def _time_parquet(n=1000):
-    d = os.path.abspath("./bench_parquet_db")
-    if os.path.exists(d):
-        shutil.rmtree(d)
-    os.makedirs(d, exist_ok=True)
-
-    client = tm.TinyMongoClient(d)
-    c = client.bench.collection
-
-    docs = [{"i": i, "v": str(i)} for i in range(n)]
-    t0 = time.time()
-    c.insert_many(docs)
-    t1 = time.time()
-    return t1 - t0
+BACKENDS = ("tinydb", "parquet", "sqlite", "duckdb")
 
 
-def _time_json(n=1000):
-    d = os.path.abspath("./bench_json_db")
-    if os.path.exists(d):
-        shutil.rmtree(d)
-    os.makedirs(d, exist_ok=True)
-
-    path = os.path.join(d, "bench.json")
-    db = TinyDB(path, storage=JSONStorage)
-    table = db.table("collection")
-    docs = [{"i": i, "v": str(i)} for i in range(n)]
-    t0 = time.time()
-    table.insert_multiple(docs)
-    t1 = time.time()
-    return t1 - t0
+def _docs(count):
+    return [
+        {
+            "_id": "doc-{0}".format(index),
+            "i": index,
+            "group": "g{0}".format(index % 10),
+            "payload": "value-{0}".format(index),
+        }
+        for index in range(count)
+    ]
 
 
-def run_benchmarks():
-    for n in (100, 1000):
-        p = _time_parquet(n)
-        j = _time_json(n)
-        print(f"n={n} parquet={p:.3f}s json={j:.3f}s")
+def _time_call(func):
+    started = time.perf_counter()
+    result = func()
+    return time.perf_counter() - started, result
+
+
+def _percentile(values, percentile):
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = int(round((percentile / 100.0) * (len(ordered) - 1)))
+    return ordered[index]
+
+
+def _available_backend(backend):
+    if backend == "duckdb":
+        try:
+            __import__("duckdb")
+        except Exception:
+            return False
+    if backend in ("parquet", "parquetv2"):
+        try:
+            __import__("pyarrow")
+        except Exception:
+            return False
+    return True
+
+
+def run_backend(backend, doc_count, query_count, work_root):
+    if not _available_backend(backend):
+        return {
+            "backend": backend,
+            "available": False,
+            "reason": "optional dependency is not installed",
+        }
+
+    db_dir = os.path.join(work_root, backend)
+    if os.path.exists(db_dir):
+        shutil.rmtree(db_dir)
+    os.makedirs(db_dir, exist_ok=True)
+
+    client = tm.TinyMongoClient(db_dir, backend=backend)
+    collection = client.loadtest.records
+    docs = _docs(doc_count)
+
+    insert_seconds, _ = _time_call(lambda: collection.insert_many(docs))
+    read_seconds, all_docs = _time_call(lambda: list(collection.find({})))
+
+    query_latencies = []
+    for index in range(query_count):
+        target = "doc-{0}".format(index % doc_count)
+        elapsed, found = _time_call(lambda target=target: collection.find_one({"_id": target}))
+        query_latencies.append(elapsed)
+        if found is None:
+            raise AssertionError("missing document {0}".format(target))
+
+    update_seconds, update_result = _time_call(
+        lambda: collection.update_many({"group": "g1"}, {"$inc": {"i": 1}})
+    )
+    delete_seconds, delete_result = _time_call(
+        lambda: collection.delete_many({"group": "g2"})
+    )
+    remaining = collection.count()
+
+    file_bytes = 0
+    for root, _, filenames in os.walk(db_dir):
+        for filename in filenames:
+            file_bytes += os.path.getsize(os.path.join(root, filename))
+
+    return {
+        "backend": backend,
+        "available": True,
+        "documents": doc_count,
+        "queries": query_count,
+        "insert_seconds": insert_seconds,
+        "insert_docs_per_second": doc_count / insert_seconds if insert_seconds else 0,
+        "read_seconds": read_seconds,
+        "read_docs_per_second": len(all_docs) / read_seconds if read_seconds else 0,
+        "query_avg_ms": statistics.mean(query_latencies) * 1000,
+        "query_p95_ms": _percentile(query_latencies, 95) * 1000,
+        "update_seconds": update_seconds,
+        "updated_docs": update_result.modified_count,
+        "delete_seconds": delete_seconds,
+        "deleted_docs": delete_result.deleted_count,
+        "remaining_docs": remaining,
+        "file_kib": file_bytes / 1024.0,
+    }
+
+
+def format_markdown(results):
+    rows = [
+        "| Backend | Insert docs/s | Read docs/s | Avg point lookup ms | p95 point lookup ms | Update s | Delete s | Size KiB |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        if not result.get("available"):
+            rows.append(
+                "| {backend} | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |".format(
+                    **result
+                )
+            )
+            continue
+        rows.append(
+            "| {backend} | {insert_docs_per_second:,.0f} | {read_docs_per_second:,.0f} | {query_avg_ms:.3f} | {query_p95_ms:.3f} | {update_seconds:.3f} | {delete_seconds:.3f} | {file_kib:,.1f} |".format(
+                **result
+            )
+        )
+    return "\n".join(rows)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--docs", type=int, default=1000)
+    parser.add_argument("--queries", type=int, default=200)
+    parser.add_argument("--backend", action="append", choices=BACKENDS)
+    parser.add_argument("--work-root")
+    parser.add_argument("--json-output")
+    args = parser.parse_args(argv)
+
+    backends = args.backend or list(BACKENDS)
+    work_root = args.work_root or tempfile.mkdtemp(prefix="tinymongo-bench-")
+    os.makedirs(work_root, exist_ok=True)
+
+    results = [run_backend(backend, args.docs, args.queries, work_root) for backend in backends]
+    payload = {
+        "documents": args.docs,
+        "queries": args.queries,
+        "work_root": work_root,
+        "results": results,
+    }
+
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+    print(format_markdown(results))
+    return 0
 
 
 if __name__ == "__main__":
-    run_benchmarks()
+    raise SystemExit(main())

--- a/tests/integration/test_concurrent_writes.py
+++ b/tests/integration/test_concurrent_writes.py
@@ -1,0 +1,142 @@
+import multiprocessing as mp
+import os
+import time
+
+import pytest
+
+import tinymongo as tm
+
+
+def _env_int(name, default):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _writer_process(db_dir, backend, proc_id, writes_per_proc, start, errors):
+    try:
+        start.wait(timeout=30)
+        client = tm.TinyMongoClient(db_dir, backend=backend)
+        collection = client.integrationDB.concurrentWrites
+        docs = [
+            {
+                "_id": "{0}-{1}".format(proc_id, index),
+                "proc": proc_id,
+                "index": index,
+                "value": proc_id * writes_per_proc + index,
+            }
+            for index in range(writes_per_proc)
+        ]
+        collection.insert_many(docs)
+    except Exception as exc:
+        errors.put("{0}: {1}".format(type(exc).__name__, exc))
+        raise
+
+
+@pytest.mark.integration
+def test_concurrent_bulk_writes_scale(tmp_path):
+    backend = os.environ.get("TINYMONGO_INTEGRATION_BACKEND", "tinydb")
+    processes = _env_int("TINYMONGO_INTEGRATION_PROCS", 32)
+    writes_per_proc = _env_int("TINYMONGO_INTEGRATION_WRITES_PER_PROC", 100)
+    expected = processes * writes_per_proc
+
+    db_dir = str(tmp_path / "tinymongo-stress")
+    start = mp.Barrier(processes)
+    errors = mp.Queue()
+    workers = [
+        mp.Process(
+            target=_writer_process,
+            args=(db_dir, backend, proc_id, writes_per_proc, start, errors),
+        )
+        for proc_id in range(processes)
+    ]
+
+    started = time.monotonic()
+    for worker in workers:
+        worker.start()
+
+    for worker in workers:
+        worker.join(timeout=120)
+
+    failed = [worker.exitcode for worker in workers if worker.exitcode != 0]
+    while not errors.empty():
+        failed.append(errors.get())
+
+    for worker in workers:
+        if worker.is_alive():
+            worker.terminate()
+            failed.append("timeout")
+
+    assert failed == []
+
+    client = tm.TinyMongoClient(db_dir, backend=backend)
+    collection = client.integrationDB.concurrentWrites
+    docs = list(collection.find({}))
+    values = sorted(doc["value"] for doc in docs)
+
+    assert len(docs) == expected
+    assert len({doc["_id"] for doc in docs}) == expected
+    assert values == list(range(expected))
+    assert time.monotonic() - started < 120
+
+
+def _single_insert_writer(db_dir, backend, proc_id, writes_per_proc, start, errors):
+    try:
+        start.wait(timeout=30)
+        client = tm.TinyMongoClient(db_dir, backend=backend)
+        collection = client.integrationDB.singleInserts
+        for index in range(writes_per_proc):
+            collection.insert_one(
+                {
+                    "_id": "{0}-{1}".format(proc_id, index),
+                    "proc": proc_id,
+                    "index": index,
+                }
+            )
+    except Exception as exc:
+        errors.put("{0}: {1}".format(type(exc).__name__, exc))
+        raise
+
+
+@pytest.mark.integration
+def test_concurrent_single_writes_smoke(tmp_path):
+    backend = os.environ.get("TINYMONGO_INTEGRATION_BACKEND", "tinydb")
+    processes = _env_int("TINYMONGO_INTEGRATION_SINGLE_PROCS", 8)
+    writes_per_proc = _env_int("TINYMONGO_INTEGRATION_SINGLE_WRITES_PER_PROC", 25)
+    expected = processes * writes_per_proc
+
+    db_dir = str(tmp_path / "tinymongo-single-stress")
+    start = mp.Barrier(processes)
+    errors = mp.Queue()
+    workers = [
+        mp.Process(
+            target=_single_insert_writer,
+            args=(db_dir, backend, proc_id, writes_per_proc, start, errors),
+        )
+        for proc_id in range(processes)
+    ]
+
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=120)
+
+    failed = [worker.exitcode for worker in workers if worker.exitcode != 0]
+    while not errors.empty():
+        failed.append(errors.get())
+
+    for worker in workers:
+        if worker.is_alive():
+            worker.terminate()
+            failed.append("timeout")
+
+    assert failed == []
+
+    docs = list(tm.TinyMongoClient(db_dir, backend=backend).integrationDB.singleInserts.find({}))
+    assert len(docs) == expected
+    assert len({doc["_id"] for doc in docs}) == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,134 @@
+import json
+
+import pytest
+import tinymongo as tm
+from tinymongo import cli
+
+
+def test_cli_inspect_export_import_and_migrate(tmp_path, capsys):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    export_file = tmp_path / "users.json"
+
+    client = tm.TinyMongoClient(str(source))
+    users = client.app.users
+    users.insert_many([
+        {"_id": 1, "name": "Ada"},
+        {"_id": 2, "name": "Grace"},
+    ])
+
+    assert cli.main(["list-dbs", str(source)]) == 0
+    assert "app" in capsys.readouterr().out
+
+    assert cli.main(["list-collections", str(source), "app"]) == 0
+    assert "users" in capsys.readouterr().out
+
+    assert cli.main(["inspect", str(source)]) == 0
+    inspected = json.loads(capsys.readouterr().out)
+    assert inspected["databases"][0]["name"] == "app"
+    collections = {
+        item["name"]: item["count"] for item in inspected["databases"][0]["collections"]
+    }
+    assert collections["users"] == 2
+
+    assert cli.main(["export", str(source), "app", "users", "-o", str(export_file)]) == 0
+    assert json.loads(export_file.read_text()) == [
+        {"_id": 1, "name": "Ada"},
+        {"_id": 2, "name": "Grace"},
+    ]
+
+    assert cli.main([
+        "import",
+        str(target),
+        "app",
+        "users",
+        str(export_file),
+        "--mode",
+        "replace",
+    ]) == 0
+    capsys.readouterr()
+    assert tm.TinyMongoClient(str(target)).app.users.count() == 2
+
+    migrated = tmp_path / "migrated"
+    assert cli.main([
+        "migrate",
+        str(source),
+        str(migrated),
+        "--to-backend",
+        "sqlite",
+        "--database",
+        "app",
+    ]) == 0
+    migrated_payload = json.loads(capsys.readouterr().out)
+    migrated_counts = {
+        item["collection"]: item["count"] for item in migrated_payload["migrated"]
+    }
+    assert migrated_counts["users"] == 2
+    assert (migrated / "app.sqlite").exists()
+
+
+def test_cli_backend_option_exports_sqlite_backend(tmp_path, capsys):
+    db_dir = tmp_path / "sqlite-db"
+    client = tm.TinyMongoClient(str(db_dir), backend="sqlite")
+    client.app.users.insert_one({"_id": 1, "name": "Ada"})
+
+    assert cli.main([
+        "export",
+        str(db_dir),
+        "app",
+        "users",
+        "--backend",
+        "sqlite",
+    ]) == 0
+
+    assert json.loads(capsys.readouterr().out) == [{"_id": 1, "name": "Ada"}]
+
+
+def test_cli_import_from_stdin_and_replace_mode(tmp_path, monkeypatch, capsys):
+    db_dir = tmp_path / "db"
+    client = tm.TinyMongoClient(str(db_dir))
+    client.app.users.insert_one({"_id": 1, "name": "old"})
+    monkeypatch.setattr(
+        "sys.stdin",
+        type("Input", (), {"read": lambda self: '[{"_id": 2, "name": "new"}]'})(),
+    )
+
+    assert cli.main([
+        "import",
+        str(db_dir),
+        "app",
+        "users",
+        "-",
+        "--mode",
+        "replace",
+    ]) == 0
+
+    assert "imported 1 documents" in capsys.readouterr().out
+    assert list(client.app.users.find({})) == [{"_id": 2, "name": "new"}]
+
+
+def test_cli_import_rejects_non_array_input(tmp_path):
+    input_file = tmp_path / "bad.json"
+    input_file.write_text('{"_id": 1}', encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="JSON array"):
+        cli.main(["import", str(tmp_path / "db"), "app", "users", str(input_file)])
+
+
+def test_cli_migrate_all_databases(tmp_path, capsys):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    client = tm.TinyMongoClient(str(source))
+    client.app.users.insert_one({"_id": 1})
+    client.audit.events.insert_one({"_id": "event"})
+
+    assert cli.main(["migrate", str(source), str(target), "--to-backend", "sqlite"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    migrated = {
+        (item["database"], item["collection"]): item["count"]
+        for item in payload["migrated"]
+    }
+    assert migrated[("app", "users")] == 1
+    assert migrated[("audit", "events")] == 1
+    assert tm.TinyMongoClient(str(target), backend="sqlite").audit.events.count() == 1

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -1,0 +1,533 @@
+import json
+import runpy
+import os
+import sqlite3
+import sys
+import threading
+import warnings
+
+import pytest
+
+import tinymongo as tm
+from tinymongo import cli
+from tinymongo import tinymongo as core
+from tinymongo import parquet_storage as ps
+from tinymongo import storage_backends as sb
+from tinymongo.errors import DuplicateKeyError, OperationFailure
+from tinymongo.results import (
+    DeleteResult,
+    InsertManyResult,
+    InsertOneResult,
+    UpdateResult,
+)
+
+
+def test_result_properties_and_error_classes():
+    one = InsertOneResult(eid=10, inserted_id="abc")
+    many = InsertManyResult(eids=[1, 2], inserted_ids=["a", "b"])
+    updated = UpdateResult(raw_result="not-a-list")
+    deleted = DeleteResult(raw_result=3)
+
+    assert one.eid == 10
+    assert one.inserted_id == "abc"
+    assert many.eids == [1, 2]
+    assert many.inserted_ids == ["a", "b"]
+    assert updated.raw_result == "not-a-list"
+    assert updated.matched_count == 0
+    assert updated.modified_count == 0
+    assert updated.upserted_id is None
+    assert deleted.raw_result == 3
+    assert deleted.deleted_count == 3
+    assert str(DuplicateKeyError("duplicate"))
+    failure = OperationFailure("failed", code=42, details={"ok": False})
+    assert str(failure)
+    assert failure.code == 42
+    assert failure.details == {"ok": False}
+
+
+def test_cli_json_helpers_and_errors(tmp_path, capsys):
+    payload_file = tmp_path / "payload.json"
+
+    cli._dump_json({"b": 1}, str(payload_file))
+    assert json.loads(payload_file.read_text(encoding="utf-8")) == {"b": 1}
+    assert cli._load_json(str(payload_file)) == {"b": 1}
+
+    cli._dump_json({"a": 1}, "-")
+    assert json.loads(capsys.readouterr().out) == {"a": 1}
+
+    with pytest.raises(SystemExit):
+        cli.main(["import", str(tmp_path), "db", "coll", str(payload_file)])
+
+    bad_docs = tmp_path / "bad-docs.json"
+    bad_docs.write_text('[{"_id": 1}, 2]', encoding="utf-8")
+    with pytest.raises(SystemExit, match="JSON objects"):
+        cli.main(["import", str(tmp_path), "db", "coll", str(bad_docs)])
+
+    assert cli._db_names(str(tmp_path / "missing"), "tinydb") == []
+    (tmp_path / ".hidden.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "wrong.sqlite").write_text("", encoding="utf-8")
+    assert ".hidden" not in cli._db_names(str(tmp_path), "tinydb")
+
+
+def test_cli_main_module_entrypoint(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["tinymongo", "--help"])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="'tinymongo.cli' found in sys.modules")
+        with pytest.raises(SystemExit) as exc:
+            runpy.run_module("tinymongo.cli", run_name="__main__")
+    assert exc.value.code == 0
+
+
+def test_storage_backend_helpers_and_sqlite_edge_paths(tmp_path, monkeypatch):
+    db_file = tmp_path / "db.sqlite"
+    storage = sb.SQLiteStorage(str(db_file))
+
+    assert storage.read() == {}
+    storage.write({"_default": {"1": {"_id": 1}}})
+    assert storage.read() == {"_default": {"1": {"_id": 1}}}
+
+    sqlite3.connect(str(db_file)).execute("DELETE FROM tinydb").connection.commit()
+    assert storage.read() == {}
+
+    db_file.write_text("not sqlite", encoding="utf-8")
+    assert storage.read() == {}
+
+    assert sb.get_storage_class(None) is sb.get_storage_class("tinydb")
+    assert sb.get_storage_class(sb.SQLiteStorage) is sb.SQLiteStorage
+    assert sb.storage_extension("json") == ".json"
+    assert sb.storage_extension("parquetv2") == ".parquet"
+    assert sb.storage_extension("duckdb") == ".duckdb"
+    with pytest.raises(ValueError):
+        sb.get_storage_class("missing")
+    with pytest.raises(ValueError):
+        sb.storage_extension("missing")
+
+    monkeypatch.setattr(sb, "duckdb", None)
+    with pytest.raises(ImportError):
+        sb.DuckDBStorage(str(tmp_path / "db.duckdb"))
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(sb.os, "open", lambda *args, **kwargs: (_ for _ in ()).throw(OSError()))
+        sb._fsync_dir(str(tmp_path))
+
+    cleanup_file = tmp_path / "cleanup.sqlite"
+    cleanup_storage = sb.SQLiteStorage(str(cleanup_file))
+    monkeypatch.setattr(sb.os, "replace", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()))
+    monkeypatch.setattr(sb.os, "remove", lambda *args, **kwargs: (_ for _ in ()).throw(OSError()))
+    with pytest.raises(RuntimeError):
+        cleanup_storage.write({"x": {}})
+
+
+def test_duckdb_storage_with_fake_driver(tmp_path, monkeypatch):
+    class FakeCursor:
+        def __init__(self, path):
+            self.path = path
+
+        def execute(self, sql, args=None):
+            if "INSERT" in sql:
+                with open(self.path, "w", encoding="utf-8") as handle:
+                    handle.write(args[0])
+            return self
+
+        def fetchone(self):
+            if not os.path.exists(self.path):
+                return None
+            with open(self.path, "r", encoding="utf-8") as handle:
+                value = handle.read()
+            return None if value is None else (value,)
+
+        def close(self):
+            pass
+
+    class FakeDuckDB:
+        def connect(self, path):
+            return FakeCursor(path)
+
+    monkeypatch.setattr(sb, "duckdb", FakeDuckDB())
+    storage = sb.DuckDBStorage(str(tmp_path / "db.duckdb"))
+    assert storage.read() == {}
+    storage.write({"_default": {"1": {"_id": 1}}})
+    assert storage.read() == {"_default": {"1": {"_id": 1}}}
+
+    empty_file = tmp_path / "empty.duckdb"
+    empty_file.touch()
+    assert sb.DuckDBStorage(str(empty_file)).read() == {}
+
+    with open(empty_file, "w", encoding="utf-8") as handle:
+        handle.write("not json")
+    assert sb.DuckDBStorage(str(empty_file)).read() == {}
+
+    class NoneCursor(FakeCursor):
+        def fetchone(self):
+            return None
+
+    class NoneDuckDB:
+        def connect(self, path):
+            return NoneCursor(path)
+
+    monkeypatch.setattr(sb, "duckdb", NoneDuckDB())
+    assert sb.DuckDBStorage(str(empty_file)).read() == {}
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(sb.os, "replace", lambda *args, **kwargs: None)
+        sb.DuckDBStorage(str(tmp_path / "cleanup.duckdb")).write({"x": {}})
+
+
+def test_parquet_storage_read_write_and_merge(tmp_path):
+    path = tmp_path / "db.parquet"
+    storage = ps.ParquetStorage(str(path))
+
+    assert storage.read() == {}
+    storage.write({"users": {"1": {"_id": "a", "name": "Ada"}}})
+    storage.write({"users": {"1": {"_id": "a", "name": "Ada Lovelace"}}})
+    storage.write({"users": {"2": {"_id": "b", "name": "Grace"}}})
+
+    assert storage.read()["users"] == {
+        "1": {"_id": "a", "name": "Ada Lovelace"},
+        "2": {"_id": "b", "name": "Grace"},
+    }
+
+    path.write_text("not parquet", encoding="utf-8")
+    assert storage.read() == {}
+
+
+def test_parquet_storage_json_fallback(tmp_path, monkeypatch):
+    path = tmp_path / "db.parquet"
+    storage = ps.ParquetStorage(str(path))
+
+    monkeypatch.setattr(ps, "pq", None)
+    monkeypatch.setattr(ps, "pa", None)
+    storage.write({"users": {"1": {"_id": "a", "name": "Ada"}}})
+    storage.write({"users": {"1": {"_id": "a", "name": "Ada Lovelace"}}})
+    storage.write({"users": {"2": {"_id": "b", "name": "Grace"}}})
+
+    assert storage.read()["users"] == {
+        "1": {"_id": "a", "name": "Ada Lovelace"},
+        "2": {"_id": "b", "name": "Grace"},
+    }
+
+    path.write_text("not json", encoding="utf-8")
+    assert storage.read() == {}
+
+    storage.write({"users": {"1": {"_id": "a"}}})
+    assert storage.read()["users"]["1"] == {"_id": "a"}
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(ps.os, "replace", lambda *args, **kwargs: None)
+        storage.write({"users": {"2": {"_id": "b"}}})
+
+
+def test_parquet_storage_fake_arrow_edge_paths(tmp_path, monkeypatch):
+    path = tmp_path / "db.parquet"
+    storage = ps.ParquetStorage(str(path))
+    path.write_text("exists", encoding="utf-8")
+
+    class FakeColumn:
+        def __init__(self, values):
+            self.values = values
+
+        def to_pylist(self):
+            return self.values
+
+    class FakeTable:
+        def __init__(self, names, values=None):
+            self.column_names = names
+            self.values = values or []
+
+        def column(self, name):
+            return FakeColumn(self.values)
+
+    class FakePQ:
+        def __init__(self, table):
+            self.table = table
+
+        def read_table(self, path):
+            return self.table
+
+        def write_table(self, table, tmp, version=None):
+            with open(tmp, "w", encoding="utf-8") as handle:
+                handle.write("parquet")
+
+    monkeypatch.setattr(ps, "pq", FakePQ(FakeTable(["other"])))
+    assert storage.read() == {}
+    monkeypatch.setattr(ps, "pq", FakePQ(FakeTable(["data"], [])))
+    assert storage.read() == {}
+    monkeypatch.setattr(ps, "pq", FakePQ(FakeTable(["data"], ["not json"])))
+    assert storage.read() == {}
+
+    monkeypatch.setattr(ps, "pq", FakePQ(FakeTable(["data"], ['{"old":{"1":{"_id":"a"}}}'])))
+
+    class FakePA:
+        def string(self):
+            return "string"
+
+        def array(self, values, type=None):
+            return values
+
+        def table(self, data):
+            return data
+
+    monkeypatch.setattr(ps, "pa", FakePA())
+    storage.write({"new": {"1": {"_id": "b"}}})
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(ps.os, "replace", lambda *args, **kwargs: None)
+        storage.write({"new": {"2": {"_id": "c"}}})
+
+
+def test_parquet_lock_helpers_and_fsync_failures(monkeypatch):
+    lock = threading.RLock()
+    assert ps._acquire_rlock(lock) is True
+    assert ps._acquire_rlock(lock) is False
+    lock.release()
+    lock.release()
+
+    monkeypatch.setattr(ps.os, "open", lambda *args, **kwargs: (_ for _ in ()).throw(OSError()))
+    ps._fsync_dir("/does/not/matter")
+
+    class BadLock:
+        def _is_owned(self):
+            raise RuntimeError()
+
+        def acquire(self, blocking=True):
+            return True
+
+    assert ps._acquire_rlock(BadLock()) is True
+
+    class BlockingLock:
+        def __init__(self):
+            self.calls = 0
+
+        def _is_owned(self):
+            return False
+
+        def acquire(self, blocking=True):
+            self.calls += 1
+            return False if self.calls == 1 else True
+
+    assert ps._acquire_rlock(BlockingLock()) is False
+
+
+def test_cursor_and_gridfs_edges():
+    cursor = tm.TinyMongoCursor([
+        {"name": "Ada", "scores": [{"value": 2}]},
+        {"name": "Grace", "scores": [{"value": 1}]},
+        {"name": "Empty", "scores": []},
+        {"name": "Missing"},
+    ])
+
+    assert cursor.sort("scores.value", -1)[0]["name"] == "Ada"
+    assert tm.TinyMongoCursor([{"name": "Ada"}])["name"] == "Ada"
+    assert cursor.limit(2).count(with_limit_and_skip=True) == 2
+    assert cursor.has_next() is True
+    assert cursor.next()["name"] == "Ada"
+    assert cursor.hasNext() is True
+    assert list(iter(cursor))
+
+    with pytest.raises(TypeError):
+        tm.TinyMongoCursor([]).sort([("name", 2)])
+    with pytest.raises(TypeError):
+        tm.TinyMongoCursor([]).sort(["name"])
+    with pytest.raises(ValueError):
+        tm.TinyMongoCursor([]).sort([("name", 1, 2)])
+    with pytest.raises(TypeError):
+        tm.TinyMongoCursor([]).sort([(1, 1)])
+    with pytest.raises(ValueError):
+        tm.TinyMongoCursor([]).sort([("name", 1)], 1)
+    with pytest.raises(TypeError):
+        tm.TinyMongoCursor([]).sort("name", 0)
+    with pytest.raises(ValueError):
+        tm.TinyMongoCursor([]).sort(42)
+
+    gridfs = tm.TinyGridFS()
+    assert gridfs.grid_fs("db").database == "db"
+    assert gridfs.GridFS("other").database == "other"
+    assert len(tm.generate_id()) > 0
+
+
+def test_collection_error_and_compatibility_edges(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path / "db"))
+    client.close()
+    collection = client.db.collection
+    assert repr(collection) == "collection"
+    assert collection.anything is collection
+
+    with pytest.raises(ValueError):
+        collection.insert_one(["not", "a", "dict"])
+    with pytest.raises(ValueError):
+        collection.insert_many({"not": "a list"})
+    with pytest.raises(AttributeError):
+        getattr(client, "_private")
+
+    collection.insert_one({"_id": 0, "name": "zero"})
+    collection.insert_one({"_id": "", "name": "empty"})
+    generated = collection.insert_one({"name": "generated"})
+    assert generated.inserted_id
+    bypassed = collection.insert_one({"_id": 0}, bypass_document_validation=True)
+    assert bypassed.inserted_id == 0
+    with pytest.raises(DuplicateKeyError):
+        collection.insert_one({"_id": 0})
+    with pytest.raises(DuplicateKeyError):
+        collection.insert_many([{"_id": "dupe"}, {"_id": "dupe"}])
+    assert collection.insert_many([{"name": "generated-many"}]).inserted_ids[0]
+
+    assert collection.insert({"_id": "single"}).inserted_id == "single"
+    assert collection.insert([{"_id": "many"}]).inserted_ids == ["many"]
+    assert collection.update({"_id": "many"}, {"$set": {"updated": True}}).modified_count == 1
+    assert collection.update({"_id": "many"}, [{"$set": {"updated": False}}])[0].modified_count == 1
+    assert collection.remove({"_id": "many"}, multi=False).deleted_count == 1
+    assert collection.remove({"name": "missing"}, multi=True).deleted_count == 0
+
+
+def test_direct_helper_and_lock_edges(tmp_path, monkeypatch):
+    doc = {"a": {"b": 1}, "items": []}
+    core._unset_nested(doc, "a.missing.value")
+    assert doc == {"a": {"b": 1}, "items": []}
+    assert core._apply_update_document({"_id": 1}, {"$pull": {"items": "x"}})["items"] == []
+    assert core._apply_update_document({"_id": 1}, {"$addToSet": {"items": "x"}})["items"] == ["x"]
+    with pytest.raises(ValueError):
+        core._apply_update_document({"_id": 1, "items": "x"}, {"$pull": {"items": "x"}})
+    with pytest.raises(ValueError):
+        core._apply_update_document({"_id": 1, "items": "x"}, {"$addToSet": {"items": "x"}})
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(core.os, "makedirs", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("nope")))
+        tm.TinyMongoClient(str(tmp_path / "cannot-create"))
+
+    client = tm.TinyMongoClient(str(tmp_path / "db"))
+    c = client.db.collection
+    c.insert_many([{"_id": 1, "lookup": {"nested": ["x"]}}, {"_id": 2}])
+    assert c._get_index("missing") is None
+    unbuilt = core.TinyMongoCollection("unbuilt", client.db)
+    unbuilt.create_index("field")
+    assert unbuilt._get_index("field") == {}
+    c.create_index("absent")
+    assert c._get_index("absent") == {}
+    assert c._get_index("absent") == {}
+    c.create_index("lookup")
+    assert c._get_index("lookup") == {}
+
+    monkeypatch.setattr(ps, "_acquire_rlock", lambda lock: (_ for _ in ()).throw(RuntimeError()))
+    assert c._acquire_collection_lock() == (None, None)
+    c._release_collection_lock(object(), object())
+
+
+def test_query_operator_branches_without_mongo(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path / "db"))
+    c = client.db.collection
+    c.insert_many([
+        {"_id": 1, "count": 1, "name": "alpha", "tags": ["a"], "meta": {"active": True}},
+        {"_id": 2, "count": 5, "name": "beta", "tags": ["b"], "meta": {"active": False}},
+        {"_id": 3, "count": 10, "name": "gamma", "tags": ["a", "c"]},
+    ])
+
+    assert c.find({"count": {"$gt": 1, "$lt": 10}}).count() == 1
+    assert c.find({"count": {"$gte": 5, "$lte": 10}}).count() == 2
+    assert c.find({"name": {"$ne": "alpha"}}).count() == 2
+    assert c.find({"name": {"$regex": "^a"}}).count() == 1
+    assert c.find({"name": {"$not": "alpha"}}).count() == 2
+    assert c.find({"count": {"$not": {"$gt": 5}}}).count() == 2
+    assert c.find({"tags": {"$in": ["c", "missing"]}}).count() == 1
+    assert c.find({"$and": [{"tags": {"$in": ["a"]}}, {"count": {"$lt": 5}}]}).count() == 1
+    assert c.find({"$or": [{"name": "alpha"}, {"name": "gamma"}]}).count() == 2
+    assert c.find({"missing": {"$exists": False}}).count() == 3
+    assert c.find({"tags": [["a"]]}).count() == 0
+    assert c.find({"tags": {"$unknown": ["a"]}}).count() == 0
+
+
+def test_collection_write_and_no_match_edges(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path / "db"))
+    db = client.db
+    c = db.collection
+
+    assert c.count_documents() == 0
+    assert c.update_one({"_id": "missing"}, {"$set": {"x": 1}}).matched_count == 0
+    assert c.replace_one({"_id": "missing"}, {"x": 1}).matched_count == 0
+    assert c.find_one_and_update({"_id": "missing"}, {"$set": {"x": 1}}) is None
+
+    c.insert_one({"_id": "a", "value": 1})
+    assert c.find_one_and_update({"_id": "a"}, {"$set": {"value": 2}})["value"] == 1
+    assert c.find_one({"_id": "a"})["value"] == 2
+
+    c.update_one({"_id": "a"}, {"value": 3})
+    assert c.find_one({"_id": "a"}) == {"_id": "a", "value": 3}
+
+    assert c.drop() is True
+    assert c.drop() is False
+    c.build_table()
+    c.insert_one({"_id": "drop-table-branch"})
+    db.tinydb.drop_table = lambda name: None
+    assert c.drop() is True
+    c.insert_many([{"_id": 1}, {"_id": 2}], bypass_document_validation=True)
+    assert c.delete_many({}).deleted_count == 3
+    assert "_default" in db.collection_names()
+
+
+def test_update_operator_error_edges(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path / "db"))
+    c = client.db.collection
+    c.insert_one({"_id": 1, "count": "one"})
+
+    assert c.update_one({"_id": 1}, {"$unknown": {"x": 1}}).modified_count == 0
+    assert c.update_one({"_id": 1}, {"$set": "not-a-dict"}).modified_count == 0
+    assert c.update_one({"_id": 1}, {"$inc": {"count": 1}}).modified_count == 0
+    assert c.update_many({"_id": 1}, {"$inc": {"count": 1}}).modified_count == 0
+    assert c.replace_one({"_id": 1}, object()).modified_count == 0
+
+    fresh = core.TinyMongoCollection("fresh", client.db)
+    assert fresh.update_one({"_id": "missing"}, {"$set": {"x": 1}}).matched_count == 0
+    assert core.TinyMongoCollection("fresh_many", client.db).update_many(
+        {"_id": "missing"}, {"$set": {"x": 1}}
+    ).matched_count == 0
+    assert core.TinyMongoCollection("fresh_replace", client.db).replace_one(
+        {"_id": "missing"}, {"x": 1}
+    ).matched_count == 0
+    assert core.TinyMongoCollection("fresh_find_update", client.db).find_one_and_update(
+        {"_id": "missing"}, {"$set": {"x": 1}}
+    ) is None
+    assert core.TinyMongoCollection("fresh_find_one", client.db).find_one({"_id": "missing"}) is None
+
+
+def test_database_refresh_ignores_close_errors(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path / "db"))
+    db = client.db
+
+    class BadTinyDB:
+        def close(self):
+            raise RuntimeError()
+
+    db.tinydb = BadTinyDB()
+    db._refresh_table()
+    assert "_default" in db.collection_names()
+
+
+def test_cursor_sort_order_branches():
+    cursor = tm.TinyMongoCursor([
+        {"_id": 1, "value": {"b": 2, "a": 1}},
+        {"_id": 2, "value": ["z", "a"]},
+        {"_id": 3, "value": []},
+        {"_id": 4, "value": object()},
+    ])
+
+    assert cursor.sort("value", 1).count() == 4
+    assert cursor.sort("value").count() == 4
+    assert cursor._order(True) == (5, True)
+    assert cursor._order([1, "a"], None)[0] == 4
+    assert cursor.sort([("value", 1), ("_id", -1)]).count() == 4
+    assert tm.TinyMongoCursor([{"x": 1}, {"x": 2}, {"x": 3}], skip=1, limit=2).count() == 2
+    assert tm.TinyMongoCursor([]).hasNext() is False
+
+    ascending_list = tm.TinyMongoCursor([
+        {"items": [{"score": 1}]},
+        {"items": [{"score": 2}]},
+    ])
+    assert ascending_list.sort("items.score", 1)[0]["items"][0]["score"] == 1
+
+
+def test_backend_duckdb_selection_with_fake_driver(monkeypatch):
+    class FakeDuckDB:
+        def connect(self, path):
+            raise RuntimeError(path)
+
+    monkeypatch.setattr(sb, "duckdb", FakeDuckDB())
+    assert sb.get_storage_class("duckdb") is sb.DuckDBStorage

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -1,0 +1,67 @@
+import sys
+
+import tinymongo
+
+
+def test_pymongo_shaped_application_code_can_run_with_tinymongo(tmp_path):
+    original_pymongo = sys.modules.get("pymongo")
+    sys.modules["pymongo"] = tinymongo
+    try:
+        namespace = {"storage_path": str(tmp_path / "compat-db")}
+        exec(
+            """
+import pymongo
+
+client = pymongo.MongoClient(
+    "mongodb://localhost:27017",
+    serverSelectionTimeoutMS=50,
+    connect=False,
+    tinymongo_folder=storage_path,
+)
+assert client.server_info()["tinymongo"] is True
+
+db = client["contract"]
+users = db["users"]
+users.create_index("email")
+users.insert_many([
+    {"_id": 1, "email": "ada@example.com", "score": 7, "tags": ["math"]},
+    {"_id": 2, "email": "grace@example.com", "score": 9, "tags": ["code"]},
+])
+users.update_one({"email": "ada@example.com"}, {"$inc": {"score": 2}})
+users.update_many({}, {"$addToSet": {"tags": "pioneer"}})
+
+rows = list(users.find({"score": {"$gte": 9}}).sort("email", pymongo.ASCENDING))
+assert [row["email"] for row in rows] == ["ada@example.com", "grace@example.com"]
+assert users.count_documents({"tags": {"$all": ["pioneer"]}}) == 2
+assert users.delete_one({"_id": 1}).deleted_count == 1
+assert "contract" in client.list_database_names()
+assert "users" in db.list_collection_names()
+client.close()
+""",
+            namespace,
+        )
+    finally:
+        if original_pymongo is None:
+            sys.modules.pop("pymongo", None)
+        else:
+            sys.modules["pymongo"] = original_pymongo
+
+
+def test_client_database_listing_and_server_info(tmp_path):
+    client = tinymongo.MongoClient(tinymongo_folder=str(tmp_path / "dbs"))
+
+    assert client.server_info()["storage"] == "tinydb"
+    assert client.list_database_names() == []
+
+    client.alpha.users.insert_one({"_id": 1})
+    client.beta.users.insert_one({"_id": 2})
+
+    assert client.database_names() == ["alpha", "beta"]
+    assert client.alpha.list_collection_names() == ["users"]
+
+
+def test_list_database_names_returns_empty_for_missing_folder(tmp_path):
+    client = tinymongo.TinyMongoClient(str(tmp_path / "missing"))
+    client._foldername = str(tmp_path / "does-not-exist")
+
+    assert client.list_database_names() == []

--- a/tests/test_pymongo_dropin.py
+++ b/tests/test_pymongo_dropin.py
@@ -1,0 +1,82 @@
+import tinymongo as pymongo
+from tinymongo import tinymongo as core
+
+
+def test_import_tinymongo_as_pymongo_dropin_subset(tmp_path):
+    client = pymongo.MongoClient(str(tmp_path / "db"))
+    collection = client.app.users
+
+    collection.create_index("email")
+    result = collection.insert_many(
+        [
+            {"_id": 1, "email": "ada@example.com", "name": "Ada", "score": 7},
+            {"_id": 2, "email": "grace@example.com", "name": "Grace", "score": 9},
+        ]
+    )
+
+    assert result.inserted_ids == [1, 2]
+    assert collection.find_one({"email": "ada@example.com"})["name"] == "Ada"
+    assert collection.count_documents({"score": {"$gte": 7}}) == 2
+
+    update = collection.update_one({"_id": 1}, {"$inc": {"score": 1}})
+    assert update.modified_count == 1
+
+    rows = list(
+        collection.find({"score": {"$gte": 8}}).sort("score", pymongo.DESCENDING)
+    )
+    assert [row["_id"] for row in rows] == [2, 1]
+
+    delete = collection.delete_one({"_id": 1})
+    assert delete.deleted_count == 1
+    assert collection.count_documents({}) == 1
+
+
+def test_pymongo_sort_constants_are_exposed():
+    assert pymongo.ASCENDING == 1
+    assert pymongo.DESCENDING == -1
+
+
+def test_mongo_client_ignores_uri_and_uses_configured_local_folder(tmp_path):
+    local_folder = tmp_path / "local"
+    client = pymongo.MongoClient(
+        "mongodb://localhost:27017",
+        serverSelectionTimeoutMS=10,
+        connect=False,
+        tinymongo_folder=str(local_folder),
+    )
+
+    client.app.users.insert_one({"_id": "network-shaped", "ok": True})
+
+    assert client._foldername == str(local_folder)
+    assert (local_folder / "app.json").exists()
+    assert client.app.users.find_one({"_id": "network-shaped"})["ok"] is True
+
+
+def test_mongo_client_uses_env_folder_for_network_target(tmp_path, monkeypatch):
+    local_folder = tmp_path / "env-local"
+    monkeypatch.setenv("TINYMONGO_HOME", str(local_folder))
+
+    client = pymongo.MongoClient(host="localhost", port=27017)
+    client.app.users.insert_one({"_id": "host-port"})
+
+    assert client._foldername == str(local_folder)
+    assert client.app.users.count_documents({}) == 1
+
+
+def test_mongo_client_keeps_plain_path_as_storage_folder(tmp_path):
+    local_folder = tmp_path / "plain-path"
+    client = pymongo.MongoClient(str(local_folder))
+
+    client.app.users.insert_one({"_id": "plain"})
+
+    assert client._foldername == str(local_folder)
+    assert (local_folder / "app.json").exists()
+
+
+def test_network_target_detection_branches():
+    assert core._looks_like_network_target(["localhost:27017"]) is True
+    assert core._looks_like_network_target(object()) is False
+    assert core._looks_like_network_target("mongodb://localhost:27017") is True
+    assert core._looks_like_network_target("127.0.0.1") is True
+    assert core._looks_like_network_target("[::1]:27017") is True
+    assert core._folder_from_mongo_client_args(None, None, {}) == "tinydb"

--- a/tests/test_query_more.py
+++ b/tests/test_query_more.py
@@ -106,3 +106,154 @@ def test_count_documents_uses_filter():
     ])
 
     assert c.count_documents({"even": True}) == 2
+
+
+def test_exists_query_operator():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_many([
+        {"_id": 1, "name": "alpha", "meta": {"active": True}},
+        {"_id": 2, "name": "beta"},
+    ])
+
+    assert c.find({"meta": {"$exists": True}}).count() == 1
+    assert c.find({"meta": {"$exists": False}}).count() == 1
+
+
+def test_update_operator_support():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_one({"_id": 1, "count": 1, "tags": ["a"], "meta": {"old": True}})
+
+    c.update_one(
+        {"_id": 1},
+        {
+            "$inc": {"count": 2},
+            "$set": {"meta.active": True},
+            "$unset": {"meta.old": ""},
+            "$push": {"tags": "b"},
+            "$addToSet": {"tags": "b"},
+        },
+    )
+    c.update_one({"_id": 1}, {"$pull": {"tags": "a"}})
+
+    doc = c.find_one({"_id": 1})
+    assert doc["count"] == 3
+    assert doc["meta"] == {"active": True}
+    assert doc["tags"] == ["b"]
+
+
+def test_update_many_applies_operators_to_each_match():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_many([
+        {"_id": 1, "group": "a", "count": 1, "tags": []},
+        {"_id": 2, "group": "a", "count": 2, "tags": []},
+        {"_id": 3, "group": "b", "count": 3, "tags": []},
+    ])
+
+    result = c.update_many(
+        {"group": "a"},
+        {"$inc": {"count": 10}, "$push": {"tags": "updated"}},
+    )
+
+    assert result.modified_count == 2
+    assert c.find_one({"_id": 1})["count"] == 11
+    assert c.find_one({"_id": 2})["count"] == 12
+    assert c.find_one({"_id": 3})["count"] == 3
+    assert c.find({"tags": {"$all": ["updated"]}}).count() == 2
+
+
+def test_nested_update_creates_missing_subdocuments():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_one({"_id": 1})
+
+    c.update_one({"_id": 1}, {"$set": {"profile.name": "Ada"}, "$inc": {"stats.views": 1}})
+
+    assert c.find_one({"_id": 1}) == {
+        "_id": 1,
+        "profile": {"name": "Ada"},
+        "stats": {"views": 1},
+    }
+
+
+def test_update_rejects_list_operator_target():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_one({"_id": 1, "tags": "not-a-list"})
+
+    result = c.update_one({"_id": 1}, {"$push": {"tags": "new"}})
+
+    assert result.modified_count == 0
+    assert c.find_one({"_id": 1})["tags"] == "not-a-list"
+
+
+def test_replacement_update_many_does_not_reuse_document_between_matches():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_many([
+        {"_id": 1, "group": "a", "old": True},
+        {"_id": 2, "group": "a", "old": True},
+    ])
+
+    c.update_many({"group": "a"}, {"group": "a", "new": True})
+
+    assert c.find_one({"_id": 1}) == {"_id": 1, "group": "a", "new": True}
+    assert c.find_one({"_id": 2}) == {"_id": 2, "group": "a", "new": True}
+
+
+def test_collection_indexes_accelerate_equality_queries():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_many([
+        {"_id": 1, "email": "a@example.com"},
+        {"_id": 2, "email": "b@example.com"},
+    ])
+
+    assert c.create_index("email") == "email"
+    assert {"name": "email_1", "key": [("email", 1)]} in c.list_indexes()
+    assert c.find({"email": "b@example.com"})[0]["_id"] == 2
+
+    c.update_one({"_id": 2}, {"$set": {"email": "c@example.com"}})
+    assert c.find({"email": "c@example.com"})[0]["_id"] == 2
+
+    c.drop_index("email")
+    assert c.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+
+
+def test_index_cache_is_invalidated_after_insert_and_delete():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_one({"_id": 1, "email": "a@example.com"})
+    c.create_index("email")
+    assert c.find({"email": "a@example.com"}).count() == 1
+
+    c.insert_one({"_id": 2, "email": "b@example.com"})
+    assert c.find({"email": "b@example.com"}).count() == 1
+
+    c.delete_one({"_id": 2})
+    assert c.find({"email": "b@example.com"}).count() == 0
+
+
+def test_index_matches_array_membership_semantics():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_many([
+        {"_id": 1, "tags": ["a", "b"]},
+        {"_id": 2, "tags": "a"},
+    ])
+
+    c.create_index("tags")
+    assert c.find({"tags": "a"}).count() == 2
+    c.drop_index("tags")
+    assert c.find({"tags": "a"}).count() == 2

--- a/tests/test_storage_backends.py
+++ b/tests/test_storage_backends.py
@@ -44,6 +44,17 @@ def test_duckdb_backend(tmp_path):
     assert (tmp_path / "db" / "testdb.duckdb").exists()
 
 
+def test_duckdb_backend_multiple_writes(tmp_path):
+    pytest.importorskip("duckdb")
+    client = tm.TinyMongoClient(str(tmp_path / "db"), backend="duckdb")
+    coll = client.testdb.testcollection
+
+    coll.insert_one({"_id": 1, "value": "first"})
+    coll.insert_one({"_id": 2, "value": "second"})
+
+    assert coll.count() == 2
+
+
 def test_internal_client_attrs_are_preserved(tmp_path):
     client = tm.TinyMongoClient(str(tmp_path / "db"), backend="tinydb")
 

--- a/tinymongo/__init__.py
+++ b/tinymongo/__init__.py
@@ -1,4 +1,4 @@
 try:
     from tinymongo.tinymongo import *  # noqa
-except ImportError:
+except ImportError:  # pragma: no cover - legacy import fallback
     from tinymongo import *  # noqa

--- a/tinymongo/cli.py
+++ b/tinymongo/cli.py
@@ -1,0 +1,202 @@
+"""Command line tools for inspecting and moving TinyMongo data."""
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import os
+import sys
+
+from .storage_backends import storage_extension
+from .tinymongo import TinyMongoClient
+
+
+SUPPORTED_BACKENDS = ("tinydb", "json", "parquet", "parquetv2", "sqlite", "duckdb")
+
+
+def _client(path, backend):
+    return TinyMongoClient(path, backend=backend)
+
+
+def _db_names(path, backend):
+    ext = storage_extension(backend)
+    if not os.path.isdir(path):
+        return []
+    names = []
+    for filename in sorted(os.listdir(path)):
+        if filename.startswith(".") or not filename.endswith(ext):
+            continue
+        names.append(filename[: -len(ext)])
+    return names
+
+
+def _load_json(path):
+    if path == "-":
+        return json.load(sys.stdin)
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _dump_json(data, path):
+    if path == "-":
+        json.dump(data, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def cmd_inspect(args):
+    client = _client(args.path, args.backend)
+    payload = {"path": args.path, "backend": args.backend, "databases": []}
+    for db_name in _db_names(args.path, args.backend):
+        db = client[db_name]
+        collections = []
+        for collection_name in sorted(db.collection_names()):
+            count = db[collection_name].count()
+            collections.append({"name": collection_name, "count": count})
+        payload["databases"].append({"name": db_name, "collections": collections})
+    _dump_json(payload, args.output)
+    return 0
+
+
+def cmd_list_dbs(args):
+    for name in _db_names(args.path, args.backend):
+        print(name)
+    return 0
+
+
+def cmd_list_collections(args):
+    client = _client(args.path, args.backend)
+    for name in sorted(client[args.database].collection_names()):
+        print(name)
+    return 0
+
+
+def cmd_export(args):
+    client = _client(args.path, args.backend)
+    docs = list(client[args.database][args.collection].find({}))
+    _dump_json(docs, args.output)
+    return 0
+
+
+def cmd_import(args):
+    docs = _load_json(args.input)
+    if not isinstance(docs, list):
+        raise SystemExit("import input must be a JSON array of documents")
+    for doc in docs:
+        if not isinstance(doc, dict):
+            raise SystemExit("import input must contain only JSON objects")
+
+    client = _client(args.path, args.backend)
+    collection = client[args.database][args.collection]
+    if args.mode == "replace":
+        collection.delete_many({})
+    if docs:
+        collection.insert_many(docs)
+    print("imported {0} documents".format(len(docs)))
+    return 0
+
+
+def cmd_migrate(args):
+    source_client = _client(args.source, args.from_backend)
+    target_client = _client(args.target, args.to_backend)
+
+    database_names = [args.database] if args.database else _db_names(args.source, args.from_backend)
+    migrated = []
+    for db_name in database_names:
+        source_db = source_client[db_name]
+        target_db = target_client[db_name]
+        for collection_name in sorted(source_db.collection_names()):
+            docs = list(source_db[collection_name].find({}))
+            target_collection = target_db[collection_name]
+            target_collection.delete_many({})
+            if docs:
+                target_collection.insert_many(docs)
+            migrated.append(
+                {"database": db_name, "collection": collection_name, "count": len(docs)}
+            )
+
+    _dump_json(
+        {
+            "source": args.source,
+            "target": args.target,
+            "from_backend": args.from_backend,
+            "to_backend": args.to_backend,
+            "migrated": migrated,
+        },
+        args.output,
+    )
+    return 0
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="tinymongo")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    backend_parser = argparse.ArgumentParser(add_help=False)
+    backend_parser.add_argument("--backend", default="tinydb", choices=SUPPORTED_BACKENDS)
+
+    inspect = subparsers.add_parser(
+        "inspect",
+        parents=[backend_parser],
+        help="print database and collection counts",
+    )
+    inspect.add_argument("path")
+    inspect.add_argument("-o", "--output", default="-")
+    inspect.set_defaults(func=cmd_inspect)
+
+    list_dbs = subparsers.add_parser(
+        "list-dbs", parents=[backend_parser], help="list database names"
+    )
+    list_dbs.add_argument("path")
+    list_dbs.set_defaults(func=cmd_list_dbs)
+
+    list_collections = subparsers.add_parser(
+        "list-collections",
+        parents=[backend_parser],
+        help="list collections in a database",
+    )
+    list_collections.add_argument("path")
+    list_collections.add_argument("database")
+    list_collections.set_defaults(func=cmd_list_collections)
+
+    export = subparsers.add_parser(
+        "export", parents=[backend_parser], help="export a collection to JSON"
+    )
+    export.add_argument("path")
+    export.add_argument("database")
+    export.add_argument("collection")
+    export.add_argument("-o", "--output", default="-")
+    export.set_defaults(func=cmd_export)
+
+    import_cmd = subparsers.add_parser(
+        "import", parents=[backend_parser], help="import JSON documents"
+    )
+    import_cmd.add_argument("path")
+    import_cmd.add_argument("database")
+    import_cmd.add_argument("collection")
+    import_cmd.add_argument("input")
+    import_cmd.add_argument("--mode", choices=("append", "replace"), default="append")
+    import_cmd.set_defaults(func=cmd_import)
+
+    migrate = subparsers.add_parser("migrate", help="copy data between backends")
+    migrate.add_argument("source")
+    migrate.add_argument("target")
+    migrate.add_argument("--from-backend", default="tinydb", choices=SUPPORTED_BACKENDS)
+    migrate.add_argument("--to-backend", required=True, choices=SUPPORTED_BACKENDS)
+    migrate.add_argument("--database")
+    migrate.add_argument("-o", "--output", default="-")
+    migrate.set_defaults(func=cmd_migrate)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tinymongo/parquet_storage.py
+++ b/tinymongo/parquet_storage.py
@@ -96,11 +96,11 @@ class ParquetStorage(Storage):
             if portalocker_lock is not None:
                 try:
                     portalocker_lock.release()
-                except Exception:
+                except Exception:  # pragma: no cover - defensive lock fallback
                     pass
             try:
                 rlock.release()
-            except Exception:
+            except Exception:  # pragma: no cover - defensive lock fallback
                 pass
 
     def write(self, data):
@@ -129,7 +129,7 @@ class ParquetStorage(Storage):
                     try:
                         with open(self.path, "r", encoding="utf8") as f:
                             existing = json.load(f) or {}
-                    except Exception:
+                    except Exception:  # pragma: no cover - corrupt existing JSON fallback
                         existing = {}
 
                 # Merge incoming into existing, matching on logical `_id`.
@@ -173,7 +173,7 @@ class ParquetStorage(Storage):
                     if os.path.exists(tmp):
                         try:
                             os.remove(tmp)
-                        except Exception:
+                        except Exception:  # pragma: no cover - best-effort cleanup
                             pass
                 return
 
@@ -186,7 +186,7 @@ class ParquetStorage(Storage):
                         data_arr = table.column("data").to_pylist()
                         if data_arr:
                             existing = json.loads(data_arr[0])
-                except Exception:
+                except Exception:  # pragma: no cover - corrupt existing parquet fallback
                     existing = {}
 
             # Merge incoming into existing, matching on logical `_id`.
@@ -232,7 +232,7 @@ class ParquetStorage(Storage):
                     with open(tmp, "rb") as f:
                         f.flush()
                         os.fsync(f.fileno())
-                except Exception:
+                except Exception:  # pragma: no cover - best-effort fsync
                     pass
                 os.replace(tmp, self.path)
                 _fsync_dir(dname)
@@ -240,17 +240,17 @@ class ParquetStorage(Storage):
                 if os.path.exists(tmp):
                     try:
                         os.remove(tmp)
-                    except Exception:
+                    except Exception:  # pragma: no cover - best-effort cleanup
                         pass
         finally:
             # Release portalocker only if we acquired it here.
-            if 'portalocker_lock' in locals() and portalocker_lock is not None:
+            if 'portalocker_lock' in locals() and portalocker_lock is not None:  # pragma: no cover
                 try:
                     portalocker_lock.release()
-                except Exception:
+                except Exception:  # pragma: no cover - best-effort lock release
                     pass
             # Release in-process reentrant lock once.
             try:
                 rlock.release()
-            except Exception:
+            except Exception:  # pragma: no cover - defensive lock release
                 pass

--- a/tinymongo/storage_backends.py
+++ b/tinymongo/storage_backends.py
@@ -2,23 +2,122 @@ import json
 import os
 import sqlite3
 import tempfile
+import threading
 from tinydb.storages import Storage
+from .parquet_storage import _acquire_rlock, _fsync_dir, _local_rlocks, portalocker
 
 try:
     import duckdb
-except Exception:
+except Exception:  # pragma: no cover - optional dependency fallback
     duckdb = None
 
 
-def _fsync_dir(path):
-    try:
-        fd = os.open(path, os.O_RDONLY)
+class AtomicJSONStorage(Storage):
+    """TinyDB JSON storage with inter-process locks and atomic replace writes."""
+
+    def __init__(self, path):
+        self.path = path
+        self._directory = os.path.dirname(path) or "."
+        self.merge_writes = True
+        os.makedirs(self._directory, exist_ok=True)
+
+    def _lock_path(self):
+        return os.path.join(self._directory, ".tinymongo.lock")
+
+    def _acquire_lock(self):
+        lock_path = self._lock_path()
+        rlock = _local_rlocks.setdefault(lock_path, threading.RLock())
+        first_acquire = _acquire_rlock(rlock)
+        portalocker_lock = None
+        if first_acquire and portalocker is not None:
+            portalocker_lock = portalocker.Lock(lock_path, timeout=30)
+            portalocker_lock.acquire()
+        return rlock, portalocker_lock
+
+    def _release_lock(self, rlock, portalocker_lock):
+        if portalocker_lock is not None:
+            try:
+                portalocker_lock.release()
+            except Exception:  # pragma: no cover - defensive lock fallback
+                pass
         try:
-            os.fsync(fd)
+            rlock.release()
+        except Exception:  # pragma: no cover - defensive lock fallback
+            pass
+
+    def read(self):
+        rlock, portalocker_lock = self._acquire_lock()
+        try:
+            if not os.path.exists(self.path) or os.path.getsize(self.path) == 0:
+                return {}
+            with open(self.path, "r", encoding="utf8") as handle:
+                return json.load(handle)
+        except Exception:  # pragma: no cover - corrupt JSON fallback
+            return {}
         finally:
-            os.close(fd)
-    except Exception:
-        pass
+            self._release_lock(rlock, portalocker_lock)
+
+    def _merge_data(self, existing, incoming):
+        merged = {}
+        for table_name, table_data in (existing or {}).items():
+            merged[str(table_name)] = {
+                str(key): value for key, value in (table_data or {}).items()
+            }
+
+        for table_name, table_data in (incoming or {}).items():
+            table = str(table_name)
+            incoming_table = {
+                str(key): value for key, value in (table_data or {}).items()
+            }
+            existing_table = merged.get(table, {})
+            id_to_eid = {
+                value.get("_id"): key
+                for key, value in existing_table.items()
+                if isinstance(value, dict) and "_id" in value
+            }
+            try:
+                next_eid = max(int(key) for key in existing_table.keys()) + 1
+            except Exception:
+                next_eid = 1
+
+            for value in incoming_table.values():
+                doc_id = value.get("_id") if isinstance(value, dict) else None
+                if doc_id is not None and doc_id in id_to_eid:
+                    existing_table[id_to_eid[doc_id]] = value
+                else:
+                    existing_table[str(next_eid)] = value
+                    next_eid += 1
+
+            merged[table] = existing_table
+
+        return merged
+
+    def write(self, data):
+        rlock, portalocker_lock = self._acquire_lock()
+        fd, tmp = tempfile.mkstemp(prefix="tmp", dir=self._directory)
+        try:
+            payload_data = data or {}
+            if self.merge_writes and os.path.exists(self.path):
+                try:
+                    with open(self.path, "r", encoding="utf8") as handle:
+                        payload_data = self._merge_data(json.load(handle) or {}, payload_data)
+                except Exception:  # pragma: no cover - corrupt JSON fallback
+                    payload_data = self._merge_data({}, payload_data)
+
+            payload = json.dumps(payload_data, ensure_ascii=False)
+            with os.fdopen(fd, "w", encoding="utf8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, self.path)
+            _fsync_dir(self._directory)
+        finally:
+            if os.path.exists(tmp):  # pragma: no cover - os.replace removes tmp
+                try:
+                    os.remove(tmp)
+                except Exception:  # pragma: no cover - best-effort cleanup
+                    pass
+            self._release_lock(rlock, portalocker_lock)
 
 
 class SQLiteStorage(Storage):
@@ -56,15 +155,12 @@ class SQLiteStorage(Storage):
         try:
             conn = sqlite3.connect(tmp)
             cursor = conn.cursor()
-            cursor.execute(
-                "PRAGMA journal_mode = OFF"
-            )
+            cursor.execute("PRAGMA journal_mode = OFF")
             cursor.execute(
                 "CREATE TABLE IF NOT EXISTS tinydb(id INTEGER PRIMARY KEY, data TEXT)"
             )
             cursor.execute(
-                "INSERT OR REPLACE INTO tinydb(id, data) VALUES(1, ?)"
-                , (json_str,)
+                "INSERT OR REPLACE INTO tinydb(id, data) VALUES(1, ?)", (json_str,)
             )
             conn.commit()
             conn.close()
@@ -74,7 +170,7 @@ class SQLiteStorage(Storage):
             if os.path.exists(tmp):
                 try:
                     os.remove(tmp)
-                except Exception:
+                except Exception:  # pragma: no cover - best-effort cleanup
                     pass
 
 
@@ -110,6 +206,7 @@ class DuckDBStorage(Storage):
         fd, tmp = tempfile.mkstemp(prefix="tmp", dir=dname)
         os.close(fd)
         try:
+            os.remove(tmp)
             conn = duckdb.connect(tmp)
             conn.execute("CREATE TABLE IF NOT EXISTS tinydb(id INTEGER PRIMARY KEY, data TEXT)")
             conn.execute(
@@ -123,7 +220,7 @@ class DuckDBStorage(Storage):
             if os.path.exists(tmp):
                 try:
                     os.remove(tmp)
-                except Exception:
+                except Exception:  # pragma: no cover - best-effort cleanup
                     pass
 
 
@@ -137,10 +234,7 @@ def get_storage_class(name):
     backend = str(name).lower()
 
     if backend in ("tinydb", "json"):
-        from tinydb import TinyDB
-
-        # TinyDB 3.x exposes DEFAULT_STORAGE instead of default_storage_class.
-        return getattr(TinyDB, "default_storage_class", TinyDB.DEFAULT_STORAGE)
+        return AtomicJSONStorage
     if backend in ("parquet", "parquetv2"):
         from .parquet_storage import ParquetStorage
 

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -8,7 +8,7 @@ from functools import reduce
 import logging
 import os
 from math import ceil
-from uuid import uuid1
+from uuid import uuid4
 
 from tinydb import Query, TinyDB, where
 from .storage_backends import get_storage_class, storage_extension
@@ -1276,7 +1276,7 @@ class TinyGridFS(object):
 def generate_id():
     """Generate new UUID"""
     # TODO: Use six.string_type to Py3 compat
-    return str(uuid1()).replace(u"-", u"")
+    return str(uuid4()).replace(u"-", u"")
 
 # def generate_id():
 #     """Generate new UUID"""

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -24,11 +24,145 @@ except NameError:
 
 logger = logging.getLogger(__name__)
 
+ASCENDING = 1
+DESCENDING = -1
+
 
 def Q(query, key):
     return reduce(
         lambda partial_query, field: partial_query[field], key.split("."), query
     )
+
+
+_MISSING = object()
+
+
+def _get_nested(doc, path, default=_MISSING):
+    current = doc
+    for key in path.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return default
+        current = current[key]
+    return current
+
+
+def _set_nested(doc, path, value):
+    current = doc
+    parts = path.split(".")
+    for key in parts[:-1]:
+        child = current.get(key)
+        if not isinstance(child, dict):
+            child = {}
+            current[key] = child
+        current = child
+    current[parts[-1]] = value
+
+
+def _unset_nested(doc, path):
+    current = doc
+    parts = path.split(".")
+    for key in parts[:-1]:
+        current = current.get(key)
+        if not isinstance(current, dict):
+            return
+    current.pop(parts[-1], None)
+
+
+def _apply_update_document(item, update_doc):
+    updated = copy.deepcopy(item)
+    operator_keys = [key for key in update_doc if key.startswith("$")]
+
+    if not operator_keys:
+        replacement = copy.deepcopy(update_doc)
+        if u"_id" not in replacement:
+            replacement[u"_id"] = item[u"_id"]
+        return replacement
+
+    for operator, changes in update_doc.items():
+        if not isinstance(changes, dict):
+            raise ValueError("{0} update requires a dict".format(operator))
+
+        if operator == u"$set":
+            for path, value in changes.items():
+                _set_nested(updated, path, value)
+        elif operator == u"$unset":
+            for path in changes:
+                _unset_nested(updated, path)
+        elif operator == u"$inc":
+            for path, value in changes.items():
+                current = _get_nested(updated, path, 0)
+                _set_nested(updated, path, current + value)
+        elif operator == u"$push":
+            for path, value in changes.items():
+                current = _get_nested(updated, path, [])
+                if not isinstance(current, list):
+                    raise ValueError("$push target must be a list")
+                current = list(current)
+                current.append(value)
+                _set_nested(updated, path, current)
+        elif operator == u"$pull":
+            for path, value in changes.items():
+                current = _get_nested(updated, path, [])
+                if not isinstance(current, list):
+                    raise ValueError("$pull target must be a list")
+                _set_nested(updated, path, [item for item in current if item != value])
+        elif operator == u"$addToSet":
+            for path, value in changes.items():
+                current = _get_nested(updated, path, [])
+                if not isinstance(current, list):
+                    raise ValueError("$addToSet target must be a list")
+                current = list(current)
+                if value not in current:
+                    current.append(value)
+                _set_nested(updated, path, current)
+        else:
+            raise ValueError("Unsupported update operator: {0}".format(operator))
+
+    updated[u"_id"] = item[u"_id"]
+    return updated
+
+
+def _is_operator_update(update_doc):
+    return any(key.startswith("$") for key in update_doc)
+
+
+def _simple_equality_filter(_filter):
+    if not isinstance(_filter, dict) or len(_filter) != 1:
+        return None
+    field, value = next(iter(_filter.items()))
+    if field.startswith("$") or isinstance(value, (dict, list)):
+        return None
+    return field, value
+
+
+def _looks_like_network_target(host, port=None):
+    if port is not None or isinstance(host, (list, tuple)):
+        return True
+    if not isinstance(host, str):
+        return False
+
+    target = host.strip()
+    if "://" in target or "," in target:
+        return True
+    if target in ("localhost", "127.0.0.1", "::1"):
+        return True
+    if target.startswith("[") and "]" in target:
+        return True
+    return ":" in target and not os.path.isabs(target)
+
+
+def _folder_from_mongo_client_args(host, port, kwargs):
+    folder = (
+        kwargs.pop("tinymongo_folder", None)
+        or kwargs.pop("tinymongo_path", None)
+        or kwargs.pop("foldername", None)
+        or os.environ.get("TINYMONGO_HOME")
+    )
+    if folder is not None:
+        return folder
+    if host is None or _looks_like_network_target(host, port):
+        return u"tinydb"
+    return host
 
 
 class TinyMongoClient(object):
@@ -62,11 +196,58 @@ class TinyMongoClient(object):
         """Do nothing"""
         pass
 
+    def server_info(self):
+        """Return local TinyMongo metadata in the shape of PyMongo's call."""
+        return {
+            "version": "tinymongo",
+            "storage": self._backend,
+            "localPath": self._foldername,
+            "tinymongo": True,
+        }
+
+    def list_database_names(self):
+        """Return database names found in the configured local storage folder."""
+        extension = storage_extension(self._backend)
+        if not os.path.isdir(self._foldername):
+            return []
+        names = []
+        for filename in os.listdir(self._foldername):
+            if filename.endswith(extension):
+                names.append(filename[: -len(extension)])
+        return sorted(names)
+
+    def database_names(self):
+        """Compatibility alias for older PyMongo versions."""
+        return self.list_database_names()
+
     def __getattr__(self, name):
         """Gets a new or existing database based in attribute."""
         if name.startswith("_"):
             raise AttributeError("{} object has no attribute {}".format(type(self).__name__, name))
         return self._get_db(name)
+
+
+class MongoClient(TinyMongoClient):
+    """PyMongo-style client that stores data locally with TinyMongo.
+
+    Network hosts, ports, and MongoDB URIs are accepted for drop-in ergonomics
+    but ignored. Use ``tinymongo_folder`` or ``TINYMONGO_HOME`` to choose the
+    local storage folder while leaving PyMongo-shaped code mostly unchanged.
+    """
+
+    def __init__(
+        self,
+        host=None,
+        port=None,
+        document_class=None,
+        tz_aware=None,
+        connect=None,
+        type_registry=None,
+        **kwargs
+    ):
+        backend = kwargs.pop("backend", "tinydb")
+        foldername = _folder_from_mongo_client_args(host, port, kwargs)
+        super(MongoClient, self).__init__(foldername=foldername, backend=backend)
 
 
 class TinyMongoDatabase(object):
@@ -99,6 +280,10 @@ class TinyMongoDatabase(object):
         """Get a list of all the collection names in this database"""
         return list(self.tinydb.tables())
 
+    def list_collection_names(self):
+        """Compatibility alias for modern PyMongo."""
+        return [name for name in self.collection_names() if name != "_default"]
+
 
 class TinyMongoCollection(object):
     """
@@ -116,6 +301,8 @@ class TinyMongoCollection(object):
         self.tablename = table
         self.table = None
         self.parent = parent
+        self._indexes = set()
+        self._index_cache = {}
 
     def __repr__(self):
         """Return collection name"""
@@ -144,6 +331,49 @@ class TinyMongoCollection(object):
         """Reload the TinyDB database from disk and reset the table object."""
         self.parent._refresh_table()
         self.table = self.parent.tinydb.table(self.tablename)
+        self._index_cache = {}
+
+    def create_index(self, key):
+        """Create an in-memory equality index for this collection instance."""
+        self._indexes.add(key)
+        self._index_cache.pop(key, None)
+        return key
+
+    def drop_index(self, key):
+        """Drop an in-memory equality index for this collection instance."""
+        self._indexes.discard(key)
+        self._index_cache.pop(key, None)
+
+    def list_indexes(self):
+        """Return index metadata for this collection instance."""
+        indexes = [{"name": "_id_", "key": [("_id", 1)]}]
+        for key in sorted(self._indexes):
+            indexes.append({"name": "{0}_1".format(key), "key": [(key, 1)]})
+        return indexes
+
+    def _invalidate_indexes(self):
+        self._index_cache = {}
+
+    def _get_index(self, key):
+        if key not in self._indexes:
+            return None
+        if key in self._index_cache:
+            return self._index_cache[key]
+        if self.table is None:
+            self.build_table()
+        index = {}
+        for doc in self.table.all():
+            value = _get_nested(doc, key)
+            if value is _MISSING:
+                continue
+            values = value if isinstance(value, list) else [value]
+            for item in values:
+                try:
+                    index.setdefault(item, []).append(doc)
+                except TypeError:
+                    continue
+        self._index_cache[key] = index
+        return index
 
     def _acquire_collection_lock(self):
         lock_path = os.path.join(self.parent._foldername, ".tinymongo.lock")
@@ -173,6 +403,11 @@ class TinyMongoCollection(object):
             except Exception:
                 pass
 
+    def _set_storage_merge_writes(self, enabled):
+        storage = getattr(self.parent.tinydb, "_storage", None)
+        if hasattr(storage, "merge_writes"):
+            storage.merge_writes = enabled
+
     def count(self):
         """
         Counts the documents in the collection.
@@ -195,8 +430,17 @@ class TinyMongoCollection(object):
         exist.
         """
         if self.table:
-            self.parent.tinydb.drop_table(self.tablename)
-            return True
+            self._set_storage_merge_writes(False)
+            try:
+                drop_table = getattr(self.parent.tinydb, "drop_table", None)
+                if drop_table is not None:
+                    drop_table(self.tablename)
+                else:
+                    self.parent.tinydb.purge_table(self.tablename)
+                self.table = None
+                return True
+            finally:
+                self._set_storage_merge_writes(True)
             # from tinydb.database import TinyDB
             # TinyDB().
         else:
@@ -216,11 +460,10 @@ class TinyMongoCollection(object):
         :param doc: the document
         :return: InsertOneResult
         """
-        if self.table is None:
-            self.build_table()
-
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
+            if self.table is None:
+                self.build_table()
             self._refresh_table()
             if not isinstance(doc, dict):
                 raise ValueError(u'"doc" must be a dict')
@@ -247,6 +490,7 @@ class TinyMongoCollection(object):
                         )
                     )
 
+            self._invalidate_indexes()
             return InsertOneResult(eid=eid, inserted_id=_id)
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
@@ -257,11 +501,10 @@ class TinyMongoCollection(object):
         :param docs: a list of documents
         :return: InsertManyResult
         """
-        if self.table is None:
-            self.build_table()
-
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
+            if self.table is None:
+                self.build_table()
             self._refresh_table()
             if not isinstance(docs, list):
                 raise ValueError(u'"insert_many" requires a list input')
@@ -293,6 +536,7 @@ class TinyMongoCollection(object):
                 _ids.append(_id)
 
             results = self.table.insert_multiple(docs)
+            self._invalidate_indexes()
 
             return InsertManyResult(
                 eids=[eid for eid in results],
@@ -420,6 +664,12 @@ class TinyMongoCollection(object):
                     term = Q(q, prev_key) != v
                     nin_cond = term if nin_cond is None else (nin_cond & term)
                 conditions = nin_cond if not conditions else (conditions & nin_cond)
+            elif key == u"$exists":
+                exists_cond = Q(q, prev_key).exists()
+                if value:
+                    conditions = exists_cond if not conditions else conditions & exists_cond
+                else:
+                    conditions = ~exists_cond if not conditions else conditions & ~exists_cond
             elif key in ["$and", "$or", "$in", "$all"]:
                 pass
             else:
@@ -506,20 +756,21 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            if u"$set" in doc:
-                doc = doc[u"$set"]
-
             allcond = self.parse_query(query)
             item = self.table.get(allcond)
 
             if item is None:
                 return UpdateResult(raw_result=[])
 
-            if u"_id" not in doc:
-                doc[u"_id"] = item[u"_id"]
-
             try:
-                result = self.table.update(doc, where(u"_id") == item[u"_id"])
+                updated = _apply_update_document(item, doc)
+                if _is_operator_update(doc):
+                    result = self.table.update(updated, where(u"_id") == item[u"_id"])
+                else:
+                    self.table.remove(where(u"_id") == item[u"_id"])
+                    self.table.insert(updated)
+                    result = [item[u"_id"]]
+                self._invalidate_indexes()
             except Exception:
                 result = []
 
@@ -541,12 +792,21 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            if u"$set" in doc:
-                doc = doc[u"$set"]
-
             allcond = self.parse_query(query)
             try:
-                result = self.table.update(doc, allcond)
+                items = list(self.table.search(allcond))
+                result = []
+                for item in items:
+                    updated = _apply_update_document(item, doc)
+                    if _is_operator_update(doc):
+                        result.extend(
+                            self.table.update(updated, where(u"_id") == item[u"_id"])
+                        )
+                    else:
+                        self.table.remove(where(u"_id") == item[u"_id"])
+                        self.table.insert(updated)
+                        result.append(item[u"_id"])
+                self._invalidate_indexes()
             except Exception:
                 result = []
 
@@ -569,11 +829,11 @@ class TinyMongoCollection(object):
             if item is None:
                 return UpdateResult(raw_result=[])
 
-            replacement[u"_id"] = item[u"_id"]
-
             try:
+                replacement[u"_id"] = item[u"_id"]
                 self.table.remove(where(u"_id") == item[u"_id"])
                 self.table.insert(replacement)
+                self._invalidate_indexes()
                 result = [item[u"_id"]]
             except Exception:
                 result = []
@@ -611,6 +871,14 @@ class TinyMongoCollection(object):
         if _filter is None:
             result = self.table.all()
         else:
+            simple = _simple_equality_filter(_filter)
+            if simple is not None:
+                key, value = simple
+                index = self._get_index(key)
+                if index is not None:
+                    return TinyMongoCursor(
+                        list(index.get(value, [])), sort=sort, skip=skip, limit=limit
+                    )
             allcond = self.parse_query(_filter)
 
             try:
@@ -651,7 +919,12 @@ class TinyMongoCollection(object):
         :return: DeleteResult
         """
         item = self.find_one(query)
-        result = self.table.remove(where(u"_id") == item[u"_id"])
+        self._set_storage_merge_writes(False)
+        try:
+            result = self.table.remove(where(u"_id") == item[u"_id"])
+            self._invalidate_indexes()
+        finally:
+            self._set_storage_merge_writes(True)
 
         return DeleteResult(raw_result=result)
 
@@ -663,11 +936,18 @@ class TinyMongoCollection(object):
         :return: DeleteResult
         """
         items = self.find(query)
-        result = [self.table.remove(where(u"_id") == item[u"_id"]) for item in items]
+        self._set_storage_merge_writes(False)
+        try:
+            result = [
+                self.table.remove(where(u"_id") == item[u"_id"]) for item in items
+            ]
+            self._invalidate_indexes()
 
-        if query == {}:
-            # need to reset TinyDB's index for docs order consistency
-            self.table._last_id = 0
+            if query == {}:
+                # need to reset TinyDB's index for docs order consistency
+                self.table._last_id = 0
+        finally:
+            self._set_storage_merge_writes(True)
 
         return DeleteResult(raw_result=result)
 


### PR DESCRIPTION
## Summary
- add CLI commands for inspecting, importing, exporting, and migrating TinyMongo data
- move SQLite, DuckDB, and Parquet from blob-style storage to table-native collection backends
- compile supported Mongo-style filters into SQL over _id and JSON document payloads, with Python fallback for unsupported shapes
- add legacy blob-file migration for SQLite and DuckDB files when opened
- document TinyDB, table-native SQLite, table-native DuckDB, and DuckDB-managed Parquet backends with refreshed benchmark results
- add integration stress tests for concurrent writes and fix default JSON storage races with atomic locked writes
- expand PyMongo-style compatibility with MongoClient URI handling, constants, server/listing helpers, and contract tests
- broaden unit coverage for query/update/index/result/error/CLI/table backend behavior

## Verification
- .venv/bin/python -m coverage run -m pytest -q
- .venv/bin/python -m pytest -q -m integration tests/integration/test_concurrent_writes.py
- .venv/bin/python -m coverage report --include='tinymongo/*' -> 100%
- .venv/bin/python -m ruff check .
- .venv/bin/python -m build
- .venv/bin/python -m twine check dist/*
- .venv/bin/python tests/benchmarks/bench_storage.py --docs 1000 --queries 200 --json-output /tmp/tinymongo-table-backend-load-1000.json
