### PR TITLE
Add process-local memory backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Process-local `memory` backend for isolated tests and temporary data, with
+  explicit same-process sharing through named `memory://NAME` namespaces.
+- The memory backend now participates in the shared MongoDB compatibility
+  contract matrix.
+
 ## [1.2.0] - 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ TinyMongo defaults to TinyDB's JSON storage:
 You can select another backend with the `backend` argument:
 
 ```python
+    memory_connection = TinyMongoClient(backend="memory")
     parquet_connection = TinyMongoClient("/path/to/folder", backend="parquet")
     sqlite_connection = TinyMongoClient("/path/to/folder", backend="sqlite")
     duckdb_connection = TinyMongoClient("/path/to/folder", backend="duckdb")
@@ -102,6 +103,7 @@ updates/deletes rewrite that file:
 
 Available backends:
 
+- `memory`: Process-local storage that creates no database or lock files. Each unnamed client is isolated; a `memory://NAME` URI explicitly shares a named namespace within one process.
 - `tinydb` or `json`: TinyDB-compatible JSON storage. This is the default and writes `.json` files.
 - `sqlite`: Table-native SQLite storage using one SQL table per collection. This writes `.sqlite` files.
 - `duckdb`: Table-native DuckDB storage using one DuckDB table per collection. This writes `.duckdb` files.
@@ -125,12 +127,48 @@ dependency; it is used only by the development compatibility tests.
 
 | Backend | Dependency | Best fit | Notes |
 | --- | --- | --- | --- |
+| `memory` | None | Isolated tests and temporary data | Creates no files. Named `memory://NAME` namespaces can be shared only within one process. |
 | `tinydb` / `json` | TinyDB | Default local JSON files | Human-readable and simplest to inspect. |
 | `sqlite` | Python standard library | Embedded transactional storage | Uses `_id` primary keys and JSON document payloads in collection tables. |
 | `duckdb` | `duckdb` | SQL-backed local analytics workflows | Uses real DuckDB collection tables and SQL JSON predicates where supported. |
 | `parquet` / `parquetv2` | `duckdb`, `pyarrow` | Columnar local or object-storage workflows | Stores collection Parquet files that DuckDB reads and writes. |
 | `postgres` / `postgresql` | `tinymongo[postgres]` | Remote transactional storage | Stores documents in PostgreSQL tables with JSONB payloads. |
 | `mysql` / `mariadb` | `tinymongo[mysql]` or `tinymongo[mariadb]` | Remote transactional storage | Stores documents in MariaDB/MySQL tables with JSON payloads. |
+
+## In-memory testing and temporary data
+
+For test isolation or scratch data, select the memory backend without a named
+address. Every client receives a separate in-memory database and creates no
+files:
+
+```python
+from tinymongo import TinyMongoClient
+
+client = TinyMongoClient(backend="memory")
+client.app.users.insert_one({"name": "Ada"})
+assert client.app.users.count_documents({}) == 1
+client.close()
+```
+
+Use a named URI only when clients in the same process need to share data. A
+named namespace remains available after a client closes and can be reopened
+until the process exits:
+
+```python
+writer = TinyMongoClient("memory://shared-test", backend="memory")
+writer.app.users.insert_one({"name": "Grace"})
+writer.close()
+
+reader = TinyMongoClient("memory://shared-test", backend="memory")
+assert reader.app.users.find_one({"name": "Grace"}) is not None
+```
+
+Memory data never persists across process restarts, and named namespaces are not
+safe for sharing between processes. Prefer unnamed clients, or unique names, in
+independent tests. Use a durable backend instead when data must survive a test
+run or application restart. The command-line tool intentionally omits the
+memory backend because every CLI invocation exits immediately; use it through
+the Python API instead.
 
 SQLite, DuckDB, and Parquet compile supported Mongo-style filters into SQL over
 the `_id` column and JSON document payload. Unsupported filter shapes fall back

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -1,9 +1,9 @@
 # Compatibility contracts
 
 These tests describe the application-facing behavior TinyMongo intends to share
-with PyMongo and a real MongoDB server. Each contract runs against JSON, SQLite,
-DuckDB, and Parquet during the normal unit suite. The same test item is marked
-`mongodb` for the real server target.
+with PyMongo and a real MongoDB server. Each contract runs against memory, JSON,
+SQLite, DuckDB, and Parquet during the normal unit suite. The same test item is
+marked `mongodb` for the real server target.
 
 Run the embedded backend matrix:
 

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -11,6 +11,7 @@ from .support import ContractTarget
 
 
 TARGETS = [
+    pytest.param("memory", id="memory"),
     pytest.param("json", id="json"),
     pytest.param("sqlite", id="sqlite"),
     pytest.param("duckdb", id="duckdb"),
@@ -44,7 +45,7 @@ def _mongo_client(uri):
 
 
 @pytest.fixture(params=TARGETS)
-def contract_target(request, tmp_path):
+def contract_target(request, tmp_path, monkeypatch):
     """Yield an isolated collection for a TinyMongo backend or real MongoDB."""
 
     target_name = request.param
@@ -84,10 +85,16 @@ def contract_target(request, tmp_path):
     if backend == "parquet":
         pytest.importorskip("pyarrow")
 
-    client = tinymongo.TinyMongoClient(
-        str(tmp_path / target_name),
-        backend=backend,
-    )
+    if backend == "memory":
+        working_directory = tmp_path / "memory-cwd"
+        working_directory.mkdir()
+        monkeypatch.chdir(working_directory)
+        client = tinymongo.TinyMongoClient(backend=backend)
+    else:
+        client = tinymongo.TinyMongoClient(
+            str(tmp_path / target_name),
+            backend=backend,
+        )
     database = client[database_name]
     try:
         yield ContractTarget(

--- a/tests/contracts/known_differences.py
+++ b/tests/contracts/known_differences.py
@@ -10,6 +10,7 @@ KNOWN_DIFFERENCES = {
         "parquet": "#77: table-native $in does not yet match values inside arrays",
     },
     "cursor_skip_limit": {
+        "memory": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
         "json": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
         "sqlite": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
         "duckdb": "#73: cursor pagination does not yet retain a PyMongo-style query spec",

--- a/tests/test_memory_backend.py
+++ b/tests/test_memory_backend.py
@@ -1,0 +1,407 @@
+from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
+
+import pytest
+import tinymongo as tm
+from tinymongo.errors import DuplicateKeyError
+from tinymongo import storage_backends
+from tinymongo.storage_backends import storage_extension
+
+
+def _memory_uri(prefix):
+    return "memory://{0}-{1}".format(prefix, uuid4().hex)
+
+
+def test_anonymous_memory_backend_supports_crud_without_creating_files(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    client = tm.TinyMongoClient(backend="memory")
+    collection = client.app.items
+
+    inserted = collection.insert_one({"_id": "item-1", "count": 1})
+    updated = collection.update_one({"_id": "item-1"}, {"$inc": {"count": 2}})
+
+    assert inserted.inserted_id == "item-1"
+    assert (updated.matched_count, updated.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "item-1"}) == {
+        "_id": "item-1",
+        "count": 3,
+    }
+    assert collection.delete_one({"_id": "item-1"}).deleted_count == 1
+    assert collection.count_documents({}) == 0
+
+    client.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_anonymous_memory_clients_are_isolated(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    first = tm.TinyMongoClient(backend="memory")
+    second = tm.TinyMongoClient(backend="memory")
+
+    first.app.items.insert_one({"_id": "private"})
+
+    assert first.app.items.count_documents({}) == 1
+    assert second.app.items.count_documents({}) == 0
+
+    first.close()
+    second.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_named_memory_clients_share_data_and_survive_close(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    uri = _memory_uri("shared")
+    writer = tm.TinyMongoClient(uri, backend="memory")
+    peer = tm.TinyMongoClient(uri, backend="memory")
+
+    writer.app.items.insert_one({"_id": "shared", "value": 42})
+    assert peer.app.items.find_one({"_id": "shared"})["value"] == 42
+
+    writer.close()
+    peer.close()
+    later = tm.TinyMongoClient(uri, backend="memory")
+    try:
+        assert later.app.items.find_one({"_id": "shared"}) == {
+            "_id": "shared",
+            "value": 42,
+        }
+    finally:
+        later.close()
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_named_reader_refreshes_a_cached_miss_after_another_client_writes():
+    uri = _memory_uri("cache-refresh")
+    writer = tm.TinyMongoClient(uri, backend="memory")
+    reader = tm.TinyMongoClient(uri, backend="memory")
+    try:
+        assert list(reader.app.items.find({"kind": "new"})) == []
+
+        writer.app.items.insert_one({"_id": "later", "kind": "new"})
+
+        assert list(reader.app.items.find({"kind": "new"})) == [
+            {"_id": "later", "kind": "new"}
+        ]
+    finally:
+        writer.close()
+        reader.close()
+
+
+def test_each_retained_collection_handle_tracks_its_own_cache_revision():
+    uri = _memory_uri("per-collection-cache")
+    writer = tm.TinyMongoClient(uri, backend="memory")
+    reader = tm.TinyMongoClient(uri, backend="memory")
+    stale_items = reader.app.items
+    unrelated = reader.app.audit
+    try:
+        assert list(stale_items.find({"kind": "new"})) == []
+        assert list(unrelated.find({})) == []
+
+        writer.app.items.insert_one({"_id": "later", "kind": "new"})
+        assert list(unrelated.find({})) == []
+
+        assert list(stale_items.find({"kind": "new"})) == [
+            {"_id": "later", "kind": "new"}
+        ]
+    finally:
+        writer.close()
+        reader.close()
+
+
+def test_shared_collection_invalidates_its_cached_equality_index():
+    uri = _memory_uri("index-cache")
+    writer = tm.TinyMongoClient(uri, backend="memory")
+    reader = tm.TinyMongoClient(uri, backend="memory")
+    indexed = reader.app.items
+    unrelated = reader.app.audit
+    try:
+        writer.app.items.insert_one({"_id": 1, "name": "Ada"})
+        indexed.create_index("name")
+        assert list(indexed.find({"name": "Ada"})) == [{"_id": 1, "name": "Ada"}]
+
+        writer.app.items.update_one({"_id": 1}, {"$set": {"name": "Grace"}})
+        assert list(unrelated.find({})) == []
+
+        assert list(indexed.find({"name": "Ada"})) == []
+        assert list(indexed.find({"name": "Grace"})) == [{"_id": 1, "name": "Grace"}]
+    finally:
+        writer.close()
+        reader.close()
+
+
+def test_shared_find_one_and_update_refreshes_before_returning_old_document():
+    uri = _memory_uri("find-and-update")
+    writer = tm.TinyMongoClient(uri, backend="memory")
+    reader = tm.TinyMongoClient(uri, backend="memory")
+    try:
+        assert reader.app.items.find_one({"_id": "later"}) is None
+        writer.app.items.insert_one({"_id": "later", "count": 1})
+
+        previous = reader.app.items.find_one_and_update(
+            {"_id": "later"}, {"$inc": {"count": 1}}
+        )
+
+        assert previous == {"_id": "later", "count": 1}
+        assert writer.app.items.find_one({"_id": "later"})["count"] == 2
+    finally:
+        writer.close()
+        reader.close()
+
+
+def test_memory_storage_copies_input_and_returned_documents():
+    client = tm.TinyMongoClient(backend="memory")
+    source = {"_id": "copy", "nested": {"count": 1}}
+    try:
+        client.app.items.insert_one(source)
+        source["nested"]["count"] = 99
+        returned = client.app.items.find_one({"_id": "copy"})
+        returned["nested"]["count"] = 42
+
+        assert client.app.items.find_one({"_id": "copy"}) == {
+            "_id": "copy",
+            "nested": {"count": 1},
+        }
+    finally:
+        client.close()
+
+
+def test_memory_storage_uses_the_same_json_value_rules_as_default_storage():
+    client = tm.TinyMongoClient(backend="memory")
+    try:
+        client.app.items.insert_one({"_id": "tuple", "values": (1, 2)})
+        assert client.app.items.find_one({"_id": "tuple"})["values"] == [1, 2]
+
+        with pytest.raises(TypeError):
+            client.app.items.insert_one({"_id": "unsupported", "value": object()})
+        assert client.app.items.find_one({"_id": "unsupported"}) is None
+    finally:
+        client.close()
+
+
+def test_different_named_memory_registries_are_isolated(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    first = tm.TinyMongoClient(_memory_uri("first"), backend="memory")
+    second = tm.TinyMongoClient(_memory_uri("second"), backend="memory")
+
+    first.app.items.insert_one({"_id": "only-first"})
+
+    assert second.app.items.find_one({"_id": "only-first"}) is None
+
+    first.close()
+    second.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_named_clients_share_collection_lifecycle_and_local_index_behavior():
+    uri = _memory_uri("collection-lifecycle")
+    writer = tm.TinyMongoClient(uri, backend="memory")
+    peer = tm.TinyMongoClient(uri, backend="memory")
+    collection = writer.app.items
+    try:
+        collection.insert_one({"_id": 1, "name": "Ada"})
+        assert collection.create_index("name") == "name"
+        assert {index["name"] for index in collection.list_indexes()} == {
+            "_id_",
+            "name_1",
+        }
+        assert collection.find_one({"name": "Ada"})["_id"] == 1
+
+        assert peer.app.drop_collection("items") is True
+        assert "items" not in peer.app.list_collection_names()
+        assert collection.find_one({"_id": 1}) is None
+    finally:
+        writer.close()
+        peer.close()
+
+
+def test_named_memory_backend_handles_concurrent_client_inserts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    uri = _memory_uri("threads")
+    workers = 4
+    inserts_per_worker = 20
+
+    def insert_batch(worker):
+        with tm.TinyMongoClient(uri, backend="memory") as client:
+            client.app.items.insert_many(
+                [
+                    {
+                        "_id": "{0}-{1}".format(worker, index),
+                        "worker": worker,
+                        "index": index,
+                    }
+                    for index in range(inserts_per_worker)
+                ]
+            )
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        list(executor.map(insert_batch, range(workers)))
+
+    reader = tm.TinyMongoClient(uri, backend="memory")
+    try:
+        documents = list(reader.app.items.find({}))
+        assert len(documents) == workers * inserts_per_worker
+        assert {document["_id"] for document in documents} == {
+            "{0}-{1}".format(worker, index)
+            for worker in range(workers)
+            for index in range(inserts_per_worker)
+        }
+    finally:
+        reader.close()
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_concurrent_duplicate_id_allows_exactly_one_insert():
+    uri = _memory_uri("duplicate")
+
+    def insert_duplicate(_worker):
+        with tm.TinyMongoClient(uri, backend="memory") as client:
+            try:
+                client.app.items.insert_one({"_id": "same"})
+                return True
+            except DuplicateKeyError:
+                return False
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        outcomes = list(executor.map(insert_duplicate, range(4)))
+
+    reader = tm.TinyMongoClient(uri, backend="memory")
+    try:
+        assert outcomes.count(True) == 1
+        assert reader.app.items.count_documents({"_id": "same"}) == 1
+    finally:
+        reader.close()
+
+
+def test_memory_database_listing_and_capabilities(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    client = tm.TinyMongoClient(backend="memory")
+
+    assert client.list_database_names() == []
+
+    client.alpha.items.insert_one({"_id": 1})
+    client.zeta.items.insert_one({"_id": 2})
+    capabilities = client.capabilities()
+
+    assert client.list_database_names() == ["alpha", "zeta"]
+    assert capabilities["backend"] == "memory"
+    assert capabilities["persistent"] is False
+    assert capabilities["multiprocess_writes"] is False
+    assert client.supports("persistent") is False
+    assert client.supports("multiprocess_writes") is False
+
+    client.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_mongo_client_memory_uri_uses_the_named_registry_without_disk(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    shared_uri = _memory_uri("mongo-client")
+    other_uri = _memory_uri("other-mongo-client")
+    writer = tm.MongoClient(shared_uri, backend="memory")
+
+    writer.app.items.insert_one({"_id": "through-mongo-client"})
+    writer.close()
+
+    reader = tm.MongoClient(shared_uri, backend="memory")
+    isolated = tm.MongoClient(other_uri, backend="memory")
+    try:
+        assert reader.app.items.find_one({"_id": "through-mongo-client"}) == {
+            "_id": "through-mongo-client"
+        }
+        assert isolated.app.items.find_one({"_id": "through-mongo-client"}) is None
+    finally:
+        reader.close()
+        isolated.close()
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_memory_uri_scheme_is_case_insensitive_for_both_client_classes():
+    name = "case-{0}".format(uuid4().hex)
+    writer = tm.TinyMongoClient("Memory://{0}".format(name), backend="memory")
+    reader = tm.MongoClient("memory://{0}".format(name), backend="memory")
+    try:
+        writer.app.items.insert_one({"_id": "shared"})
+        assert reader.app.items.find_one({"_id": "shared"}) == {"_id": "shared"}
+    finally:
+        writer.close()
+        reader.close()
+
+
+def test_closing_anonymous_client_clears_its_private_namespace():
+    client = tm.TinyMongoClient(backend="memory")
+    private_uri = client._memory_namespace
+    client.app.items.insert_one({"_id": "temporary"})
+    client.close()
+    client.close()
+
+    reopened = tm.TinyMongoClient(private_uri, backend="memory")
+    try:
+        assert reopened.list_database_names() == []
+        assert reopened.app.items.find_one({"_id": "temporary"}) is None
+    finally:
+        reopened.close()
+
+
+def test_stale_cleanup_does_not_remove_a_replacement_memory_entry():
+    namespace = "memory://cleanup-{0}".format(uuid4().hex)
+    address = namespace + "/app"
+    replacement = {
+        "data": {"items": {"1": {"_id": "replacement"}}},
+        "revision": 1,
+        "lock": storage_backends.threading.RLock(),
+    }
+
+    class ReplaceEntryOnAcquire:
+        def __enter__(self):
+            with storage_backends._memory_registry_lock:
+                storage_backends._memory_registry[address] = replacement
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    stale = {"data": None, "revision": 0, "lock": ReplaceEntryOnAcquire()}
+    with storage_backends._memory_registry_lock:
+        storage_backends._memory_registry[address] = stale
+
+    try:
+        storage_backends.clear_memory_namespace(namespace)
+        with storage_backends._memory_registry_lock:
+            assert storage_backends._memory_registry[address] is replacement
+    finally:
+        with storage_backends._memory_registry_lock:
+            storage_backends._memory_registry.pop(address, None)
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "memory://",
+        "memory://nested/path",
+        "memory://name?option=1",
+        "memory://name#x",
+        "memory://two words",
+    ],
+)
+def test_invalid_named_memory_addresses_fail_clearly(address):
+    with pytest.raises(ValueError, match="memory://test-suite"):
+        tm.TinyMongoClient(address, backend="memory")
+
+
+@pytest.mark.parametrize("client_class", [tm.TinyMongoClient, tm.MongoClient])
+@pytest.mark.parametrize("address", ["memroy://name", "mongodb://localhost"])
+def test_other_uri_schemes_are_rejected_instead_of_silently_isolated(
+    client_class, address
+):
+    with pytest.raises(ValueError, match="must start with memory://"):
+        client_class(address, backend="memory")
+
+
+def test_memory_storage_extension_is_empty():
+    assert storage_extension("memory") == ""

--- a/tinymongo/storage_backends.py
+++ b/tinymongo/storage_backends.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import sqlite3
@@ -18,6 +19,46 @@ duckdb: Any = _duckdb
 
 
 OBJECT_STORAGE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
+
+
+_memory_registry: dict[str, dict[str, Any]] = {}
+_memory_registry_lock = threading.RLock()
+
+
+def _memory_entry(address):
+    """Return the process-local storage entry for a memory database."""
+    with _memory_registry_lock:
+        return _memory_registry.setdefault(
+            str(address),
+            {"data": None, "revision": 0, "lock": threading.RLock()},
+        )
+
+
+def list_memory_databases(namespace):
+    """List databases currently present in a process-local namespace."""
+    prefix = str(namespace).rstrip("/") + "/"
+    with _memory_registry_lock:
+        return sorted(
+            address[len(prefix) :]
+            for address in _memory_registry
+            if address.startswith(prefix) and address[len(prefix) :]
+        )
+
+
+def clear_memory_namespace(namespace):
+    """Remove all databases belonging to an anonymous memory client."""
+    prefix = str(namespace).rstrip("/") + "/"
+    with _memory_registry_lock:
+        entries = [
+            (address, entry)
+            for address, entry in _memory_registry.items()
+            if address.startswith(prefix)
+        ]
+    for address, entry in entries:
+        with entry["lock"]:
+            with _memory_registry_lock:
+                if _memory_registry.get(address) is entry:
+                    _memory_registry.pop(address, None)
 
 
 def is_object_storage_uri(value):
@@ -146,6 +187,43 @@ class AtomicJSONStorage(Storage):
             self._release_lock(rlock, portalocker_lock)
 
 
+class MemoryStorage(AtomicJSONStorage):
+    """TinyDB storage shared by a named address inside the current process."""
+
+    is_memory = True
+
+    def __init__(self, address):
+        self.address = str(address)
+        self.merge_writes = True
+        self._entry = _memory_entry(self.address)
+
+    @property
+    def collection_lock(self):
+        """Return the lock shared by every client using this database."""
+        return self._entry["lock"]
+
+    @property
+    def revision(self):
+        """Return the generation used to invalidate per-collection caches."""
+        with self.collection_lock:
+            return self._entry["revision"]
+
+    def read(self):
+        with self.collection_lock:
+            return copy.deepcopy(self._entry["data"])
+
+    def write(self, data):
+        with self.collection_lock:
+            payload = json.loads(json.dumps(data or {}, ensure_ascii=False))
+            if self.merge_writes and self._entry["data"] is not None:
+                payload = self._merge_data(self._entry["data"], payload)
+            self._entry["data"] = copy.deepcopy(payload)
+            self._entry["revision"] += 1
+
+    def close(self):
+        """Memory remains available to other clients in the process."""
+
+
 class SQLiteStorage(Storage):
     """TinyDB storage backend using SQLite as a single-row JSON store."""
 
@@ -265,6 +343,8 @@ def get_storage_class(name):
 
     backend = str(name).lower()
 
+    if backend == "memory":
+        return MemoryStorage
     if backend in ("tinydb", "json", "postgres", "postgresql", "mysql", "mariadb"):
         return AtomicJSONStorage
     if backend in ("parquet", "parquetv2"):
@@ -277,7 +357,7 @@ def get_storage_class(name):
         return DuckDBStorage
 
     raise ValueError(
-        "Unsupported backend '{0}'. Supported backends: tinydb, parquet, parquetv2, sqlite, duckdb, postgres, mariadb.".format(
+        "Unsupported backend '{0}'. Supported backends: memory, tinydb, parquet, parquetv2, sqlite, duckdb, postgres, mariadb.".format(
             name
         )
     )
@@ -285,6 +365,8 @@ def get_storage_class(name):
 
 def storage_extension(name):
     backend = str(name).lower()
+    if backend == "memory":
+        return ""
     if backend in ("tinydb", "json"):
         return ".json"
     if backend in ("parquet", "parquetv2"):
@@ -296,7 +378,7 @@ def storage_extension(name):
     if backend in ("postgres", "postgresql", "mysql", "mariadb"):
         return ""
     raise ValueError(
-        "Unsupported backend '{0}'. Supported backends: tinydb, parquet, parquetv2, sqlite, duckdb, postgres, mariadb.".format(
+        "Unsupported backend '{0}'. Supported backends: memory, tinydb, parquet, parquetv2, sqlite, duckdb, postgres, mariadb.".format(
             name
         )
     )

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -13,11 +13,13 @@ from uuid import uuid4
 
 from tinydb import Query, TinyDB, where
 from .storage_backends import (
+    clear_memory_namespace,
     get_storage_class,
     get_table_backend,
     is_remote_sql_backend,
     is_table_backend,
     join_storage_uri,
+    list_memory_databases,
     storage_extension,
 )
 
@@ -203,6 +205,24 @@ def _folder_from_mongo_client_args(host, port, kwargs):
     return host
 
 
+def _memory_namespace(foldername):
+    """Return an isolated or explicitly shared process-memory namespace."""
+    address = str(foldername or "").strip()
+    if "://" not in address:
+        return "memory://__anonymous__{0}".format(uuid4().hex), False
+    if not address.lower().startswith("memory://"):
+        raise ValueError("Memory backend addresses must start with memory://")
+
+    name = address[len("memory://") :]
+    if not name or not all(
+        character.isalnum() or character in "._-" for character in name
+    ):
+        raise ValueError(
+            "Memory addresses must use a simple name such as memory://test-suite"
+        )
+    return "memory://{0}".format(name), True
+
+
 class TinyMongoClient(object):
     """Represents the Tiny `db` client"""
 
@@ -210,6 +230,11 @@ class TinyMongoClient(object):
         """Initialize container folder and choose a storage backend."""
         self._foldername = foldername
         self._backend = backend or "tinydb"
+        self._memory_namespace = None
+        self._shared_memory = False
+        if str(self._backend).lower() == "memory":
+            self._memory_namespace, self._shared_memory = _memory_namespace(foldername)
+            self._foldername = self._memory_namespace
         self._threads = kwargs.get("threads")
         self._storage_uri = kwargs.get("storage_uri") or os.environ.get(
             "TINYMONGO_STORAGE_URI"
@@ -218,10 +243,11 @@ class TinyMongoClient(object):
         self._dsn = kwargs.get("dsn") or self._dsn_from_env(self._backend)
         self._databases = {}
         self._closed = False
-        try:
-            os.makedirs(foldername, exist_ok=True)
-        except OSError as x:
-            logger.info("{}".format(x))
+        if self._memory_namespace is None:
+            try:
+                os.makedirs(foldername, exist_ok=True)
+            except OSError as x:
+                logger.info("{}".format(x))
 
     def _dsn_from_env(self, backend):
         backend = str(backend or "").lower()
@@ -250,6 +276,8 @@ class TinyMongoClient(object):
         return self._get_db(key)
 
     def _get_db_path(self, key):
+        if self._memory_namespace is not None:
+            return self._memory_namespace.rstrip("/") + "/" + str(key)
         if is_remote_sql_backend(self._backend):
             return key
         if self._storage_uri and str(self._backend).lower() in ("parquet", "parquetv2"):
@@ -290,6 +318,8 @@ class TinyMongoClient(object):
         for database in self._databases.values():
             database.close()
         self._databases.clear()
+        if self._memory_namespace is not None and not self._shared_memory:
+            clear_memory_namespace(self._memory_namespace)
         self._closed = True
 
     def __enter__(self):
@@ -316,11 +346,11 @@ class TinyMongoClient(object):
         object_storage = bool(self._storage_uri and backend in ("parquet", "parquetv2"))
         return {
             "backend": backend,
-            "persistent": True,
+            "persistent": backend != "memory",
             "remote_storage": remote,
             "object_storage": object_storage,
             "table_native": is_table_backend(backend),
-            "multiprocess_writes": not object_storage,
+            "multiprocess_writes": backend != "memory" and not object_storage,
             "native_indexes": backend == "sqlite",
             "projections": False,
             "bulk_writes": False,
@@ -350,6 +380,8 @@ class TinyMongoClient(object):
 
     def list_database_names(self):
         """Return database names found in the configured local storage folder."""
+        if self._memory_namespace is not None:
+            return list_memory_databases(self._memory_namespace)
         extension = storage_extension(self._backend)
         if is_remote_sql_backend(self._backend):
             engine_class = get_table_backend(self._backend)
@@ -413,7 +445,20 @@ class MongoClient(TinyMongoClient):
         threads = kwargs.pop("threads", None)
         duckdb_config = kwargs.pop("duckdb_config", None)
         dsn = kwargs.pop("dsn", None)
+        explicit_folder = (
+            kwargs.get("tinymongo_folder")
+            or kwargs.get("tinymongo_path")
+            or kwargs.get("foldername")
+            or os.environ.get("TINYMONGO_HOME")
+        )
         foldername = _folder_from_mongo_client_args(host, port, kwargs)
+        if (
+            str(backend).lower() == "memory"
+            and explicit_folder is None
+            and isinstance(host, str)
+            and "://" in host
+        ):
+            foldername = host
         super(MongoClient, self).__init__(
             foldername=foldername,
             backend=backend,
@@ -431,10 +476,19 @@ class TinyMongoDatabase(object):
         """Initialize a TinyDB file named as the db name in the given folder."""
         self.database = database
         self._path = path
-        self._foldername = os.path.dirname(path) or "."
+        self._foldername = (
+            path.rsplit("/", 1)[0]
+            if str(path).startswith("memory://")
+            else os.path.dirname(path) or "."
+        )
         self._storage = storage
         self.engine = engine
         self.tinydb = None if engine is not None else TinyDB(path, storage=storage)
+        self._memory_revision = self._current_memory_revision()
+
+    def _current_memory_revision(self):
+        storage = getattr(self.tinydb, "_storage", None)
+        return getattr(storage, "revision", None)
 
     def _refresh_table(self):
         """Reload the TinyDB database from disk to pick up external writes."""
@@ -445,6 +499,7 @@ class TinyMongoDatabase(object):
         except Exception:
             pass
         self.tinydb = TinyDB(self._path, storage=self._storage)
+        self._memory_revision = self._current_memory_revision()
 
     def __getattr__(self, name):
         """Gets a new or existing collection"""
@@ -516,6 +571,7 @@ class TinyMongoCollection(object):
         self.parent = parent
         self._indexes = set()
         self._index_cache = {}
+        self._memory_revision = None
 
     def __repr__(self):
         """Return collection name"""
@@ -574,12 +630,24 @@ class TinyMongoCollection(object):
             self.parent.engine.create_collection(self.tablename)
             return
         self.table = self.parent.tinydb.table(self.tablename)
+        self._remember_memory_revision()
 
     def _refresh_table(self):
         """Reload the TinyDB database from disk and reset the table object."""
         self.parent._refresh_table()
         self.table = self.parent.tinydb.table(self.tablename)
         self._index_cache = {}
+        self._remember_memory_revision()
+
+    def _remember_memory_revision(self):
+        self._memory_revision = self.parent._memory_revision
+
+    def _refresh_stale_memory_table(self):
+        """Reset TinyDB query caches after another memory client writes."""
+        storage = getattr(self.parent.tinydb, "_storage", None)
+        revision = getattr(storage, "revision", None)
+        if revision is not None and revision != self._memory_revision:
+            self._refresh_table()
 
     def create_index(self, key, *args, **kwargs):
         """Create an in-memory equality index for this collection instance."""
@@ -633,7 +701,19 @@ class TinyMongoCollection(object):
         self._index_cache[key] = index
         return index
 
+    def _acquire_memory_collection_lock(self):
+        storage = getattr(self.parent.tinydb, "_storage", None)
+        memory_lock = getattr(storage, "collection_lock", None)
+        if memory_lock is not None:
+            memory_lock.acquire()
+            return memory_lock, None
+        return None, None
+
     def _acquire_collection_lock(self):
+        memory_lock, portalocker_lock = self._acquire_memory_collection_lock()
+        if memory_lock is not None:
+            return memory_lock, portalocker_lock
+
         lock_path = os.path.join(self.parent._foldername, ".tinymongo.lock")
         from .parquet_storage import _local_rlocks, _acquire_rlock, portalocker
         import threading
@@ -696,7 +776,10 @@ class TinyMongoCollection(object):
         _reject_session(kwargs)
         if self.parent.engine is not None:
             return self.parent.engine.drop_collection(self.tablename)
-        if self.tablename in self.parent.collection_names():
+        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        try:
+            if self.tablename not in self.parent.collection_names():
+                return False
             if self.table is None:
                 self.build_table()
             self._set_storage_merge_writes(False)
@@ -710,10 +793,8 @@ class TinyMongoCollection(object):
                 return True
             finally:
                 self._set_storage_merge_writes(True)
-            # from tinydb.database import TinyDB
-            # TinyDB().
-        else:
-            return False
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
 
     def insert(self, docs, *args, **kwargs):
         """Backwards compatibility with insert"""
@@ -1308,11 +1389,7 @@ class TinyMongoCollection(object):
             self.update_one(query, update, *args, **kwargs)
             return self.find_one(query) if kwargs.get("return_document") else item
 
-        if self.table is None:
-            self.build_table()
-
-        allcond = self.parse_query(query)
-        item = self.table.get(allcond)
+        item = self.find_one(query)
         if item is None:
             result = self.update_one(query, update, *args, **kwargs)
             if result.upserted_id is None:
@@ -1350,36 +1427,40 @@ class TinyMongoCollection(object):
                 result, sort=sort, skip=skip, limit=limit, collection=self
             )
 
-        if self.table is None:
-            self.build_table()
+        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        try:
+            if self.table is None:
+                self.build_table()
 
-        if _filter is None:
-            result = self.table.all()
-        else:
-            simple = _simple_equality_filter(_filter)
-            if simple is not None:
-                key, value = simple
-                index = self._get_index(key)
-                if index is not None:
-                    return TinyMongoCursor(
-                        list(index.get(value, [])),
-                        sort=sort,
-                        skip=skip,
-                        limit=limit,
-                        collection=self,
-                    )
-            allcond = self.parse_query(_filter)
+            self._refresh_stale_memory_table()
 
-            try:
-                result = self.table.search(allcond)
-            except (AttributeError, TypeError):
-                result = []
+            if _filter is None:
+                result = self.table.all()
+            else:
+                simple = _simple_equality_filter(_filter)
+                if simple is not None:
+                    key, value = simple
+                    index = self._get_index(key)
+                    if index is not None:
+                        return TinyMongoCursor(
+                            list(index.get(value, [])),
+                            sort=sort,
+                            skip=skip,
+                            limit=limit,
+                            collection=self,
+                        )
+                allcond = self.parse_query(_filter)
 
-        result = TinyMongoCursor(
-            result, sort=sort, skip=skip, limit=limit, collection=self
-        )
+                try:
+                    result = self.table.search(allcond)
+                except (AttributeError, TypeError):
+                    result = []
 
-        return result
+            return TinyMongoCursor(
+                result, sort=sort, skip=skip, limit=limit, collection=self
+            )
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
 
     def find_one(self, _filter=None, *args, **kwargs):
         """
@@ -1392,12 +1473,18 @@ class TinyMongoCollection(object):
         if self.parent.engine is not None:
             return self.parent.engine.find_one(self.tablename, _filter)
 
-        if self.table is None:
-            self.build_table()
+        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        try:
+            if self.table is None:
+                self.build_table()
 
-        allcond = self.parse_query(_filter)
+            self._refresh_stale_memory_table()
 
-        return self.table.get(allcond)
+            allcond = self.parse_query(_filter)
+
+            return self.table.get(allcond)
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
 
     def remove(self, spec_or_id, multi=True, *args, **kwargs):
         """Backwards compatibility with remove"""
@@ -1417,17 +1504,21 @@ class TinyMongoCollection(object):
             result = self.parent.engine.delete_many(self.tablename, query, multi=False)
             return DeleteResult(raw_result=result)
 
-        item = self.find_one(query)
-        if item is None:
-            return DeleteResult(raw_result=[])
-        self._set_storage_merge_writes(False)
+        rlock, portalocker_lock = self._acquire_memory_collection_lock()
         try:
-            result = self.table.remove(where("_id") == item["_id"])
-            self._invalidate_indexes()
-        finally:
-            self._set_storage_merge_writes(True)
+            item = self.find_one(query)
+            if item is None:
+                return DeleteResult(raw_result=[])
+            self._set_storage_merge_writes(False)
+            try:
+                result = self.table.remove(where("_id") == item["_id"])
+                self._invalidate_indexes()
+            finally:
+                self._set_storage_merge_writes(True)
 
-        return DeleteResult(raw_result=result)
+            return DeleteResult(raw_result=result)
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
 
     def delete_many(self, query, *args, **kwargs):
         """
@@ -1441,19 +1532,25 @@ class TinyMongoCollection(object):
             result = self.parent.engine.delete_many(self.tablename, query, multi=True)
             return DeleteResult(raw_result=result)
 
-        items = self.find(query)
-        self._set_storage_merge_writes(False)
+        rlock, portalocker_lock = self._acquire_memory_collection_lock()
         try:
-            result = [self.table.remove(where("_id") == item["_id"]) for item in items]
-            self._invalidate_indexes()
+            items = self.find(query)
+            self._set_storage_merge_writes(False)
+            try:
+                result = [
+                    self.table.remove(where("_id") == item["_id"]) for item in items
+                ]
+                self._invalidate_indexes()
 
-            if query == {}:
-                # need to reset TinyDB's index for docs order consistency
-                self.table._last_id = 0
+                if query == {}:
+                    # need to reset TinyDB's index for docs order consistency
+                    self.table._last_id = 0
+            finally:
+                self._set_storage_merge_writes(True)
+
+            return DeleteResult(raw_result=result)
         finally:
-            self._set_storage_merge_writes(True)
-
-        return DeleteResult(raw_result=result)
+            self._release_collection_lock(rlock, portalocker_lock)
 
 
 class TinyMongoCursor(object):


### PR DESCRIPTION
## Summary

This adds the roadmap's process-local in-memory backend and closes #69.

- Add `backend="memory"` support to `TinyMongoClient` and `MongoClient`.
- Give unnamed clients isolated private namespaces that are removed on close.
- Support explicit same-process sharing through named `memory://NAME` namespaces.
- Add memory to the shared MongoDB compatibility contract matrix.
- Document the public API, lifecycle, intended uses, and limitations.

## Why

Tests and temporary workloads currently need a filesystem-backed database even
when persistence is unwanted. The memory backend provides a zero-file,
zero-extra-dependency option while preserving TinyMongo's existing collection
API and JSON-compatible value behavior. It also establishes the backend needed
before the roadmap's async work can be developed and tested cleanly.

## Behavior and design

### Isolated clients

```python
client = TinyMongoClient(backend="memory")
```

Each unnamed client receives a unique namespace. It does not create database or
lock files, and its namespace is cleared when the client closes.

### Named sharing

```python
writer = TinyMongoClient("memory://shared-test", backend="memory")
reader = TinyMongoClient("memory://shared-test", backend="memory")
```

Named clients share data inside the current Python process. Named data can be
reopened after a client closes and remains available until process exit.

### Correctness

- A process-local registry holds TinyDB-compatible storage entries by database
  address.
- Every database entry has a reentrant lock so read/modify/write operations from
  multiple clients are atomic.
- Revision tracking is recorded per retained collection handle, so one
  collection refresh cannot hide changes from another collection.
- External writes invalidate cached queries and equality indexes before the
  next read.
- Reads and writes use deep copies and JSON serialization rules, matching the
  default JSON backend's value behavior.
- Anonymous cleanup verifies registry-entry identity so concurrent closes
  cannot remove a newly created replacement entry.
- Invalid or mistyped URI schemes fail clearly instead of silently creating an
  isolated database.

## Capabilities and limits

- No disk files and no new runtime dependency.
- Thread-safe for clients in one process.
- Not persistent and not safe for sharing between processes.
- Intentionally exposed through the Python API only; a one-shot CLI process
  cannot make useful use of process-local state.
- Existing persistent backend locking behavior is unchanged.

## Tests

The focused memory suite covers CRUD, isolation, named sharing, lifecycle
behavior, copying and serialization, cache refreshes, retained collection
handles, equality-index invalidation, duplicate IDs, threaded inserts,
concurrent cleanup, URI validation, capability reporting, and both client
classes.

Validation completed locally:

- `181 passed, 47 deselected, 8 xfailed`
- 100% statement coverage and 100% branch coverage
- Ruff, Black, mypy, and `git diff --check` pass
- Python 3.9.6 with minimum supported TinyDB 3.2.1 passes the focused suite and
  contracts
- Real MongoDB 8.0 contract matrix: `28 passed, 8 xfailed`

The eight xfails are existing, explicitly documented compatibility gaps;
memory inherits the cursor pagination gap tracked by #73.

Closes #69
