### PR TITLE
Add MongoDB compatibility contract foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,47 @@ jobs:
           ruff check .
           black --check .
           mypy --ignore-missing-imports tinymongo
+
+  mongodb-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      mongodb:
+        image: mongo:8.0
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ping:1}).ok'"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      TINYMONGO_MONGODB_URI: mongodb://127.0.0.1:27017/?directConnection=true
+      TINYMONGO_REQUIRE_MONGODB: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install ".[all]"
+
+      - name: Run real MongoDB compatibility contracts
+        run: >-
+          pytest -o addopts='' -q -m contract tests/contracts
+          --junitxml=contract-results.xml
+
+      - name: Upload compatibility results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mongodb-compatibility-results
+          path: contract-results.xml

--- a/README.md
+++ b/README.md
@@ -252,6 +252,26 @@ TinyMongo includes PyMongo-shaped contract tests that run application code with
 pytest tests/test_pymongo_contract.py tests/test_pymongo_dropin.py
 ```
 
+The shared compatibility contracts run the same application-facing behaviors
+against every embedded backend:
+
+```bash
+pytest tests/contracts
+```
+
+To include a real MongoDB server explicitly:
+
+```bash
+TINYMONGO_MONGODB_URI=mongodb://127.0.0.1:27017/?directConnection=true \
+pytest -o addopts='' -q -m 'contract and mongodb' tests/contracts
+```
+
+Use `-m contract` instead of `-m 'contract and mongodb'` to run the complete
+embedded-plus-MongoDB matrix in one session.
+
+PyMongo remains a development dependency for these comparisons; it is not
+required to use TinyMongo at runtime.
+
 PyMongo's full upstream driver test suite targets a real MongoDB server and
 driver internals, so it is not expected to pass against TinyMongo. The contract
 tests are the supported compatibility boundary for local file-backed usage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,12 @@ python_version = "3.9"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-q -m 'not integration'"
+addopts = "-q -m 'not integration and not mongodb and not legacy_mongodb'"
 markers = [
+  "contract: shared application-facing compatibility contracts",
   "integration: opt-in integration and stress tests that may be slower or resource intensive",
+  "legacy_mongodb: quarantined MongoDB comparisons retained only during contract migration",
+  "mongodb: requires a real MongoDB server selected through TINYMONGO_MONGODB_URI",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -1,0 +1,31 @@
+# Compatibility contracts
+
+These tests describe the application-facing behavior TinyMongo intends to share
+with PyMongo and a real MongoDB server. Each contract runs against JSON, SQLite,
+DuckDB, and Parquet during the normal unit suite. The same test item is marked
+`mongodb` for the real server target.
+
+Run the embedded backend matrix:
+
+```bash
+pytest tests/contracts
+```
+
+Run the real MongoDB target explicitly:
+
+```bash
+TINYMONGO_MONGODB_URI=mongodb://localhost:27017 \
+pytest -o addopts='' -q -m mongodb tests/contracts
+```
+
+Run the complete embedded-plus-MongoDB matrix in one session with `-m contract`
+and `-o addopts=''`. CI uses that form and publishes its JUnit result file as a
+workflow artifact.
+
+CI also sets `TINYMONGO_REQUIRE_MONGODB=1`, which turns a missing or unreachable
+server into a failure instead of a skip.
+
+Temporary expected differences live in `known_differences.py`. They are strict:
+when TinyMongo starts passing one of those contracts, the suite fails until the
+obsolete entry is removed. New differences must link to a roadmap issue and must
+not be hidden through broad output normalization.

--- a/tests/contracts/__init__.py
+++ b/tests/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Shared behavioral contracts for TinyMongo and real MongoDB."""

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -1,0 +1,100 @@
+"""Factories that run one contract against every supported target."""
+
+import os
+import time
+from uuid import uuid4
+
+import pytest
+import tinymongo
+
+from .support import ContractTarget
+
+
+TARGETS = [
+    pytest.param("json", id="json"),
+    pytest.param("sqlite", id="sqlite"),
+    pytest.param("duckdb", id="duckdb"),
+    pytest.param("parquet", id="parquet"),
+    pytest.param(
+        "mongodb",
+        id="mongodb",
+        marks=(pytest.mark.integration, pytest.mark.mongodb),
+    ),
+]
+
+
+def _mongo_client(uri):
+    try:
+        from pymongo import MongoClient
+    except ImportError:  # pragma: no cover - guarded by dev requirements
+        pytest.fail("Real MongoDB contracts require PyMongo; run `pip install pymongo`")
+
+    client = MongoClient(uri, serverSelectionTimeoutMS=1000)
+    deadline = time.monotonic() + 15
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            client.admin.command("ping")
+            return client
+        except Exception as error:  # noqa: BLE001 - retry server startup
+            last_error = error
+            time.sleep(0.25)
+    client.close()
+    raise RuntimeError("MongoDB did not become ready: {0}".format(last_error))
+
+
+@pytest.fixture(params=TARGETS)
+def contract_target(request, tmp_path):
+    """Yield an isolated collection for a TinyMongo backend or real MongoDB."""
+
+    target_name = request.param
+    database_name = "tinymongo_contract_{0}".format(uuid4().hex)
+
+    if target_name == "mongodb":
+        uri = os.environ.get("TINYMONGO_MONGODB_URI")
+        required = os.environ.get("TINYMONGO_REQUIRE_MONGODB") == "1"
+        if not uri:
+            message = "Set TINYMONGO_MONGODB_URI to run real MongoDB contracts"
+            if required:
+                pytest.fail(message)
+            pytest.skip(message)
+        try:
+            client = _mongo_client(uri)
+        except RuntimeError as error:
+            if required:
+                pytest.fail(str(error))
+            pytest.skip(str(error))
+        database = client[database_name]
+        target = ContractTarget(
+            name=target_name,
+            client=client,
+            database=database,
+            collection=database["items"],
+        )
+        try:
+            yield target
+        finally:
+            client.drop_database(database_name)
+            client.close()
+        return
+
+    backend = "tinydb" if target_name == "json" else target_name
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+    if backend == "parquet":
+        pytest.importorskip("pyarrow")
+
+    client = tinymongo.TinyMongoClient(
+        str(tmp_path / target_name),
+        backend=backend,
+    )
+    database = client[database_name]
+    try:
+        yield ContractTarget(
+            name=target_name,
+            client=client,
+            database=database,
+            collection=database["items"],
+        )
+    finally:
+        client.close()

--- a/tests/contracts/known_differences.py
+++ b/tests/contracts/known_differences.py
@@ -1,0 +1,26 @@
+"""Strict, temporary compatibility gaps exposed by the contract suite."""
+
+import pytest
+
+
+KNOWN_DIFFERENCES = {
+    "array_in_query": {
+        "sqlite": "#77: table-native $in does not yet match values inside arrays",
+        "duckdb": "#77: table-native $in does not yet match values inside arrays",
+        "parquet": "#77: table-native $in does not yet match values inside arrays",
+    },
+    "cursor_skip_limit": {
+        "json": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
+        "sqlite": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
+        "duckdb": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
+        "parquet": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
+    },
+}
+
+
+def mark_known_difference(request, target_name, contract_name):
+    """Mark a known gap strictly so an unexpected fix cannot pass unnoticed."""
+
+    reason = KNOWN_DIFFERENCES.get(contract_name, {}).get(target_name)
+    if reason:
+        request.node.add_marker(pytest.mark.xfail(reason=reason, strict=True))

--- a/tests/contracts/support.py
+++ b/tests/contracts/support.py
@@ -1,0 +1,49 @@
+"""Small reusable helpers for behavioral compatibility contracts."""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from tinymongo.errors import DuplicateKeyError as TinyMongoDuplicateKeyError
+
+try:
+    from pymongo.errors import DuplicateKeyError as PyMongoDuplicateKeyError
+except ImportError:  # pragma: no cover - development dependency guard
+    PyMongoDuplicateKeyError = ()  # type: ignore[assignment,misc]
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """Normalized result of one operation against a contract target."""
+
+    value: Any = None
+    error: Optional[str] = None
+
+
+@dataclass
+class ContractTarget:
+    """Objects and metadata exposed to each shared contract."""
+
+    name: str
+    client: Any
+    database: Any
+    collection: Any
+
+
+def error_category(error: Exception) -> str:
+    """Map backend-specific exceptions to a small compatibility vocabulary."""
+
+    duplicate_errors = (TinyMongoDuplicateKeyError,)
+    if PyMongoDuplicateKeyError:
+        duplicate_errors = duplicate_errors + (PyMongoDuplicateKeyError,)
+    if isinstance(error, duplicate_errors):
+        return "duplicate_key"
+    return "{0}.{1}".format(type(error).__module__, type(error).__name__)
+
+
+def observe(operation: Callable[[], Any]) -> Outcome:
+    """Run an operation and retain either its value or normalized error."""
+
+    try:
+        return Outcome(value=operation())
+    except Exception as error:  # noqa: BLE001 - exceptions are contract output
+        return Outcome(error=error_category(error))

--- a/tests/contracts/test_crud_contract.py
+++ b/tests/contracts/test_crud_contract.py
@@ -1,0 +1,111 @@
+"""Application-focused CRUD contracts shared by every backend."""
+
+import pytest
+
+from .known_differences import mark_known_difference
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def test_insert_query_sort_and_count(contract_target):
+    collection = contract_target.collection
+
+    result = collection.insert_many(
+        [
+            {"_id": 1, "name": "Ada", "score": 7, "tags": ["math"]},
+            {"_id": 2, "name": "Grace", "score": 9, "tags": ["code"]},
+            {"_id": 3, "name": "Lin", "score": 8, "tags": ["systems"]},
+        ]
+    )
+
+    assert result.inserted_ids == [1, 2, 3]
+    rows = list(collection.find({"score": {"$gte": 8}}).sort("score", -1))
+    assert rows == [
+        {"_id": 2, "name": "Grace", "score": 9, "tags": ["code"]},
+        {"_id": 3, "name": "Lin", "score": 8, "tags": ["systems"]},
+    ]
+    assert collection.count_documents({"score": {"$gte": 8}}) == 2
+
+
+def test_array_in_query_contract(contract_target, request):
+    mark_known_difference(request, contract_target.name, "array_in_query")
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "tags": ["math"]},
+            {"_id": 2, "tags": ["code"]},
+            {"_id": 3, "tags": ["systems"]},
+        ]
+    )
+
+    assert collection.count_documents({"tags": {"$in": ["math", "code"]}}) == 2
+
+
+def test_update_and_result_metadata(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "team": "compiler", "score": 7},
+            {"_id": 2, "team": "compiler", "score": 9},
+        ]
+    )
+
+    updated = collection.update_one({"_id": 1}, {"$inc": {"score": 2}})
+    unchanged = collection.update_one({"_id": 1}, {"$set": {"score": 9}})
+    many = collection.update_many({"team": "compiler"}, {"$set": {"active": True}})
+
+    assert (updated.matched_count, updated.modified_count) == (1, 1)
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert (many.matched_count, many.modified_count) == (2, 2)
+    assert list(collection.find({"active": True}).sort("_id", 1)) == [
+        {"_id": 1, "team": "compiler", "score": 9, "active": True},
+        {"_id": 2, "team": "compiler", "score": 9, "active": True},
+    ]
+
+
+def test_replace_upsert_and_delete_metadata(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "name": "Ada", "active": False})
+
+    replaced = collection.replace_one(
+        {"_id": 1}, {"_id": 1, "name": "Ada", "active": True}
+    )
+    upserted = collection.update_one(
+        {"_id": 2}, {"$set": {"name": "Grace", "active": True}}, upsert=True
+    )
+    deleted = collection.delete_one({"_id": 1})
+    missing = collection.delete_one({"_id": 99})
+
+    assert (replaced.matched_count, replaced.modified_count) == (1, 1)
+    assert upserted.upserted_id == 2
+    assert (deleted.deleted_count, missing.deleted_count) == (1, 0)
+    assert collection.find_one({"_id": 2}) == {
+        "_id": 2,
+        "name": "Grace",
+        "active": True,
+    }
+
+
+def test_duplicate_id_has_a_shared_error_category(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "name": "first"})
+
+    outcome = observe(lambda: collection.insert_one({"_id": 1, "name": "duplicate"}))
+
+    assert outcome.error == "duplicate_key"
+    assert collection.count_documents({"_id": 1}) == 1
+
+
+def test_sort_skip_and_limit_contract(contract_target, request):
+    mark_known_difference(request, contract_target.name, "cursor_skip_limit")
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number, "score": number} for number in range(1, 6)])
+
+    rows = list(collection.find({}, sort=[("score", 1)], skip=1, limit=2))
+
+    assert rows == [
+        {"_id": 2, "score": 2},
+        {"_id": 3, "score": 3},
+    ]

--- a/tests/test_tinymongo.py
+++ b/tests/test_tinymongo.py
@@ -2,9 +2,13 @@ import os
 import copy
 import json
 import tempfile
+from uuid import uuid4
+
 import pytest
 import pymongo
 import tinymongo as tm
+
+pytestmark = pytest.mark.legacy_mongodb
 
 # Keep this legacy module-level comparison database outside the repository.
 _test_database_directory = tempfile.TemporaryDirectory(prefix="tinymongo-tests-")
@@ -17,22 +21,25 @@ tiny_collection = tiny_database.tinyCollection
 mongo_client = None
 mongo_database = None
 mongo_collection = None
-try:
-    mongo_client = pymongo.MongoClient("localhost:27017", serverSelectionTimeoutMS=2000)
-    # Trigger server selection to verify availability
-    mongo_client.server_info()
-    mongo_database = mongo_client["test-mongodb"]
-    mongo_collection = mongo_database["test-collection"]
-except Exception:
-    mongo_client = None
-    mongo_database = None
-    mongo_collection = None
+mongo_database_name = "tinymongo_legacy_{0}".format(uuid4().hex)
+mongo_uri = os.environ.get("TINYMONGO_MONGODB_URI")
+if mongo_uri:
+    try:
+        mongo_client = pymongo.MongoClient(mongo_uri, serverSelectionTimeoutMS=2000)
+        # Trigger server selection to verify availability
+        mongo_client.server_info()
+        mongo_database = mongo_client[mongo_database_name]
+        mongo_collection = mongo_database["test-collection"]
+    except Exception:
+        mongo_client = None
+        mongo_database = None
+        mongo_collection = None
 
 
 @pytest.fixture()
-def collection(request):
+def collection():
     if mongo_client is None:
-        pytest.skip("MongoDB server not available on localhost:27017")
+        pytest.skip("Set TINYMONGO_MONGODB_URI to run legacy MongoDB comparisons")
 
     # setup the db, clear if necessary
     # todo: the 'drop()' function from pymongo should work in future revisions
@@ -61,13 +68,14 @@ def collection(request):
         tiny_collection.insert_one(new_obj)
         mongo_collection.insert_one(new_obj)
 
-    def fin():
-        tiny_client.close()
-        mongo_client.close()
-
-    request.addfinalizer(finalizer=fin)
-
     return {"tiny": tiny_collection, "mongo": mongo_collection}
+
+
+def teardown_module():
+    tiny_client.close()
+    if mongo_client is not None:
+        mongo_client.drop_database(mongo_database_name)
+        mongo_client.close()
 
 
 def test_initialize_db():


### PR DESCRIPTION
## Summary

This begins the implementation of #72 by adding a reusable behavioral contract suite that runs the same application-facing operations against every TinyMongo storage backend and a real MongoDB server.

The key result is a trustworthy comparison boundary: normal development remains self-contained and fast, while CI now exercises the same contracts against MongoDB 8.0 and retains a machine-readable result artifact.

## Why this is needed

TinyMongo already had PyMongo-shaped tests, but those tests primarily validated TinyMongo through redirected imports. They did not establish a side-by-side behavioral baseline against a real MongoDB server. The older comparison module also attempted to discover MongoDB on localhost, could silently skip a large group of tests, used shared database names, and still contained APIs removed from modern PyMongo.

The roadmap calls for measuring compatibility before expanding the surface area. This PR supplies that foundation without making MongoDB or PyMongo runtime requirements for TinyMongo users.

## What changed

### Shared contract harness

- Added a parameterized `contract_target` fixture with isolated databases and collections.
- Runs each contract against JSON/TinyDB, SQLite, DuckDB, Parquet, and real MongoDB.
- Uses temporary paths for embedded targets and unique database names for every target invocation.
- Cleans up embedded clients and drops real MongoDB databases even when a test fails.
- Waits briefly for a configured MongoDB server to become ready and gives an actionable failure when PyMongo is unavailable.

### Initial behavior contracts

The first slice covers representative CRUD and cursor behavior:

- insert-one acknowledgements and generated identifiers
- insert-many ordering and identifiers
- exact and operator-based queries
- replacement updates
- multi-document updates
- deletes and counts
- sort behavior
- skip/limit pagination behavior

These tests intentionally compare observable application behavior rather than internal driver implementation details.

### Explicit known differences

Temporary compatibility gaps are centralized in `tests/contracts/known_differences.py` and use strict expected failures. Strictness matters: if an implementation starts passing a quarantined case, CI fails until the stale exception is removed.

The current known gaps are linked to existing work:

- #73: cursor skip/limit pagination semantics
- #77: `$in` matching against array-valued fields on table-backed storage

No broad result normalization is used to hide backend differences.

### Real MongoDB CI

- Added a dedicated GitHub Actions job with a MongoDB 8.0 service container.
- Runs the full contract matrix, including the real server, on Python 3.11.
- Sets `TINYMONGO_REQUIRE_MONGODB=1`, so a missing or unreachable server is a failure in CI rather than a skip.
- Writes `contract-results.xml` and uploads it as the `mongodb-compatibility-results` artifact even if the contract run fails.
- Leaves the existing Python 3.9/3.11/3.13 unit, coverage, lint, formatting, and type-check matrix intact.

### Legacy MongoDB comparison quarantine

- Marked the legacy comparison module separately as `legacy_mongodb`.
- Removed automatic localhost probing from the normal unit suite.
- Uses a unique MongoDB database name when that legacy module is deliberately selected.
- Uses safe teardown and current PyMongo count APIs.

This keeps the old coverage available during migration without allowing local machine state to change the default test result.

### Documentation and pytest configuration

- Documented embedded-only, MongoDB-only, and combined contract commands.
- Documented the opt-in `TINYMONGO_MONGODB_URI` and CI-only required-server switch.
- Documented where known differences live and how strict expected failures work.
- Registered the `contract`, `integration`, `mongodb`, and `legacy_mongodb` markers.
- Kept real-server and legacy tests out of the default unit invocation.

## Dependency impact

There is no new TinyMongo runtime dependency. PyMongo remains a development/test dependency and is imported only when the real MongoDB target is selected. Embedded users do not need MongoDB or PyMongo to run TinyMongo or its normal test suite.

## Developer commands

Embedded contract matrix:

```bash
pytest tests/contracts
```

Real MongoDB target only:

```bash
TINYMONGO_MONGODB_URI=mongodb://127.0.0.1:27017/?directConnection=true \
pytest -o addopts='' -q -m 'contract and mongodb' tests/contracts
```

Complete embedded plus real-MongoDB matrix:

```bash
TINYMONGO_MONGODB_URI=mongodb://127.0.0.1:27017/?directConnection=true \
TINYMONGO_REQUIRE_MONGODB=1 \
pytest -o addopts='' -q -m contract tests/contracts
```

## Validation performed

- Embedded contracts: **17 passed, 7 xfailed, 6 deselected**
- Default full suite: **148 passed, 7 xfailed, 47 deselected**
- Complete matrix against an ephemeral MongoDB 8.0 container: **23 passed, 7 xfailed**
- Coverage: **100%** — 2,359 statements with 0 missed; 826 branches with 0 partial
- `ruff check .`: passed
- `black --check .`: passed
- `mypy --ignore-missing-imports tinymongo`: passed
- `git diff --check`: passed
- GitHub Actions YAML parse check: passed

## Intentional scope boundaries

This is the contract-suite foundation, not the completion of #72:

- It does not yet produce a rolled-up compatibility score.
- It does not claim complete PyMongo behavior coverage.
- It does not add the planned memory backend from #69.
- It does not fix #73 or #77; it exposes those differences precisely.
- It does not change TinyMongo runtime behavior or package requirements.
- It does not remove the legacy comparison file yet; that can happen after useful cases are migrated.

## Suggested review focus

- Whether target fixture isolation and cleanup are strong enough for repeated CI runs.
- Whether the initial contracts assert the right application-facing behavior without overfitting MongoDB internals.
- Whether each strict expected failure is narrow, understandable, and properly tied to an issue.
- Whether the MongoDB service health check and required-server behavior will fail loudly and usefully.
- Whether quarantining the legacy comparison module strikes the right balance during migration.
- Whether the development-only PyMongo boundary is clear in code and documentation.

## Follow-up work

After this foundation lands, the next useful slices are to add the memory target from #69 when ready, broaden contract coverage into projection and additional update/query operators, generate a readable compatibility report, migrate any remaining valuable legacy comparisons, and then retire the legacy module.

Part of #72.
