### PR TITLE
Complete Milestone 1 compatibility foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,75 @@ jobs:
         with:
           name: mongodb-compatibility-results
           path: contract-results.xml
+
+  remote-sql-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: tinymongo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d tinymongo"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: mariadb
+          MARIADB_DATABASE: tinymongo
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      TINYMONGO_POSTGRES_DSN: postgresql://postgres:postgres@127.0.0.1:5432/tinymongo
+      TINYMONGO_MYSQL_DSN: mysql://root:mariadb@127.0.0.1:3306/tinymongo
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install remote SQL test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest ".[remote-sql]"
+
+      - name: Run PostgreSQL and MariaDB integration tests
+        run: pytest -o addopts='' -q -m integration tests/integration/test_remote_sql.py
+
+  pymongo-floor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: pip
+
+      - name: Install minimum supported PyMongo
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest "pymongo==4.9.*" .
+
+      - name: Run PyMongo and BSON compatibility tests
+        run: >-
+          pytest -o addopts='' -q
+          tests/test_patching.py tests/test_bson_codec.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@
   explicit same-process sharing through named `memory://NAME` namespaces.
 - The memory backend now participates in the shared MongoDB compatibility
   contract matrix.
+- `tinymongo.patch()` context-manager and decorator forms for temporarily
+  routing sync and async PyMongo client construction to a configurable
+  TinyMongo backend.
+- First-class non-blocking async client, database, collection, and lazy cursor
+  APIs with awaited cleanup and off-thread storage work.
+- Mongo-style inclusion and exclusion projections for `find()` and `find_one()`,
+  including nested dotted paths, array behavior, and compatible `_id` handling.
+- Durable single-field index metadata and unique constraints across JSON,
+  memory, SQLite, DuckDB, Parquet, PostgreSQL, and MariaDB/MySQL backends, with
+  native indexes for SQLite and remote SQL.
+- Batched duck-typed `IndexModel` planning with enforced unique indexes and
+  explicit warnings for safe performance-only degradation.
+- Common PyMongo-shaped APIs for database listing/removal,
+  `find_one_and_delete()`, `distinct()`, index information, and cursor
+  pagination, cloning, closing, and `to_list()`.
+- Tagged `datetime` and optional `ObjectId` round trips across all storage
+  backends, with `bson` and `pymongo` optional dependency groups.
+
+### Changed
+- The second positional argument to `find()` is now the PyMongo-compatible
+  projection argument. Use `sort=` or cursor `.sort()` for ordering.
+- The optional `bson` and `pymongo` dependency groups now require PyMongo 4.9
+  or newer, matching the async client and cursor APIs TinyMongo supports.
+- Nonunique descending and hashed indexes use ascending equality indexes;
+  compound indexes use their ascending leading-field prefix. Sparse and TTL
+  differences emit `TinyMongoUnsupportedWarning`, while unsafe unique
+  degradation still fails before creating a batch.
+- `create_index()` now returns the effective index name, matching PyMongo.
+- PostgreSQL and MariaDB/MySQL unique indexes reject array-valued keys because
+  their native scalar constraints cannot safely guarantee multikey uniqueness
+  across processes.
+
+### Fixed
+- `bypass_document_validation=True` no longer bypasses the built-in unique
+  `_id` constraint.
+- Durable index catalogs now use unambiguous collection/index identities, and
+  local write locks cover the complete uniqueness preflight and write.
+- File-backed deletes and find-and-modify operations now hold their collection
+  lock across the complete read/write transaction; AFTER results are fetched
+  by captured `_id`, and embedded-document `_id` values no longer break batch
+  updates.
+- Scalar equality and `$in` match array members consistently on table
+  backends while exact array equality remains supported; combined `$nin`,
+  `$not`, `$regex`, and `$options` queries
+  share missing-field behavior across backends.
+- BSON tag-shaped user dictionaries are escaped instead of being mistaken for
+  encoded datetimes or ObjectIds, and SQLite unique tokens preserve integers
+  outside the signed 64-bit range.
+- Async cursors return isolated documents, index listings are async-iterable,
+  and overlapping patch scopes in independent tasks cannot strand PyMongo's
+  process-global client replacement.
+- TinyMongo exceptions inherit matching PyMongo exception classes when PyMongo
+  is installed, while retaining dependency-free fallbacks.
 
 ## [1.2.0] - 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-![logo](artwork/tinymongo.png)
+![TinyMongo logo](https://raw.githubusercontent.com/schapman1974/tinymongo/master/artwork/tinymongo.png)
 
 [![CI](https://github.com/schapman1974/tinymongo/actions/workflows/ci.yml/badge.svg)](https://github.com/schapman1974/tinymongo/actions/workflows/ci.yml)
 
 # Purpose
 
-A simple wrapper to make a drop in replacement for mongodb out of
-[tinydb](http://tinydb.readthedocs.io/en/latest/).  This module is an
-attempt to add an interface familiar to those currently using pymongo.
+TinyMongo provides a familiar PyMongo-style document API backed by embedded
+storage instead of a MongoDB server. The default backend uses
+[TinyDB](https://tinydb.readthedocs.io/), with optional memory, SQLite, DuckDB,
+Parquet, PostgreSQL, and MariaDB/MySQL backends.
 
 # Status
 
@@ -30,10 +31,12 @@ may install native binary wheels supplied by DuckDB, PyArrow, or SQL drivers.
 
 # Project notes
 
-- **Roadmap:** See [ROADMAP.md](ROADMAP.md) for planned compatibility, GridFS, Compass, wire-server, and browser work.
+- **Roadmap:** See the [TinyMongo roadmap](https://github.com/schapman1974/tinymongo/blob/master/ROADMAP.md) for planned compatibility, GridFS, Compass, wire-server, and browser work.
 - **Default storage:** TinyMongo uses TinyDB-compatible JSON storage unless another backend is selected.
 - **Table-native backends:** SQLite, DuckDB, and Parquet backends store one real table/file per collection instead of one serialized database blob.
 - **Concurrency:** writes use atomic temp-file replace and optional advisory locks (`portalocker`) to reduce corruption risk under concurrent writers.
+- **Async API:** async clients keep storage and lock waits off the event loop
+  while sharing the synchronous implementation's behavior.
 - **Tests & CI:** a GitHub Actions workflow is included at `.github/workflows/ci.yml` to run unit tests and linters across Python versions. See `requirements-dev.txt` for dev dependencies.
 
 
@@ -63,6 +66,95 @@ sessions, or network connections. MongoDB URIs, host names, ports, and common
 connection kwargs are accepted and ignored so existing code can be tried locally.
 Set `TINYMONGO_HOME` or pass `tinymongo_folder=` to choose where TinyMongo stores
 files. See `examples/pymongo_dropin.py` for a runnable example.
+
+## Async API
+
+`AsyncMongoClient` and `AsyncTinyMongoClient` expose non-blocking client,
+database, collection, and cursor APIs. `find()` is immediate and lazy; storage
+work begins when the cursor is awaited or iterated:
+
+```python
+from tinymongo import AsyncMongoClient
+
+
+async def load_users():
+    async with AsyncMongoClient(
+        tinymongo_folder="./tinydb",
+        backend="sqlite",
+    ) as client:
+        users = client.app.users
+        await users.insert_one({"_id": 1, "name": "Ada", "score": 9})
+        return await users.find({}).sort("score", -1).to_list(length=None)
+```
+
+Async cursors support `async for`, `to_list()`, `sort()`, `skip()`,
+`limit()`, `clone()`, `rewind()`, and `close()`. Potentially blocking
+storage, serialization, locking, query, and cleanup work runs outside the event
+loop.
+
+## Patch PyMongo during tests
+
+`tinymongo.patch()` temporarily routes `pymongo.MongoClient` and
+`pymongo.AsyncMongoClient` calls to TinyMongo
+without making PyMongo a required TinyMongo dependency. Install PyMongo only for
+tests that use the helper:
+
+```bash
+pip install "tinymongo[pymongo]"
+```
+
+The default backend is an isolated in-memory database. Clients created inside
+one patch scope share data, and the original PyMongo client is restored even if
+the test raises an exception:
+
+```python
+import pymongo
+import tinymongo
+
+with tinymongo.patch():
+    writer = pymongo.MongoClient("mongodb://ignored")
+    reader = pymongo.MongoClient()
+    writer.app.users.insert_one({"name": "Ada"})
+    assert reader.app.users.count_documents({}) == 1
+```
+
+The same helper can decorate a test and can select a folder and backend:
+
+```python
+import pymongo
+import tinymongo
+
+
+@tinymongo.patch(folder="./test-data", backend="sqlite")
+def test_application_code():
+    client = pymongo.MongoClient()
+    assert client.server_info()["storage"] == "sqlite"
+```
+
+It can also decorate a `unittest` method:
+
+```python
+import unittest
+
+import pymongo
+import tinymongo
+
+
+class ApplicationTest(unittest.TestCase):
+    @tinymongo.patch()
+    def test_application_code(self):
+        client = pymongo.MongoClient()
+        client.app.users.insert_one({"name": "Ada"})
+        self.assertEqual(client.app.users.count_documents({}), 1)
+```
+
+Patch scopes may be nested. Code must look up `pymongo.MongoClient` while the
+scope is active; a `MongoClient` name imported directly before the patch cannot
+be replaced. Because PyMongo's module attribute is process-global, patch scopes
+cannot overlap across threads. Async tests should put a `with tinymongo.patch()`
+block inside the async function instead of decorating the coroutine. Prefer
+`async with tinymongo.patch()` when creating async clients so cleanup can be
+awaited.
 
 
 # Backend options
@@ -118,12 +210,17 @@ pip install "tinymongo[duckdb]"
 pip install "tinymongo[parquet]"
 pip install "tinymongo[postgres]"
 pip install "tinymongo[mysql]"
+pip install "tinymongo[bson]"
+pip install "tinymongo[pymongo]"
 pip install "tinymongo[serialization]"
 ```
 
 If an optional driver is missing, selecting that backend raises an `ImportError`
 with the corresponding installation command. PyMongo itself is not a runtime
-dependency; it is used only by the development compatibility tests.
+dependency; it is used by the optional patch helper and development compatibility
+tests only when those features are selected. Install `tinymongo[bson]` for
+`ObjectId` values or `tinymongo[pymongo]` for patching and
+installed-version compatibility.
 
 | Backend | Dependency | Best fit | Notes |
 | --- | --- | --- | --- |
@@ -177,14 +274,14 @@ Older blob-format SQLite and DuckDB files are migrated to collection tables when
 opened.
 
 Local load-test results for these backends are documented in
-[docs/BENCHMARKS.md](docs/BENCHMARKS.md).
+[backend benchmarks](https://github.com/schapman1974/tinymongo/blob/master/docs/BENCHMARKS.md).
 
 Object-storage setup examples for S3, S3-compatible providers, Backblaze B2,
 Cloudflare R2, Google Cloud Storage, Azure Blob Storage, MinIO, Wasabi, and
 DigitalOcean Spaces are documented in
-[docs/OBJECT_STORAGE.md](docs/OBJECT_STORAGE.md).
+[the object-storage guide](https://github.com/schapman1974/tinymongo/blob/master/docs/OBJECT_STORAGE.md).
 PostgreSQL and MariaDB/MySQL setup is documented in
-[docs/REMOTE_SQL.md](docs/REMOTE_SQL.md).
+[the remote SQL guide](https://github.com/schapman1974/tinymongo/blob/master/docs/REMOTE_SQL.md).
 Remote SQL drivers are optional; if one is missing, TinyMongo raises an
 `ImportError` with the exact `pip install ...` command to run.
 
@@ -261,27 +358,94 @@ the same integration tests against a non-default backend.
 
 TinyMongo intentionally implements a practical subset of PyMongo's collection
 API. It supports common inserts, finds, updates, deletes, sorting, pagination,
-and collection counting. Query support includes equality, nested document paths,
-`$gt`, `$gte`, `$lt`, `$lte`, `$ne`, `$nin`, `$in`, `$all`, `$and`, `$or`,
-`$nor`, `$not`, `$regex`, and `$exists`.
+distinct values, collection counting, `find_one_and_delete()`, database
+listing/removal, index inspection, and batched index creation. Cursors support
+single- and multi-key sorting, `skip()`, `limit()`, `clone()`, `close()`,
+and `to_list()`; `limit(0)` means no limit.
+
+Query support includes equality (including scalar matches against array
+members), nested document paths, `$gt`, `$gte`, `$lt`, `$lte`, `$ne`,
+`$nin`, `$in`, `$all`, `$and`, `$or`, `$nor`, `$not`, `$regex`,
+case-insensitive `$options`, and `$exists`.
 
 Update support includes `$set`, `$unset`, `$inc`, `$push`, `$pull`, and
 `$addToSet`, including `upsert=True`. As in PyMongo, `update_one()` and
 `update_many()` require update operators; use `replace_one()` for full-document
 replacement.
 
-Collections also expose lightweight in-memory equality indexes:
+`find()` and `find_one()` accept Mongo-style inclusion and exclusion
+projections. Dotted paths project nested fields, `_id` follows MongoDB's special
+include/exclude rules, and projection happens after filtering and sorting:
 
 ```python
-    collection.create_index("email")
-    collection.find({"email": "person@example.com"})
-    collection.list_indexes()
-    collection.drop_index("email")
+users.find({"active": True}, {"profile.email": 1, "_id": 0})
+users.find_one({"email": "ada@example.com"}, {"password_hash": 0})
 ```
 
-Indexes are scoped to the active collection object and are rebuilt from stored
-documents as needed. They are a convenience for repeated equality lookups, not a
-durable query-planner feature.
+Inclusion and exclusion cannot be mixed except for `_id`. Computed expressions,
+`$meta`, positional projection, and numeric array positions are rejected with a
+clear error. The second positional argument to `find()` is now the PyMongo-style
+projection argument; pass sorting as `sort=` or call `.sort()` on the cursor.
+
+Collections expose durable indexes and unique constraints:
+
+```python
+collection.create_index("email", unique=True, name="login_email")
+collection.find({"email": "person@example.com"})
+collection.list_indexes()
+collection.drop_index("login_email")
+```
+
+Index definitions and unique constraints survive client restarts on persistent
+backends. SQLite, PostgreSQL, and MariaDB/MySQL create native database indexes;
+JSON, DuckDB, and Parquet persist metadata and enforce unique constraints through
+TinyMongo. Named memory databases retain metadata while their process-local
+namespace exists.
+
+Plural `create_indexes()` accepts duck-typed PyMongo `IndexModel` batches
+without importing PyMongo in TinyMongo's core. Unique indexes are enforced.
+Performance-only declarations degrade safely and emit
+`TinyMongoUnsupportedWarning`: descending and hashed declarations use
+ascending equality indexes, and compound declarations use their ascending
+leading-field prefix. Sparse membership is not honored and TTL expiration is
+not performed; both are reported explicitly. A semantically unsafe unique
+declaration is rejected before any batch entry is created.
+
+Unique indexes support scalar values and flat arrays on embedded backends;
+missing and `null` share one unique key. Object values, nested arrays,
+non-finite numbers, and array traversal inside a dotted index path are not
+supported for unique indexes yet. Remote SQL uses native constraints for scalar
+races. It rejects array values under unique indexes because its native indexes
+cannot yet guarantee cross-process multikey uniqueness.
+
+Use one consistent scalar type for `_id` values. Full BSON-aware `_id`
+comparison is tracked in [#94](https://github.com/schapman1974/tinymongo/issues/94);
+cross-type comparison and sort order remain outside the current BSON slice.
+
+## ObjectId and datetime values
+
+`datetime` values round-trip through every backend. Install the optional BSON
+extra to use `bson.ObjectId` without making PyMongo a core dependency:
+
+```bash
+pip install "tinymongo[bson]"
+```
+
+```python
+from datetime import datetime
+from bson import ObjectId
+
+episode_id = ObjectId()
+episodes.insert_one(
+    {"_id": episode_id, "created_date": datetime.now(), "title": "Async Python"}
+)
+episode = episodes.find_one({"_id": episode_id})
+```
+
+JSON-backed storage uses an explicit tagged representation and restores native
+values on read. Existing plain JSON files and string or integer IDs remain
+compatible. UUID, Decimal128, Binary, and regular-expression round trips remain
+tracked in [#75](https://github.com/schapman1974/tinymongo/issues/75).
 
 TinyMongo includes PyMongo-shaped contract tests that run application code with
 `import pymongo` redirected to TinyMongo:
@@ -307,8 +471,11 @@ pytest -o addopts='' -q -m 'contract and mongodb' tests/contracts
 Use `-m contract` instead of `-m 'contract and mongodb'` to run the complete
 embedded-plus-MongoDB matrix in one session.
 
-PyMongo remains a development dependency for these comparisons; it is not
-required to use TinyMongo at runtime.
+PyMongo remains optional. It is needed for these comparisons,
+`tinymongo.patch()`, and `ObjectId` support, but it is not required for normal
+TinyMongo clients or `datetime` storage. When it is installed, TinyMongo error
+classes also inherit the matching `pymongo.errors` classes, so existing
+`PyMongoError` handlers continue to work.
 
 PyMongo's full upstream driver test suite targets a real MongoDB server and
 driver internals, so it is not expected to pass against TinyMongo. The contract
@@ -326,8 +493,9 @@ print(client.supports("multiprocess_writes"))
 
 The capability map covers persistence, remote and object storage, table-native
 storage, multiprocess writes, native indexes, projections, bulk writes,
-aggregation, sessions, transactions, change streams, and BSON types. Unknown
-capability names raise `ValueError` so configuration mistakes are visible.
+aggregation, sessions, transactions, change streams, and installed BSON support.
+Unknown capability names raise `ValueError` so configuration mistakes are
+visible.
 
 Operations whose semantics TinyMongo cannot honor raise
 `TinyMongoNotSupportedError`. This includes sessions, transactions, change
@@ -338,8 +506,8 @@ that only describe an ignored network target remain harmless for drop-in use.
 ## MongoEngine
 
 Basic MongoEngine CRUD is supported by passing TinyMongo as the client class.
-Use a string primary key because TinyMongo's JSON backend does not persist BSON
-`ObjectId` values:
+The example keeps a string primary key for maximum portability. Native
+`ObjectId` values also round-trip when `tinymongo[bson]` is installed:
 
 ```python
 import mongoengine as me
@@ -391,7 +559,7 @@ take a look at demo.py within the repository.
     # returns a list of all users of 'module'
     users = db.users.find({'module': 'module'})
 
-    #update data returns True if successful and False if unsuccessful
+    # update data and inspect matched_count or modified_count on the result
     upd = db.users.update_one({"username": "admin"}, {"$set": {"module":"someothermodule"}})
 
     # Sorting users by its username DESC
@@ -446,51 +614,14 @@ your own serializers using the `tinydb-serialization` extension.
 
 First install it with `pip install "tinymongo[serialization]"`.
 
-## Handling datetime objects
+## Custom serialized types
 
-You can create a serializer for the python `datetime` using
-the following snippet:
-
-```python
-    from datetime import datetime
-    from tinydb_serialization import Serializer
-
-    class DatetimeSerializer(Serializer):
-        OBJ_CLASS = datetime
-
-        def __init__(self, format='%Y-%m-%dT%H:%M:%S', *args, **kwargs):
-            super(DatetimeSerializer, self).__init__(*args, **kwargs)
-            self._format = format
-
-        def encode(self, obj):
-            return obj.strftime(self._format)
-
-        def decode(self, s):
-            return datetime.strptime(s, self._format)
-```
-
-> NOTE: this serializer is available in `tinymongo.serializers.DateTimeSerializer`
-
-
-Now you have to subclass `TinyMongoClient` and provide customs storage.
-
-```python
-    from tinymongo import TinyMongoClient
-    from tinymongo.serializers import DateTimeSerializer
-    from tinydb_serialization import SerializationMiddleware
-
-
-    class CustomClient(TinyMongoClient):
-        @property
-        def _storage(self):
-            serialization = SerializationMiddleware()
-            serialization.register_serializer(DateTimeSerializer(), 'TinyDate')
-            # register other custom serializers
-            return serialization
-
-
-    connection = CustomClient('/path/to/folder')
-```
+`datetime` and optional `ObjectId` values are handled directly by TinyMongo;
+they do not need a custom serializer. For application-specific classes, subclass
+`TinyMongoClient` and provide a `tinydb-serialization` middleware as described
+in the TinyDB extension documentation. The legacy
+`tinymongo.serializers.DateTimeSerializer` remains available for existing
+custom-storage integrations, but new TinyMongo storage does not require it.
 
 # Flask-Admin
 
@@ -500,23 +631,22 @@ perform CRUD (Create, Read, Update, Delete) of the TinyDB records.
 
 You can find the example of Flask-Admin with TinyMongo in [Flask-Admin Examples Repository](https://github.com/flask-admin/flask-admin/tree/master/examples/tinymongo)
 
-> NOTE: To use Flask-Admin you need to register a DateTimeSerialization as showed in the previous topic.
+Datetime fields work with TinyMongo's built-in storage codec.
 
 # Contributions
 
-Contributions are welcome!  Currently, the most valuable contributions
+Contributions are welcome! Currently, the most valuable contributions
 would be:
 
-* adding test cases
-* adding functionality consistent with pymongo
-* documentation
-* identifying bugs and issues
+- adding test cases
+- adding functionality consistent with PyMongo
+- improving documentation
+- identifying bugs and issues
 
-# Future Development
+# Future development
 
-I will also be adding support for gridFS by storing the files somehow and indexing them in a db like mongo currently does
-
-More to come......
+Planned compatibility, aggregation, GridFS, wire-server, Compass, and browser
+work is tracked in the [TinyMongo roadmap](https://github.com/schapman1974/tinymongo/blob/master/ROADMAP.md).
 
 # License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,32 +5,58 @@ while remaining an embedded, multi-backend database.
 
 The compatibility target is to pass at least 90% of a published,
 application-focused contract suite against real MongoDB. Unsupported server
-features should fail clearly instead of behaving approximately.
+features should fail clearly instead of behaving approximately. Talk Python is
+the first end-to-end application target: its real data layer should run through
+TinyMongo's synchronous and asynchronous APIs without rewriting its data-access
+call sites, with any remaining differences reported explicitly.
 
 The live checklist is [GitHub issue #103](https://github.com/schapman1974/tinymongo/issues/103),
 and progress by release is available on the
 [milestones page](https://github.com/schapman1974/tinymongo/milestones).
 
-## 1. Compatibility foundation
+## 1. Compatibility foundation and application acceptance
 
 [View milestone](https://github.com/schapman1974/tinymongo/milestone/1)
 
 Prerequisite backend work:
 
-- [ ] [#69: In-memory storage backend](https://github.com/schapman1974/tinymongo/issues/69)
-- [ ] [#70: PyMongo patching helper](https://github.com/schapman1974/tinymongo/issues/70)
-- [ ] [#74: Field projections](https://github.com/schapman1974/tinymongo/issues/74)
-- [ ] [#76: Durable indexes and unique constraints](https://github.com/schapman1974/tinymongo/issues/76)
+- [x] [#69: In-memory storage backend](https://github.com/schapman1974/tinymongo/issues/69)
+- [x] [#70: PyMongo patching helper](https://github.com/schapman1974/tinymongo/issues/70)
+- [x] [#74: Field projections](https://github.com/schapman1974/tinymongo/issues/74)
+- [x] [#76: Durable indexes and unique constraints](https://github.com/schapman1974/tinymongo/issues/76)
 
-Compatibility work:
+Application-compatibility work:
 
-- [ ] [#72: Real MongoDB contract suite](https://github.com/schapman1974/tinymongo/issues/72)
-- [ ] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
+- [ ] [#136: Full non-blocking PyMongo async API parity](https://github.com/schapman1974/tinymongo/issues/136)
+  - [x] Public async client/database/collection/cursor facade with lazy cursors,
+    off-thread storage calls, async cleanup, and sync-result parity.
+  - [ ] Run the complete async application contract against Talk Python and
+    record any remaining differences.
+- [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
+- [ ] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
+  - [x] Milestone 1 ObjectId and datetime storage/query support.
+  - [ ] Add UUID, Decimal128, Binary, and regular-expression round trips.
+- [ ] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
+  - [x] Talk Python query slice: scalar-to-array equality, combined `$nin`,
+    `$not`, `$regex`, case-insensitive `$options`, and missing fields.
+  - [ ] Prioritize the remaining query and update candidates from measured
+    application failures.
+- [ ] [#102: Optional PyMongo-version adaptation](https://github.com/schapman1974/tinymongo/issues/102)
+  - [x] TinyMongo errors conditionally inherit matching PyMongo errors.
+  - [ ] Add version-matrix CI plus broader signature and result adaptation.
+- [ ] [#72: Real MongoDB and application contract suite](https://github.com/schapman1974/tinymongo/issues/72)
 - [ ] [#87: Differential compatibility fuzzing](https://github.com/schapman1974/tinymongo/issues/87)
 
 Exit criteria:
 
-- Shared contracts run against real MongoDB and every applicable backend.
+- Every supported synchronous operation has a PyMongo-shaped asynchronous peer;
+  immediate cursor-building calls stay immediate and blocking work stays off the
+  event loop.
+- Shared contracts run both APIs against real MongoDB and every applicable
+  backend.
+- Talk Python runs against TinyMongo's async client, and any remaining
+  incompatibilities are captured as reproducible contracts or documented
+  differences.
 - Generated cases can reproduce behavioral differences.
 - Memory, projection, patching, durable indexes, and common APIs are available.
 
@@ -53,7 +79,6 @@ Exit criteria:
 
 [View milestone](https://github.com/schapman1974/tinymongo/milestone/3)
 
-- [ ] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
 - [ ] [#78: Ordered bulk writes](https://github.com/schapman1974/tinymongo/issues/78)
 - [ ] [#80: Advanced array update modifiers](https://github.com/schapman1974/tinymongo/issues/80)
 - [ ] [#95: Aggregation lookup](https://github.com/schapman1974/tinymongo/issues/95)
@@ -72,14 +97,12 @@ Exit criteria:
 
 [View milestone](https://github.com/schapman1974/tinymongo/milestone/4)
 
-- [ ] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
 - [ ] [#79: Backend benchmarks and compatibility reports](https://github.com/schapman1974/tinymongo/issues/79)
 - [ ] [#55: ODM integration](https://github.com/schapman1974/tinymongo/issues/55)
 - [ ] [#81: MongoDB document and key validation](https://github.com/schapman1974/tinymongo/issues/81)
 - [ ] [#83: Remaining common BSON types](https://github.com/schapman1974/tinymongo/issues/83)
 - [ ] [#93: Backend concurrency and compatibility stress tests](https://github.com/schapman1974/tinymongo/issues/93)
 - [ ] [#94: BSON comparison and sort order](https://github.com/schapman1974/tinymongo/issues/94)
-- [ ] [#102: Optional PyMongo-version adaptation](https://github.com/schapman1974/tinymongo/issues/102)
 
 Exit criteria:
 
@@ -189,16 +212,21 @@ Exit criteria:
 
 ## Execution order
 
-1. Complete compatibility foundations and generate a baseline score.
-2. Build aggregation core.
-3. Add advanced query, update, array, and bulk operations.
-4. Finish BSON semantics, durable indexes, and integration hardening.
-5. Implement GridFS on stable BSON, index, and cursor foundations.
-6. Publish release compatibility evidence against the 90% target.
-7. Build the wire-server foundation.
-8. Deliver read-only Compass browsing.
-9. Add Compass editing, GridFS wire clients, and broader driver support.
-10. Deliver WASM/browser support as a parallel local-first track.
+1. [x] Finish patching, projection, durable indexes, and practical batched
+   `IndexModel` behavior.
+2. [x] Complete the common synchronous API and build the asynchronous facade
+   over the same shared semantics.
+3. [x] Add the ObjectId, datetime, query, and PyMongo exception behavior
+   required by the first Talk Python contracts.
+4. [ ] Run Talk Python against TinyMongo's async client, turn every failure into a
+   contract, and publish the baseline compatibility score.
+5. [ ] Build aggregation core after the real-application acceptance path works.
+6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
+   compatibility gaps.
+7. [ ] Implement GridFS on stable BSON, index, and cursor foundations.
+8. [ ] Build the wire-server foundation, followed by read-only Compass browsing and
+   then editing support.
+9. [ ] Deliver WASM/browser support as a parallel local-first track.
 
 ## Scope boundary
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -8,7 +8,7 @@ This guide helps you migrate from earlier `tinymongo` versions to `1.0.0`.
 - Default storage remains TinyDB JSON storage.
 - Parquet v2, SQLite, and DuckDB are available as table-native backends.
 - A `tinymongo` CLI is available for inspecting, exporting, importing, and migrating data.
-- Common update operators and lightweight in-memory equality indexes are supported.
+- Common update operators and durable single-field indexes are supported.
 - Concurrent writes are safer due to atomic file replace and optional file locks.
 - Optional `uv` extras are available for dependency-managed ASGI usage.
 
@@ -33,5 +33,9 @@ pip install .[uv]
 - Select optional storage backends with `TinyMongoClient(path, backend="parquet")`, `backend="sqlite"`, or `backend="duckdb"`.
 - Older blob-format SQLite and DuckDB files are migrated to collection tables when opened.
 - Use `tinymongo migrate SOURCE TARGET --to-backend sqlite` to copy existing TinyDB JSON data into another backend.
-- In-memory indexes created with `collection.create_index("field")` are scoped to the active collection object and are rebuilt from stored documents as needed.
+- Indexes created by earlier releases were collection-handle scoped and cannot
+  be migrated automatically. Recreate them once with `collection.create_index()`;
+  new index metadata persists with the backend, and unique indexes are enforced
+  for later writes. Memory-backend metadata lasts for the named namespace's
+  process lifetime.
 - For local development, install `requirements-dev.txt` and run `pytest -q`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinymongo"
 version = "1.2.0"
-description = "A flat file drop in replacement for mongodb. Requires TinyDB"
+description = "Embedded MongoDB-compatible database with sync, async, and multi-backend storage"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [ { name = "Stephen Chapman", email = "schapman1974@gmail.com" } ]
@@ -63,6 +63,8 @@ include-package-data = true
 
 [project.optional-dependencies]
 serialization = ["tinydb-serialization>=1.0.4,<2"]
+bson = ["pymongo>=4.9"]
+pymongo = ["pymongo>=4.9"]
 duckdb = ["duckdb>=1.0.0"]
 parquet = ["duckdb>=1.0.0", "pyarrow>=10.0.0"]
 postgres = ["psycopg[binary]>=3.1"]
@@ -71,6 +73,7 @@ mariadb = ["PyMySQL>=1.1"]
 remote-sql = ["psycopg[binary]>=3.1", "PyMySQL>=1.1"]
 all = [
   "tinydb-serialization>=1.0.4,<2",
+  "pymongo>=4.9",
   "duckdb>=1.0.0",
   "pyarrow>=10.0.0",
   "psycopg[binary]>=3.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ pytest
 coverage
 pyarrow
 portalocker
-pymongo
+pymongo>=4.9
 mongoengine>=0.29,<1
 duckdb
 black>=25,<26

--- a/tests/contracts/known_differences.py
+++ b/tests/contracts/known_differences.py
@@ -3,20 +3,7 @@
 import pytest
 
 
-KNOWN_DIFFERENCES = {
-    "array_in_query": {
-        "sqlite": "#77: table-native $in does not yet match values inside arrays",
-        "duckdb": "#77: table-native $in does not yet match values inside arrays",
-        "parquet": "#77: table-native $in does not yet match values inside arrays",
-    },
-    "cursor_skip_limit": {
-        "memory": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
-        "json": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
-        "sqlite": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
-        "duckdb": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
-        "parquet": "#73: cursor pagination does not yet retain a PyMongo-style query spec",
-    },
-}
+KNOWN_DIFFERENCES = {}
 
 
 def mark_known_difference(request, target_name, contract_name):

--- a/tests/contracts/support.py
+++ b/tests/contracts/support.py
@@ -4,11 +4,14 @@ from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from tinymongo.errors import DuplicateKeyError as TinyMongoDuplicateKeyError
+from tinymongo.errors import OperationFailure as TinyMongoOperationFailure
 
 try:
     from pymongo.errors import DuplicateKeyError as PyMongoDuplicateKeyError
+    from pymongo.errors import OperationFailure as PyMongoOperationFailure
 except ImportError:  # pragma: no cover - development dependency guard
     PyMongoDuplicateKeyError = ()  # type: ignore[assignment,misc]
+    PyMongoOperationFailure = ()  # type: ignore[assignment,misc]
 
 
 @dataclass(frozen=True)
@@ -37,6 +40,11 @@ def error_category(error: Exception) -> str:
         duplicate_errors = duplicate_errors + (PyMongoDuplicateKeyError,)
     if isinstance(error, duplicate_errors):
         return "duplicate_key"
+    operation_errors = (TinyMongoOperationFailure,)
+    if PyMongoOperationFailure:
+        operation_errors = operation_errors + (PyMongoOperationFailure,)
+    if isinstance(error, operation_errors):
+        return "operation_failure"
     return "{0}.{1}".format(type(error).__module__, type(error).__name__)
 
 

--- a/tests/contracts/test_crud_contract.py
+++ b/tests/contracts/test_crud_contract.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from .known_differences import mark_known_difference
 from .support import observe
 
 
@@ -29,8 +28,7 @@ def test_insert_query_sort_and_count(contract_target):
     assert collection.count_documents({"score": {"$gte": 8}}) == 2
 
 
-def test_array_in_query_contract(contract_target, request):
-    mark_known_difference(request, contract_target.name, "array_in_query")
+def test_array_in_query_contract(contract_target):
     collection = contract_target.collection
     collection.insert_many(
         [
@@ -98,8 +96,7 @@ def test_duplicate_id_has_a_shared_error_category(contract_target):
     assert collection.count_documents({"_id": 1}) == 1
 
 
-def test_sort_skip_and_limit_contract(contract_target, request):
-    mark_known_difference(request, contract_target.name, "cursor_skip_limit")
+def test_sort_skip_and_limit_contract(contract_target):
     collection = contract_target.collection
     collection.insert_many([{"_id": number, "score": number} for number in range(1, 6)])
 

--- a/tests/contracts/test_projection_contract.py
+++ b/tests/contracts/test_projection_contract.py
@@ -1,0 +1,110 @@
+"""Field projection contracts shared by TinyMongo and MongoDB."""
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _seed(collection):
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "name": "Ada",
+                "secret": "x",
+                "score": 7,
+                "profile": {"email": "ada@example.com", "age": 36},
+                "items": [{"sku": "a", "qty": 1}, {"qty": 2}, {}],
+            },
+            {
+                "_id": 2,
+                "name": "Grace",
+                "score": 9,
+                "profile": {"age": 40},
+                "items": [],
+            },
+        ]
+    )
+
+
+def test_inclusion_exclusion_and_id_projection_contract(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+
+    assert list(collection.find({}, {"name": 1}).sort("_id", 1)) == [
+        {"_id": 1, "name": "Ada"},
+        {"_id": 2, "name": "Grace"},
+    ]
+    assert collection.find_one({"_id": 1}, {"name": 2, "_id": 0}) == {"name": "Ada"}
+    assert collection.find_one({"_id": 1}, {"secret": 0, "_id": 1}) == {
+        "_id": 1,
+        "name": "Ada",
+        "score": 7,
+        "profile": {"email": "ada@example.com", "age": 36},
+        "items": [{"sku": "a", "qty": 1}, {"qty": 2}, {}],
+    }
+    assert collection.find_one({"_id": 1}, {"_id.missing": 1}) == {}
+
+
+def test_nested_and_array_projection_contract(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+
+    assert list(collection.find({}, {"profile.email": 1}).sort("_id", 1)) == [
+        {"_id": 1, "profile": {"email": "ada@example.com"}},
+        {"_id": 2, "profile": {}},
+    ]
+    assert collection.find_one({"_id": 1}, {"items.sku": 1}) == {
+        "_id": 1,
+        "items": [{"sku": "a"}, {}, {}],
+    }
+    assert collection.find_one({"_id": 1}, {"items.qty": 0})["items"] == [
+        {"sku": "a"},
+        {},
+        {},
+    ]
+
+
+def test_projection_uses_unprojected_values_for_filter_and_sort(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+
+    assert list(
+        collection.find({"score": {"$gte": 7}}, {"name": 1}).sort("score", -1)
+    ) == [
+        {"_id": 2, "name": "Grace"},
+        {"_id": 1, "name": "Ada"},
+    ]
+
+
+def test_empty_and_invalid_projection_contract(contract_target):
+    collection = contract_target.collection
+    _seed(collection)
+    full = collection.find_one({"_id": 1})
+
+    assert collection.find_one({"_id": 1}, {}) == full
+    assert collection.find_one({"_id": 1}, []) == full
+    assert observe(
+        lambda: list(collection.find({}, {"name": 1, "secret": 0}))
+    ).error == ("operation_failure")
+    assert (
+        observe(
+            lambda: list(collection.find({}, {"profile": 1, "profile.email": 1}))
+        ).error
+        == "operation_failure"
+    )
+    assert (
+        observe(lambda: list(collection.find({}, {"_id": 1, "_id.value": 1}))).error
+        == "operation_failure"
+    )
+    assert (
+        observe(
+            lambda: list(
+                collection.find({}, {"profile": {"email": 1}, "profile.email": 1})
+            )
+        ).error
+        == "operation_failure"
+    )

--- a/tests/contracts/test_talkpython_contract.py
+++ b/tests/contracts/test_talkpython_contract.py
@@ -1,0 +1,349 @@
+"""High-signal compatibility contracts derived from the Talk Python application."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from tinymongo.indexes import TinyMongoUnsupportedWarning
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _ids(documents):
+    return [document["_id"] for document in documents]
+
+
+def test_projection_none_absent_fields_and_integer_id(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 42,
+            "title": "Python Bytes",
+            "description": "A short episode summary",
+        }
+    )
+
+    full = collection.find_one({"_id": 42}, None)
+    projected = collection.find_one({"_id": 42}, {"title": 1, "_id": 0})
+
+    assert full == {
+        "_id": 42,
+        "title": "Python Bytes",
+        "description": "A short episode summary",
+    }
+    assert type(full["_id"]) is int
+    assert projected == {"title": "Python Bytes"}
+    assert "description" not in projected
+    assert collection.find_one({"_id": 404}) is None
+
+
+def test_find_one_sort_returns_the_newest_match(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "show_id": 201, "is_published": True},
+            {"_id": 2, "show_id": 203, "is_published": True},
+            {"_id": 3, "show_id": 202, "is_published": False},
+        ]
+    )
+
+    newest = collection.find_one({"is_published": True}, sort=[("show_id", -1)])
+
+    assert newest["_id"] == 2
+
+
+def test_single_and_multi_key_sort_break_ties(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "show_id": 101, "times": 5, "last_missed": 10},
+            {"_id": 2, "show_id": 103, "times": 5, "last_missed": 30},
+            {"_id": 3, "show_id": 102, "times": 4, "last_missed": 99},
+        ]
+    )
+
+    by_show_id = collection.find({}).sort("show_id", -1)
+    by_miss_count = collection.find({}).sort([("times", -1), ("last_missed", -1)])
+
+    assert _ids(by_show_id) == [2, 3, 1]
+    assert _ids(by_miss_count) == [2, 1, 3]
+
+
+def test_cursor_to_list_accepts_both_application_spellings(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number} for number in range(3)])
+
+    implicit_length = collection.find({}).sort("_id", 1).to_list()
+    unlimited_length = collection.find({}).sort("_id", 1).to_list(length=None)
+
+    assert isinstance(implicit_length, list)
+    assert isinstance(unlimited_length, list)
+    assert _ids(implicit_length) == [0, 1, 2]
+    assert _ids(unlimited_length) == [0, 1, 2]
+
+
+def test_cursor_skip_limit_windows_and_past_end(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number} for number in range(6)])
+
+    window = collection.find({}).sort("_id", 1).skip(2).limit(3).to_list(length=None)
+    past_end = collection.find({}).sort("_id", 1).skip(20).to_list(length=None)
+
+    assert _ids(window) == [2, 3, 4]
+    assert past_end == []
+
+
+def test_cursor_limit_zero_means_unlimited(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": number} for number in range(4)])
+
+    documents = list(collection.find({}).sort("_id", 1).limit(0))
+
+    assert _ids(documents) == [0, 1, 2, 3]
+
+
+def test_scalar_equality_matches_an_array_member(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "guest_ids": ["mike", "brian"]},
+            {"_id": 2, "guest_ids": ["carol"]},
+            {"_id": 3, "guest_ids": "mike"},
+        ]
+    )
+
+    assert sorted(_ids(collection.find({"guest_ids": "mike"}))) == [1, 3]
+
+
+def test_dot_notation_matches_an_embedded_document(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "membership": {"memberful_id": "member-42"}},
+            {"_id": 2, "membership": {"memberful_id": "member-99"}},
+            {"_id": 3},
+        ]
+    )
+
+    assert collection.find_one({"membership.memberful_id": "member-42"})["_id"] == 1
+
+
+def test_not_regex_with_case_insensitive_options(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "title": "Talk Python To Me"},
+            {"_id": 2, "title": "PYTHON NEWS"},
+            {"_id": 3, "title": "MongoDB internals"},
+            {"_id": 4},
+        ]
+    )
+
+    documents = collection.find(
+        {"title": {"$not": {"$regex": "python", "$options": "i"}}}
+    )
+
+    assert sorted(_ids(documents)) == [3, 4]
+
+
+def test_nin_excludes_values_and_includes_missing_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "status": "public"},
+            {"_id": 2, "status": "private"},
+            {"_id": 3, "status": "archived"},
+            {"_id": 4},
+        ]
+    )
+
+    documents = collection.find({"status": {"$nin": ["private", "archived"]}})
+
+    assert sorted(_ids(documents)) == [1, 4]
+
+
+def test_nin_and_negated_regex_share_one_field_specification(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "title": "Private episode"},
+            {"_id": 2, "title": "Python News"},
+            {"_id": 3, "title": "MongoDB internals"},
+            {"_id": 4},
+        ]
+    )
+
+    documents = collection.find(
+        {
+            "title": {
+                "$nin": ["Private episode"],
+                "$not": {"$regex": "python", "$options": "i"},
+            }
+        }
+    )
+
+    assert sorted(_ids(documents)) == [3, 4]
+
+
+def test_write_result_metadata_used_by_the_application(contract_target):
+    collection = contract_target.collection
+
+    inserted = collection.insert_one({"_id": 1, "status": "ready"})
+    unchanged = collection.update_one({"_id": 1}, {"$set": {"status": "ready"}})
+    missing = collection.update_one({"_id": 404}, {"$set": {"status": "ready"}})
+    collection.insert_many(
+        [
+            {"_id": 2, "status": "delete"},
+            {"_id": 3, "status": "delete"},
+        ]
+    )
+    deleted_one = collection.delete_one({"_id": 1})
+    deleted_many = collection.delete_many({"status": "delete"})
+
+    assert inserted.inserted_id == 1
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert (missing.matched_count, missing.modified_count) == (0, 0)
+    assert deleted_one.deleted_count == 1
+    assert deleted_many.deleted_count == 2
+
+
+def test_inc_creates_a_missing_counter(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "show_id": 42})
+
+    result = collection.update_one({"show_id": 42}, {"$inc": {"download_totals": 1}})
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": 1})["download_totals"] == 1
+
+
+def test_replace_one_preserves_id_and_replaces_the_full_document(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {"_id": 1, "title": "Old title", "obsolete": True, "views": 10}
+    )
+
+    replaced = collection.replace_one({"_id": 1}, {"title": "New title", "views": 11})
+    unchanged = collection.replace_one(
+        {"_id": 1}, {"_id": 1, "title": "New title", "views": 11}
+    )
+    missing = collection.replace_one({"_id": 404}, {"title": "Missing"})
+
+    assert (replaced.matched_count, replaced.modified_count) == (1, 1)
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert (missing.matched_count, missing.modified_count) == (0, 0)
+    assert collection.find_one({"_id": 1}) == {
+        "_id": 1,
+        "title": "New title",
+        "views": 11,
+    }
+
+
+def test_distinct_returns_scalar_field_values(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "user_agent": "Firefox"},
+            {"_id": 2, "user_agent": "Safari"},
+            {"_id": 3, "user_agent": "Firefox"},
+            {"_id": 4},
+        ]
+    )
+
+    assert sorted(collection.distinct("user_agent")) == ["Firefox", "Safari"]
+
+
+def test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique(
+    contract_target,
+):
+    pymongo = pytest.importorskip("pymongo")
+    collection = contract_target.collection
+    models = [
+        pymongo.IndexModel([("show_id", -1)], name="newest_show"),
+        pymongo.IndexModel([("is_published", 1)], name="is_published"),
+        pymongo.IndexModel(
+            [("is_published", 1), ("show_id", -1)],
+            name="published_show_priority",
+        ),
+        pymongo.IndexModel([("api_key", "hashed")], name="api_key_lookup"),
+        pymongo.IndexModel([("optional_slug", 1)], name="optional_slug", sparse=True),
+        pymongo.IndexModel([("email", 1)], name="email_unique", unique=True),
+        pymongo.IndexModel(
+            [("created_date", 1)],
+            name="expire_geo_lookup",
+            expireAfterSeconds=63_072_000,
+        ),
+    ]
+
+    if contract_target.name == "mongodb":
+        created = collection.create_indexes(models)
+    else:
+        with pytest.warns(TinyMongoUnsupportedWarning) as captured:
+            created = collection.create_indexes(models)
+        assert len(captured) == 5
+        warning_messages = [str(item.message) for item in captured]
+        assert any("newest_show" in message for message in warning_messages)
+        assert any("published_show_priority" in message for message in warning_messages)
+        assert any("api_key_lookup" in message for message in warning_messages)
+        assert any("optional_slug" in message for message in warning_messages)
+        assert any("expire_geo_lookup" in message for message in warning_messages)
+    collection.insert_one({"_id": 1, "email": "mike@example.com"})
+    duplicate = observe(
+        lambda: collection.insert_one({"_id": 2, "email": "mike@example.com"})
+    )
+
+    assert set(created) == {
+        "newest_show",
+        "is_published",
+        "published_show_priority",
+        "api_key_lookup",
+        "optional_slug",
+        "email_unique",
+        "expire_geo_lookup",
+    }
+    assert duplicate.error == "duplicate_key"
+
+
+def test_object_id_and_datetime_round_trip_and_range_query(contract_target):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    episode_id = bson.ObjectId()
+    created_date = datetime(2025, 2, 3, 12, 30, 45, 123000)
+    collection.insert_one(
+        {"_id": episode_id, "title": "Async Python", "created_date": created_date}
+    )
+
+    document = collection.find_one({"_id": episode_id})
+    in_range = list(
+        collection.find(
+            {
+                "created_date": {
+                    "$gt": created_date - timedelta(seconds=1),
+                    "$lt": created_date + timedelta(seconds=1),
+                }
+            }
+        )
+    )
+
+    assert document["_id"] == episode_id
+    assert isinstance(document["_id"], bson.ObjectId)
+    assert document["created_date"] == created_date
+    assert isinstance(document["created_date"], datetime)
+    assert _ids(in_range) == [episode_id]
+
+
+def test_duplicate_errors_are_catchable_as_pymongo_errors(contract_target):
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    collection.insert_one({"_id": 42})
+
+    caught = None
+    try:
+        collection.insert_one({"_id": 42})
+    except pymongo_errors.PyMongoError as error:
+        caught = error
+
+    assert isinstance(caught, pymongo_errors.DuplicateKeyError)

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -1,42 +1,106 @@
 import os
+from uuid import uuid4
 
 import pytest
 
 import tinymongo as tm
+from tinymongo.errors import DuplicateKeyError, TinyMongoNotSupportedError
 
 
 pytestmark = pytest.mark.integration
 
 
-@pytest.mark.parametrize(
-    ("backend", "env_name"),
-    [
-        ("postgres", "TINYMONGO_POSTGRES_DSN"),
-        ("mariadb", "TINYMONGO_MYSQL_DSN"),
-    ],
-)
-def test_remote_sql_backend_round_trip(backend, env_name):
+REMOTE_BACKENDS = [
+    pytest.param("postgres", "TINYMONGO_POSTGRES_DSN", id="postgres"),
+    pytest.param("mariadb", "TINYMONGO_MYSQL_DSN", id="mariadb"),
+]
+
+
+def _remote_target(backend, env_name):
     dsn = os.environ.get(env_name)
     if not dsn:
         pytest.skip("{0} is required".format(env_name))
-
     database = os.environ.get("TINYMONGO_REMOTE_SQL_DB", "tinymongoIntegration")
-    collection = os.environ.get("TINYMONGO_REMOTE_SQL_COLLECTION", "roundTrip")
+    prefix = "ci_{0}".format(uuid4().hex[:12])
+    return dsn, database, prefix
+
+
+@pytest.mark.parametrize(
+    ("backend", "env_name"),
+    REMOTE_BACKENDS,
+)
+def test_remote_sql_backend_round_trip(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_round_trip"
     client = tm.TinyMongoClient(backend=backend, dsn=dsn)
     docs = client[database][collection]
-    docs.drop()
+    try:
+        docs.insert_many(
+            [
+                {"_id": "one", "kind": backend, "score": 1},
+                {"_id": "two", "kind": backend, "score": 2},
+            ]
+        )
+        docs.update_one({"_id": "one"}, {"$inc": {"score": 10}})
 
-    docs.insert_many(
-        [
-            {"_id": "one", "kind": backend, "score": 1},
-            {"_id": "two", "kind": backend, "score": 2},
-        ]
-    )
-    docs.update_one({"_id": "one"}, {"$inc": {"score": 10}})
+        assert docs.find_one({"_id": "one"})["score"] == 11
+        assert docs.find({"kind": backend}).count() == 2
+        assert collection in client[database].collection_names()
+        assert database in client.list_database_names()
+    finally:
+        docs.drop()
+        client.close()
 
-    assert docs.find_one({"_id": "one"})["score"] == 11
-    assert docs.find({"kind": backend}).count() == 2
-    assert collection in client[database].collection_names()
-    assert database in client.list_database_names()
 
-    docs.drop()
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_native_index_catalog_and_unique_enforcement(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    scalar_name = prefix + "_scalar"
+    multikey_name = prefix + "_multikey"
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    scalar = client[database][scalar_name]
+    multikey = client[database][multikey_name]
+
+    try:
+        assert (
+            scalar.create_index("email", name="email_unique", unique=True)
+            == "email_unique"
+        )
+        assert scalar.index_information() == {
+            "_id_": {"key": [("_id", 1)]},
+            "email_unique": {"key": [("email", 1)], "unique": True},
+        }
+
+        scalar.insert_many(
+            [
+                {"_id": 1, "email": "ada@example.com"},
+                {"_id": 2, "email": "grace@example.com"},
+            ]
+        )
+        with pytest.raises(DuplicateKeyError):
+            scalar.insert_one({"_id": 3, "email": "ada@example.com"})
+        assert scalar.count_documents({}) == 2
+
+        # A separate client proves the catalog is persisted remotely rather than
+        # retained only on the collection handle that created the index.
+        reader = tm.TinyMongoClient(backend=backend, dsn=dsn)
+        try:
+            assert reader[database][scalar_name].index_information()[
+                "email_unique"
+            ] == {"key": [("email", 1)], "unique": True}
+        finally:
+            reader.close()
+
+        scalar.drop_index("email_unique")
+        assert scalar.index_information() == {"_id_": {"key": [("_id", 1)]}}
+        scalar.insert_one({"_id": 3, "email": "ada@example.com"})
+
+        multikey.create_index("tags", name="tags_unique", unique=True)
+        multikey.insert_one({"_id": 1, "tags": "beta"})
+        with pytest.raises(TinyMongoNotSupportedError, match="multikey uniqueness"):
+            multikey.insert_one({"_id": 2, "tags": ["beta", "gamma"]})
+        assert multikey.count_documents({}) == 1
+    finally:
+        multikey.drop()
+        scalar.drop()
+        client.close()

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -1,0 +1,474 @@
+import asyncio
+import threading
+
+import pytest
+
+from tinymongo.asyncio import (
+    AsyncMongoClient,
+    AsyncTinyMongoClient,
+    AsyncTinyMongoCursor,
+)
+from tinymongo.errors import InvalidOperation, TinyMongoNotSupportedError
+from tinymongo.tinymongo import TinyMongoCollection
+
+
+def run(coroutine):
+    return asyncio.run(coroutine)
+
+
+def test_async_crud_cursor_and_client_metadata():
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-crud", backend="memory")
+        collection = client.app.people
+
+        result = await collection.insert_many(
+            [
+                {"_id": 1, "name": "one", "rank": 3},
+                {"_id": 2, "name": "two", "rank": 1},
+                {"_id": 3, "name": "three", "rank": 2},
+            ]
+        )
+        assert result.inserted_ids == [1, 2, 3]
+        assert await collection.count_documents({}) == 3
+
+        cursor = collection.find({}, {"name": 1, "_id": 0})
+        assert isinstance(cursor, AsyncTinyMongoCursor)
+        documents = await cursor.sort("rank").skip(1).limit(1).to_list()
+        assert documents == [{"name": "three"}]
+
+        update = await collection.update_one({"_id": 2}, {"$set": {"rank": 4}})
+        assert update.matched_count == 1
+        assert await collection.find_one({"_id": 2}, {"rank": 1}) == {
+            "_id": 2,
+            "rank": 4,
+        }
+
+        deleted = await collection.delete_one({"_id": 1})
+        assert deleted.deleted_count == 1
+        assert await client.list_database_names() == ["app"]
+        assert (await client.server_info())["tinymongo"] is True
+        assert await client.supports("projections") is True
+
+        await client.close()
+        await client.close()
+        with pytest.raises(InvalidOperation):
+            await collection.find_one({})
+
+    run(scenario())
+
+
+def test_async_database_listing_and_drop_database():
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-databases", backend="memory")
+        database = client.app
+        await database.items.insert_one({"_id": 1})
+        await client.zeta.events.insert_one({"_id": 2})
+
+        metadata = await client.list_databases()
+        assert isinstance(metadata, AsyncTinyMongoCursor)
+        metadata.sort("name", -1).skip(1).limit(1)
+        assert await metadata.to_list() == [
+            {"name": "app", "sizeOnDisk": 0, "empty": False}
+        ]
+
+        assert await client.drop_database(database) is None
+        assert await client.list_database_names() == ["zeta"]
+        assert await (await client.list_databases()).to_list() == [
+            {"name": "zeta", "sizeOnDisk": 0, "empty": False}
+        ]
+        assert await client.drop_database("zeta") is None
+        assert await client.list_database_names() == []
+        assert await client.drop_database("missing") is None
+        with pytest.raises(TypeError):
+            await client.drop_database(object())
+        await client.close()
+
+    run(scenario())
+
+
+def test_find_is_lazy_and_cursor_clone_has_independent_consumption(monkeypatch):
+    calls = []
+    original_find = TinyMongoCollection.find
+
+    def recording_find(self, *args, **kwargs):
+        calls.append((args, kwargs))
+        return original_find(self, *args, **kwargs)
+
+    monkeypatch.setattr(TinyMongoCollection, "find", recording_find)
+
+    async def scenario():
+        async with AsyncMongoClient("memory://async-lazy", backend="memory") as client:
+            collection = client.db.items
+            await collection.insert_many([{"_id": 1, "n": 2}, {"_id": 2, "n": 1}])
+            calls.clear()
+
+            cursor = collection.find({}).sort("n")
+            clone = cursor.clone()
+            assert calls == []
+
+            assert await cursor.next() == {"_id": 2, "n": 1}
+            assert await cursor.to_list() == [{"_id": 1, "n": 2}]
+            assert await cursor.try_next() is None
+            assert calls and len(calls) == 1
+
+            assert [document async for document in clone] == [
+                {"_id": 2, "n": 1},
+                {"_id": 1, "n": 2},
+            ]
+            assert len(calls) == 2
+            await clone.rewind()
+            assert await clone.to_list(1) == [{"_id": 2, "n": 1}]
+            assert await clone.to_list(0) == []
+            assert await clone.to_list() == [{"_id": 1, "n": 2}]
+
+    run(scenario())
+
+
+def test_storage_work_does_not_block_the_event_loop(monkeypatch):
+    original_insert_one = TinyMongoCollection.insert_one
+    entered = threading.Event()
+    event_loop_progressed = threading.Event()
+
+    def waiting_insert(self, *args, **kwargs):
+        entered.set()
+        if not event_loop_progressed.wait(timeout=10):
+            raise AssertionError("event loop did not progress during storage work")
+        return original_insert_one(self, *args, **kwargs)
+
+    monkeypatch.setattr(TinyMongoCollection, "insert_one", waiting_insert)
+
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-responsive", backend="memory")
+        loop = asyncio.get_running_loop()
+        loop.call_soon(event_loop_progressed.set)
+        result = await client.db.items.insert_one({"_id": 1})
+
+        assert entered.is_set()
+        assert event_loop_progressed.is_set()
+        assert result.inserted_id == 1
+        await client.close()
+
+    run(scenario())
+
+
+def test_cursor_validation_close_and_limit_zero():
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            "memory://async-cursor-validation", backend="memory"
+        )
+        collection = client.db.items
+        await collection.insert_many([{"_id": 1}, {"_id": 2}])
+
+        with pytest.raises(TypeError):
+            collection.find({}).skip(True)
+        with pytest.raises(ValueError):
+            collection.find({}).skip(-1)
+        with pytest.raises(TypeError):
+            collection.find({}).limit(1.5)
+
+        cursor = collection.find({}).limit(0)
+        assert len(await cursor.to_list()) == 2
+        with pytest.raises(InvalidOperation):
+            cursor.sort("_id")
+
+        closed = collection.find({})
+        await closed.close()
+        assert closed.alive is False
+        assert await closed.to_list() == []
+        with pytest.raises(InvalidOperation):
+            closed.skip(1)
+
+        await client.close()
+
+    run(scenario())
+
+
+def test_database_helpers_and_unsupported_calls():
+    async def scenario():
+        async with AsyncTinyMongoClient(
+            "memory://async-database", backend="memory"
+        ) as client:
+            database = client.get_database("app")
+            collection = database.get_collection("events")
+            assert database.name == "app"
+            assert collection.full_name == "app.events"
+            assert collection.with_options() is collection
+
+            await collection.insert_one({"_id": "event"})
+            assert await database.list_collection_names() == ["events"]
+            assert await database.drop_collection(collection) is True
+
+            with pytest.raises(TinyMongoNotSupportedError):
+                await database.command("ping")
+            with pytest.raises(TinyMongoNotSupportedError):
+                await collection.aggregate([])
+
+    run(scenario())
+
+
+def test_remaining_supported_collection_surface(monkeypatch):
+    def create_indexes(self, models, *args, **kwargs):
+        return ["batch_index"]
+
+    monkeypatch.setattr(
+        TinyMongoCollection, "create_indexes", create_indexes, raising=False
+    )
+
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-surface", backend="memory")
+        database = client.app
+        collection = database.items
+
+        assert repr(database) == "app"
+        assert database.database == "app"
+        assert repr(collection) == "items"
+        assert collection.tablename == "items"
+        assert collection.write_concern.document == {}
+        assert collection.read_concern.document == {}
+        assert (
+            collection.with_options(read_concern=collection.read_concern) is collection
+        )
+
+        assert (await collection.insert({"_id": 1, "kind": "a"})).inserted_id == 1
+        assert (
+            await collection.insert([{"_id": 2, "kind": "a"}, {"_id": 3, "kind": "b"}])
+        ).inserted_ids == [2, 3]
+        assert (
+            await collection.update({}, {"$set": {"seen": True}})
+        ).matched_count == 3
+        assert (
+            await collection.update_many({"kind": "a"}, {"$inc": {"score": 1}})
+        ).matched_count == 2
+        assert (
+            await collection.replace_one({"_id": 3}, {"kind": "c", "score": 5})
+        ).matched_count == 1
+
+        before = await collection.find_one_and_update(
+            {"_id": 1}, {"$set": {"kind": "changed"}}
+        )
+        assert before["kind"] == "a"
+        before_replace = await collection.find_one_and_replace(
+            {"_id": 2}, {"kind": "replaced"}
+        )
+        assert before_replace["kind"] == "a"
+        removed = await collection.find_one_and_delete(
+            {"kind": {"$in": ["changed", "replaced"]}},
+            projection={"kind": 1, "_id": 0},
+            sort=[("kind", 1)],
+        )
+        assert removed == {"kind": "changed"}
+        assert await collection.estimated_document_count() == 2
+        assert await collection.count() == 2
+
+        assert await collection.create_index("kind") == "kind_1"
+        indexes = await collection.list_indexes()
+        assert isinstance(indexes, AsyncTinyMongoCursor)
+        assert [item["name"] async for item in indexes] == ["_id_", "kind_1"]
+        assert (await collection.index_information())["kind_1"]["key"] == [("kind", 1)]
+        assert await collection.distinct("kind") == ["replaced", "c"]
+        await collection.drop_index("kind")
+        assert await collection.create_indexes([object()]) == ["batch_index"]
+
+        assert (await collection.remove({"_id": 1}, multi=False)).deleted_count == 0
+        assert (await collection.delete_many({"kind": "replaced"})).deleted_count == 1
+        assert "items" in await database.collection_names()
+
+        with pytest.raises(TinyMongoNotSupportedError):
+            await collection.bulk_write([])
+        with pytest.raises(TinyMongoNotSupportedError):
+            await collection.watch()
+        with pytest.raises(TinyMongoNotSupportedError):
+            await database.watch()
+        with pytest.raises(TinyMongoNotSupportedError):
+            await client.watch()
+        with pytest.raises(TinyMongoNotSupportedError):
+            client.start_session()
+
+        assert await collection.drop() is True
+        assert await database.drop_collection("missing") is False
+        await client.close()
+
+    run(scenario())
+
+
+def test_cursor_results_do_not_alias_the_cached_documents():
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-result-copies", backend="memory")
+        collection = client.db.items
+        await collection.insert_one({"_id": 1, "profile": {"name": "Ada"}})
+
+        cursor = collection.find({})
+        yielded = await cursor.next()
+        yielded["profile"]["name"] = "changed"
+        await cursor.rewind()
+        assert await cursor.next() == {"_id": 1, "profile": {"name": "Ada"}}
+
+        await cursor.rewind()
+        listed = await cursor.to_list()
+        listed[0]["profile"]["name"] = "changed again"
+        await cursor.rewind()
+        assert await cursor.next() == {"_id": 1, "profile": {"name": "Ada"}}
+
+        await client.close()
+
+    run(scenario())
+
+
+def test_cursor_initial_options_counts_and_error_paths(monkeypatch):
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-options", backend="memory")
+        collection = client.db.items
+        await collection.insert_many(
+            [{"_id": 1, "n": 3}, {"_id": 2, "n": 2}, {"_id": 3, "n": 1}]
+        )
+
+        cursor = collection.find({}, sort=[("n", 1)], skip=1, limit=-1)
+        assert cursor.alive is True
+        assert await cursor.count() == 1
+        assert cursor.alive is True
+        assert await cursor.to_list() == [{"_id": 2, "n": 2}]
+        assert cursor.alive is False
+        assert await cursor.to_list() == []
+        await cursor.close()
+
+        shared = collection.find({})
+        first_load, second_load = await asyncio.gather(
+            shared._ensure_loaded(), shared._ensure_loaded()
+        )
+        assert first_load is second_load
+
+        with pytest.raises(TypeError):
+            await collection.find({}).to_list(True)
+        with pytest.raises(ValueError):
+            await collection.find({}).to_list(-1)
+
+        closed = collection.find({})
+        await closed.close()
+        with pytest.raises(InvalidOperation):
+            await closed.rewind()
+
+        original_find = TinyMongoCollection.find
+
+        def broken_find(self, *args, **kwargs):
+            raise RuntimeError("query failed")
+
+        monkeypatch.setattr(TinyMongoCollection, "find", broken_find)
+        broken = collection.find({})
+        with pytest.raises(RuntimeError, match="query failed"):
+            await broken.to_list()
+        await broken.close()
+        monkeypatch.setattr(TinyMongoCollection, "find", original_find)
+
+        await client.close()
+
+    run(scenario())
+
+
+def test_cursor_legacy_pagination_and_has_next_helpers():
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-pagination", backend="memory")
+        collection = client.db.items
+        await collection.insert_many([{"_id": 1}, {"_id": 2}, {"_id": 3}, {"_id": 4}])
+
+        cursor = collection.find({}).sort("_id").paginate(1, -2)
+        assert await cursor.has_next() is True
+        assert await cursor.hasNext() is True
+        assert await cursor.next() == {"_id": 2}
+        assert await cursor.has_next() is True
+        assert await cursor.next() == {"_id": 3}
+        assert await cursor.hasNext() is False
+
+        unchanged = collection.find({}).skip(1).limit(1).paginate(None, None)
+        assert await unchanged.to_list() == [{"_id": 2}]
+
+        with pytest.raises(TypeError):
+            collection.find({}).paginate(True, None)
+        with pytest.raises(ValueError):
+            collection.find({}).paginate(-1, None)
+        with pytest.raises(TypeError):
+            collection.find({}).paginate(None, False)
+
+        started = collection.find({})
+        assert await started.has_next() is True
+        with pytest.raises(InvalidOperation):
+            started.paginate(0, 1)
+
+        closed = collection.find({})
+        await closed.close()
+        assert await closed.has_next() is False
+
+        await client.close()
+
+    run(scenario())
+
+
+def test_closed_handles_private_attributes_and_database_context():
+    async def scenario():
+        unopened = AsyncTinyMongoClient("memory://async-unopened", backend="memory")
+        await unopened.close()
+        with pytest.raises(InvalidOperation):
+            async with unopened:
+                pass
+
+        client = AsyncTinyMongoClient("memory://async-attrs", backend="memory")
+        with pytest.raises(AttributeError):
+            client.__getattr__("_missing")
+        with pytest.raises(AttributeError):
+            client.db.__getattr__("_missing")
+
+        assert await client.database_names() == []
+        assert (await client.capabilities())["backend"] == "memory"
+        async with client.context as database:
+            assert await database.list_collection_names() == []
+        await client.close()
+
+    run(scenario())
+
+
+def test_non_default_collection_options_are_rejected():
+    class Concern:
+        document = {"w": 2}
+
+    client = AsyncTinyMongoClient("memory://async-options-error", backend="memory")
+    with pytest.raises(TinyMongoNotSupportedError):
+        client.db.items.with_options(write_concern=Concern())
+    run(client.close())
+
+
+def test_close_waits_for_inflight_operations_and_calls_can_overlap():
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://async-inflight", backend="memory")
+        both_started = threading.Barrier(3)
+        release_first = threading.Event()
+        release_second = threading.Event()
+
+        def wait_for(event):
+            def operation(sync_client):
+                both_started.wait(timeout=10)
+                if not event.wait(timeout=10):
+                    raise AssertionError("in-flight operation was not released")
+                return sync_client.server_info()["tinymongo"]
+
+            return operation
+
+        first = asyncio.create_task(client._state.call(wait_for(release_first)))
+        second = asyncio.create_task(client._state.call(wait_for(release_second)))
+        await asyncio.to_thread(both_started.wait, 10)
+
+        release_first.set()
+        assert await first is True
+        close_task = asyncio.create_task(client.close())
+
+        async def wait_until_closed():
+            while not client._state.closed:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait_until_closed(), timeout=10)
+        assert client._state.closed is True
+        assert close_task.done() is False
+
+        release_second.set()
+        assert await second is True
+        await close_task
+
+    run(scenario())

--- a/tests/test_bson_codec.py
+++ b/tests/test_bson_codec.py
@@ -1,0 +1,171 @@
+import json
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+import tinymongo as tm
+from tinymongo import bson_codec
+
+
+ObjectId = pytest.importorskip("bson").ObjectId
+
+
+def _extended_document():
+    created = datetime(
+        2026, 7, 19, 9, 30, 45, 123456, tzinfo=timezone(timedelta(hours=-4))
+    )
+    document_id = ObjectId()
+    return {
+        "_id": document_id,
+        "created": created,
+        "nested": {
+            "owner_id": ObjectId(),
+            "history": [
+                {"at": created - timedelta(days=1)},
+                ObjectId(),
+            ],
+        },
+    }
+
+
+def test_codec_round_trips_nested_object_ids_and_aware_datetimes():
+    document = _extended_document()
+
+    restored = bson_codec.loads(bson_codec.dumps(document))
+
+    assert restored == document
+    assert isinstance(restored["_id"], ObjectId)
+    assert restored["created"].tzinfo is not None
+    assert restored["created"].utcoffset() == timedelta(hours=-4)
+    assert isinstance(restored["nested"]["owner_id"], ObjectId)
+    assert isinstance(restored["nested"]["history"][0]["at"], datetime)
+    assert isinstance(restored["nested"]["history"][1], ObjectId)
+
+
+def test_codec_tags_are_valid_readable_json():
+    document = _extended_document()
+
+    serialized = bson_codec.dumps(document, ensure_ascii=False, indent=2)
+    encoded = json.loads(serialized)
+
+    assert "__tinymongo_type_v1__" in serialized
+    assert encoded["_id"] == {
+        "__tinymongo_type_v1__": "objectid",
+        "value": str(document["_id"]),
+    }
+    assert encoded["created"] == {
+        "__tinymongo_type_v1__": "datetime",
+        "value": document["created"].isoformat(),
+    }
+
+
+def test_codec_loads_legacy_plain_json_without_changing_it():
+    legacy = '{"_id": 1, "nested": {"active": true}, "items": [null, "x"]}'
+
+    assert bson_codec.loads(legacy) == {
+        "_id": 1,
+        "nested": {"active": True},
+        "items": [None, "x"],
+    }
+
+
+def test_codec_preserves_unknown_exact_tag_mappings():
+    tagged = {
+        "__tinymongo_type_v1__": "future-type",
+        "value": {"nested": [1, 2]},
+    }
+
+    assert bson_codec.decode_value(tagged) == tagged
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-an-item-list",
+        [["missing-value"]],
+    ],
+)
+def test_codec_preserves_malformed_escaped_mapping_tags(payload):
+    tagged = {
+        "__tinymongo_type_v1__": "mapping",
+        "value": payload,
+    }
+
+    assert bson_codec.decode_value(tagged) == tagged
+
+
+@pytest.mark.parametrize("kind", ["datetime", "objectid", "mapping", "future-type"])
+def test_codec_escapes_user_mappings_that_look_like_internal_tags(kind):
+    tagged = {
+        "__tinymongo_type_v1__": kind,
+        "value": "2026-01-02T03:04:05",
+    }
+
+    assert bson_codec.loads(bson_codec.dumps(tagged)) == tagged
+
+
+def test_internal_tag_shaped_mapping_round_trips_through_public_storage():
+    tagged = {
+        "__tinymongo_type_v1__": "datetime",
+        "value": "2026-01-02T03:04:05",
+    }
+    client = tm.TinyMongoClient(backend="memory")
+    collection = client.app.events
+
+    collection.insert_one({"_id": 1, "payload": tagged})
+
+    assert collection.find_one({"_id": 1})["payload"] == tagged
+    client.close()
+
+
+def test_object_id_decode_explains_optional_dependency(monkeypatch):
+    encoded = {
+        "__tinymongo_type_v1__": "objectid",
+        "value": str(ObjectId()),
+    }
+    monkeypatch.setattr(bson_codec, "_ObjectId", None)
+
+    assert bson_codec.bson_available() is False
+    with pytest.raises(ImportError, match=r"pip install 'tinymongo\[bson\]'"):
+        bson_codec.decode_value(encoded)
+
+
+@pytest.mark.parametrize("backend", ["memory", "tinydb", "sqlite", "duckdb", "parquet"])
+def test_extended_values_round_trip_through_public_backends(tmp_path, backend):
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+
+    document = _extended_document()
+    if backend == "memory":
+        location = "memory://bson-codec-{0}".format(uuid4().hex)
+    else:
+        location = str(tmp_path / backend)
+
+    writer = tm.TinyMongoClient(location, backend=backend)
+    writer.app.events.insert_one(document)
+    writer.close()
+
+    reader = tm.TinyMongoClient(location, backend=backend)
+    try:
+        restored = reader.app.events.find_one({"_id": document["_id"]})
+
+        assert restored == document
+        assert reader.app.events.find_one({"created": document["created"]}) == document
+    finally:
+        reader.close()
+
+
+def test_json_backend_persists_readable_tags(tmp_path):
+    location = tmp_path / "json"
+    document = _extended_document()
+    client = tm.TinyMongoClient(str(location), backend="tinydb")
+    client.app.events.insert_one(document)
+    client.close()
+
+    raw = (location / "app.json").read_text(encoding="utf8")
+
+    assert '"__tinymongo_type_v1__": "objectid"' in raw
+    assert '"__tinymongo_type_v1__": "datetime"' in raw
+    assert str(document["_id"]) in raw
+    assert document["created"].isoformat() in raw

--- a/tests/test_common_api.py
+++ b/tests/test_common_api.py
@@ -1,0 +1,256 @@
+import os
+
+import pytest
+
+import tinymongo
+from tinymongo.errors import InvalidOperation
+
+
+def test_client_lists_and_drops_file_database(tmp_path):
+    client = tinymongo.TinyMongoClient(str(tmp_path), backend="tinydb")
+    database = client.get_database("app")
+    assert database.name == "app"
+    assert database.get_collection("items").name == "items"
+    assert database.items.database is database
+    assert database.items.full_name == "app.items"
+    database.items.insert_one({"_id": 1})
+
+    metadata = client.list_databases().to_list()
+
+    assert metadata[0]["name"] == "app"
+    assert metadata[0]["sizeOnDisk"] > 0
+    assert metadata[0]["empty"] is False
+    assert client.database_names() == ["app"]
+
+    assert client.drop_database(database) is None
+    assert client.list_database_names() == []
+    assert not os.path.exists(tmp_path / "app.json")
+    assert client.drop_database("missing") is None
+    with pytest.raises(TypeError):
+        client.drop_database(object())
+    client.close()
+
+
+def test_client_lists_and_drops_named_memory_database():
+    client = tinymongo.TinyMongoClient("memory://common-api", backend="memory")
+    client.app.items.insert_one({"_id": 1})
+
+    assert client.list_databases().to_list() == [
+        {"name": "app", "sizeOnDisk": 0, "empty": False}
+    ]
+
+    client.drop_database("app")
+    assert client.list_database_names() == []
+    client.close()
+
+
+def test_client_drops_local_parquet_database_directory(tmp_path):
+    pytest.importorskip("duckdb")
+    pytest.importorskip("pyarrow")
+    client = tinymongo.TinyMongoClient(str(tmp_path), backend="parquet")
+    client.analytics.events.insert_one({"_id": 1})
+    database_path = tmp_path / "analytics.parquet"
+    assert database_path.is_dir()
+
+    client.drop_database("analytics")
+
+    assert not database_path.exists()
+    assert client.list_database_names() == []
+    client.close()
+
+
+@pytest.mark.parametrize("backend", ["memory", "tinydb", "sqlite"])
+def test_find_one_and_delete_honors_sort_and_projection(tmp_path, backend):
+    folder = (
+        "memory://find-one-delete-{0}".format(backend)
+        if backend == "memory"
+        else str(tmp_path / backend)
+    )
+    client = tinymongo.TinyMongoClient(folder, backend=backend)
+    collection = client.app.jobs
+    collection.insert_many(
+        [
+            {"_id": 1, "status": "pending", "priority": 1, "secret": "a"},
+            {"_id": 2, "status": "pending", "priority": 2, "secret": "b"},
+        ]
+    )
+
+    removed = collection.find_one_and_delete(
+        {"status": "pending"},
+        sort=[("priority", -1)],
+        projection={"secret": 0},
+    )
+
+    assert removed == {"_id": 2, "status": "pending", "priority": 2}
+    assert collection.find_one({"_id": 2}) is None
+    assert collection.find_one_and_delete({"status": "missing"}) is None
+    client.close()
+
+
+def test_distinct_index_information_and_cursor_lifecycle():
+    assert issubclass(tinymongo.TinyMongoUnsupportedWarning, UserWarning)
+    client = tinymongo.TinyMongoClient(backend="memory")
+    collection = client.app.items
+    collection.insert_many(
+        [
+            {"_id": 1, "kind": "a", "profile": {"team": "one"}, "tags": ["x", "y"]},
+            {"_id": 2, "kind": "b", "profile": {"team": "one"}, "tags": ["y"]},
+            {"_id": 3, "kind": "a", "profile": {"team": "two"}},
+        ]
+    )
+    collection.create_index("kind", name="kind_lookup")
+
+    assert collection.distinct("profile.team", {"kind": "a"}) == ["one", "two"]
+    assert collection.distinct("tags") == ["x", "y"]
+    assert collection.index_information() == {
+        "_id_": {"key": [("_id", 1)]},
+        "kind_lookup": {"key": [("kind", 1)]},
+    }
+
+    cursor = collection.find({}).sort("_id")
+    collection.insert_one(
+        {"_id": 4, "kind": "c", "profile": {"team": "three"}, "tags": ["z"]}
+    )
+    clone = cursor.clone().skip(1).limit(-1)
+    assert clone.to_list() == [
+        {
+            "_id": 2,
+            "kind": "b",
+            "profile": {"team": "one"},
+            "tags": ["y"],
+        }
+    ]
+    assert [item["_id"] for item in cursor.clone().to_list()] == [1, 2, 3, 4]
+    assert cursor.to_list(1)[0]["_id"] == 1
+    assert cursor.rewind().to_list(1)[0]["_id"] == 1
+    assert cursor.alive is True
+    cursor.close()
+    assert cursor.alive is False
+    assert cursor.to_list() == []
+    assert list(cursor) == []
+    with pytest.raises(InvalidOperation):
+        cursor.rewind()
+    with pytest.raises(TypeError):
+        clone.skip(True)
+    with pytest.raises(ValueError):
+        clone.skip(-1)
+    with pytest.raises(TypeError):
+        clone.limit(1.5)
+    with pytest.raises(TypeError):
+        clone.to_list(True)
+    with pytest.raises(ValueError):
+        clone.to_list(-1)
+    client.close()
+
+
+def test_iterating_cursor_preserves_consumed_position():
+    cursor = tinymongo.TinyMongoCursor([{"_id": 1}, {"_id": 2}, {"_id": 3}])
+
+    assert next(cursor) == {"_id": 1}
+    assert list(cursor) == [{"_id": 2}, {"_id": 3}]
+    assert list(cursor) == []
+    with pytest.raises(StopIteration):
+        cursor.next()
+
+
+@pytest.mark.parametrize("backend", ["memory", "tinydb", "sqlite"])
+def test_find_and_modify_honors_before_after_upsert_sort_and_projection(
+    tmp_path, backend
+):
+    location = (
+        "memory://find-and-modify-semantics"
+        if backend == "memory"
+        else str(tmp_path / backend)
+    )
+    client = tinymongo.TinyMongoClient(location, backend=backend)
+    collection = client.app.items
+    collection.insert_many(
+        [
+            {"_id": 1, "status": "pending", "rank": 1, "secret": "one"},
+            {"_id": 2, "status": "pending", "rank": 2, "secret": "two"},
+        ]
+    )
+
+    after = collection.find_one_and_update(
+        {"status": "pending"},
+        {"$set": {"status": "complete"}},
+        sort=[("rank", -1)],
+        projection={"status": 1},
+        return_document=True,
+    )
+    assert after == {"_id": 2, "status": "complete"}
+
+    before = collection.find_one_and_replace(
+        {"_id": 1}, {"status": "replaced", "rank": 3}
+    )
+    assert before["status"] == "pending"
+
+    assert (
+        collection.find_one_and_update(
+            {"_id": 3}, {"$set": {"status": "inserted"}}, upsert=True
+        )
+        is None
+    )
+    assert collection.find_one({"_id": 3})["status"] == "inserted"
+    assert collection.find_one_and_replace(
+        {"_id": 4},
+        {"_id": 4, "status": "inserted replacement"},
+        upsert=True,
+        return_document=True,
+    ) == {"_id": 4, "status": "inserted replacement"}
+
+    with pytest.raises(ValueError, match="return_document"):
+        collection.find_one_and_update({}, {"$set": {"seen": True}}, return_document=1)
+    with pytest.raises(ValueError, match="return_document"):
+        collection.find_one_and_replace({}, {}, return_document="after")
+    client.close()
+
+
+def test_file_crud_read_modify_write_paths_take_an_outer_collection_lock(tmp_path):
+    client = tinymongo.TinyMongoClient(str(tmp_path / "locked"), backend="tinydb")
+    collection = client.app.items
+    collection.insert_many([{"_id": 1, "value": 1}, {"_id": 2, "value": 2}])
+    acquisitions = []
+    acquire = collection._acquire_collection_lock
+
+    def tracked_acquire():
+        acquisitions.append(True)
+        return acquire()
+
+    collection._acquire_collection_lock = tracked_acquire
+
+    collection.find_one_and_update({"_id": 1}, {"$set": {"value": 3}})
+    assert len(acquisitions) == 3
+    acquisitions.clear()
+
+    collection.find_one_and_replace({"_id": 1}, {"value": 4})
+    assert len(acquisitions) == 3
+    acquisitions.clear()
+
+    collection.delete_one({"_id": 1})
+    assert len(acquisitions) == 2
+    acquisitions.clear()
+
+    collection.delete_many({})
+    assert len(acquisitions) == 2
+    client.close()
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_update_many_supports_embedded_document_ids(tmp_path, backend):
+    location = (
+        "memory://embedded-document-id"
+        if backend == "memory"
+        else str(tmp_path / backend)
+    )
+    client = tinymongo.TinyMongoClient(location, backend=backend)
+    collection = client.app.items
+    document_id = {"tenant": 1, "item": 2}
+    collection.insert_one({"_id": document_id, "value": 1})
+
+    result = collection.update_many({}, {"$set": {"value": 2}})
+
+    assert result.matched_count == 1
+    assert result.modified_count == 1
+    assert collection.find_one({"_id": document_id})["value"] == 2
+    client.close()

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -460,7 +460,8 @@ def test_upsert_helpers_database_compatibility_and_find_and_modify(tmp_path):
     replaced = collection.find_one_and_replace(
         {"_id": 3}, {"_id": 3, "value": 2}, upsert=True
     )
-    assert replaced == {"_id": 3, "value": 2}
+    assert replaced is None
+    assert collection.find_one({"_id": 3}) == {"_id": 3, "value": 2}
     assert collection.find_one_and_replace({"_id": "missing"}, {"value": 3}) is None
     assert collection.find_one_and_replace(
         {"_id": 3}, {"value": 4}, return_document=True
@@ -480,9 +481,10 @@ def test_upsert_helpers_database_compatibility_and_find_and_modify(tmp_path):
             {"email": "grace@example.com"},
             {"$set": {"active": True}},
             upsert=True,
-        )["active"]
-        is True
+        )
+        is None
     )
+    assert sqlite.find_one({"email": "grace@example.com"})["active"] is True
 
 
 def test_parquet_lock_helpers_and_fsync_failures(monkeypatch):
@@ -517,7 +519,7 @@ def test_parquet_lock_helpers_and_fsync_failures(monkeypatch):
             self.calls += 1
             return False if self.calls == 1 else True
 
-    assert ps._acquire_rlock(BlockingLock()) is False
+    assert ps._acquire_rlock(BlockingLock()) is True
 
 
 def test_cursor_and_gridfs_edges():
@@ -580,8 +582,8 @@ def test_collection_error_and_compatibility_edges(tmp_path):
     collection.insert_one({"_id": "", "name": "empty"})
     generated = collection.insert_one({"name": "generated"})
     assert generated.inserted_id
-    bypassed = collection.insert_one({"_id": 0}, bypass_document_validation=True)
-    assert bypassed.inserted_id == 0
+    with pytest.raises(DuplicateKeyError):
+        collection.insert_one({"_id": 0}, bypass_document_validation=True)
     with pytest.raises(DuplicateKeyError):
         collection.insert_one({"_id": 0})
     with pytest.raises(DuplicateKeyError):
@@ -714,6 +716,7 @@ def test_collection_write_and_no_match_edges(tmp_path):
     c.build_table()
     c.insert_one({"_id": "drop-table-branch"})
     db.tinydb.drop_table = lambda name: None
+    db._refresh_table = lambda: None
     assert c.drop() is True
     c.insert_many([{"_id": 1}, {"_id": 2}], bypass_document_validation=True)
     assert c.delete_many({}).deleted_count == 3

--- a/tests/test_durable_indexes.py
+++ b/tests/test_durable_indexes.py
@@ -1,0 +1,532 @@
+from concurrent.futures import ThreadPoolExecutor
+import subprocess
+import sys
+import threading
+import time
+from uuid import uuid4
+
+import pytest
+
+import tinymongo
+from tinymongo.errors import (
+    DuplicateKeyError,
+    OperationFailure,
+    TinyMongoNotSupportedError,
+)
+from tinymongo.storage_backends import clear_memory_namespace
+
+
+BACKENDS = [
+    pytest.param("memory", id="memory"),
+    pytest.param("tinydb", id="json"),
+    pytest.param("sqlite", id="sqlite"),
+    pytest.param("duckdb", id="duckdb"),
+    pytest.param("parquet", id="parquet"),
+]
+
+
+class DurableIndexBackend:
+    def __init__(self, backend, address):
+        self.backend = backend
+        self.address = address
+        self.clients = []
+
+    def open(self):
+        client = tinymongo.TinyMongoClient(self.address, backend=self.backend)
+        self.clients.append(client)
+        return client
+
+    def close(self, client):
+        client.close()
+
+    def close_all(self):
+        for client in reversed(self.clients):
+            client.close()
+        if self.backend == "memory":
+            clear_memory_namespace(self.address)
+
+
+@pytest.fixture(params=BACKENDS)
+def durable_index_backend(request, tmp_path):
+    backend = request.param
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+    if backend == "parquet":
+        pytest.importorskip("pyarrow")
+
+    if backend == "memory":
+        address = "memory://durable-index-{0}".format(uuid4().hex)
+    else:
+        address = str(tmp_path / backend)
+
+    target = DurableIndexBackend(backend, address)
+    try:
+        yield target
+    finally:
+        target.close_all()
+
+
+def _indexes_by_name(collection):
+    return {index["name"]: index for index in collection.list_indexes()}
+
+
+def test_unique_index_and_enforcement_survive_client_restart(durable_index_backend):
+    first = durable_index_backend.open()
+    users = first.app.users
+    assert users.create_index("email", name="login_email", unique=True) == "login_email"
+    users.insert_many(
+        [
+            {"_id": 1, "email": "ada@example.com"},
+            {"_id": 2, "email": "grace@example.com"},
+        ]
+    )
+    durable_index_backend.close(first)
+
+    reopened = durable_index_backend.open()
+    users = reopened.app.users
+    assert _indexes_by_name(users)["login_email"] == {
+        "name": "login_email",
+        "key": [("email", 1)],
+        "unique": True,
+    }
+
+    with pytest.raises(DuplicateKeyError):
+        users.insert_one({"_id": 3, "email": "ada@example.com"})
+    with pytest.raises(DuplicateKeyError):
+        users.update_one({"_id": 2}, {"$set": {"email": "ada@example.com"}})
+
+    assert users.find_one({"_id": 2})["email"] == "grace@example.com"
+    assert users.count_documents({}) == 2
+
+
+def test_index_metadata_is_collection_scoped_and_drop_persists(
+    durable_index_backend,
+):
+    first = durable_index_backend.open()
+    users = first.app.users
+    audit = first.app.audit
+    users.create_index("email", name="login_email", unique=True)
+    audit.create_index("created_at", name="created_at_lookup")
+
+    assert set(_indexes_by_name(users)) == {"_id_", "login_email"}
+    assert _indexes_by_name(users)["login_email"]["unique"] is True
+    assert set(_indexes_by_name(audit)) == {"_id_", "created_at_lookup"}
+    assert "unique" not in _indexes_by_name(audit)["created_at_lookup"]
+
+    assert users.drop_index("login_email") is None
+    durable_index_backend.close(first)
+
+    reopened = durable_index_backend.open()
+    users = reopened.app.users
+    audit = reopened.app.audit
+    assert users.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+    assert "created_at_lookup" in _indexes_by_name(audit)
+
+    users.insert_many(
+        [
+            {"_id": 1, "email": "same@example.com"},
+            {"_id": 2, "email": "same@example.com"},
+        ]
+    )
+    assert audit.drop_index("created_at") is None
+    with pytest.raises(OperationFailure, match="not found"):
+        audit.drop_index("created_at")
+    with pytest.raises(OperationFailure, match="cannot be dropped"):
+        audit.drop_index("_id_")
+
+
+def test_catalog_identity_cannot_collide_across_collection_and_index_names(
+    durable_index_backend,
+):
+    client = durable_index_backend.open()
+    first = client.app["a:b"]
+    second = client.app["a"]
+
+    first.create_index("value", name="c", unique=True)
+    second.create_index("value", name="b:c", unique=True)
+    assert set(_indexes_by_name(first)) == {"_id_", "c"}
+    assert set(_indexes_by_name(second)) == {"_id_", "b:c"}
+
+    first.drop_index("c")
+    assert "b:c" in _indexes_by_name(second)
+
+
+def test_drop_collection_removes_its_durable_index_catalog(durable_index_backend):
+    client = durable_index_backend.open()
+    users = client.app.users
+    users.create_index("email", unique=True)
+    users.insert_one({"_id": 1, "email": "same@example.com"})
+
+    assert client.app.drop_collection("users") is True
+    recreated = client.app.users
+    assert recreated.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+    recreated.insert_many(
+        [
+            {"_id": 2, "email": "same@example.com"},
+            {"_id": 3, "email": "same@example.com"},
+        ]
+    )
+
+
+def test_unique_index_rejects_existing_duplicates_without_adding_metadata(
+    durable_index_backend,
+):
+    client = durable_index_backend.open()
+    users = client.app.users
+    users.insert_many(
+        [
+            {"_id": 1, "email": "duplicate@example.com"},
+            {"_id": 2, "email": "duplicate@example.com"},
+        ]
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        users.create_index("email", name="login_email", unique=True)
+
+    assert users.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+
+
+def test_unique_insert_operations_fail_atomically(durable_index_backend):
+    client = durable_index_backend.open()
+    users = client.app.users
+    users.create_index("email", unique=True)
+    users.insert_one({"_id": 1, "email": "ada@example.com"})
+
+    with pytest.raises(DuplicateKeyError):
+        users.insert_one({"_id": 2, "email": "ada@example.com"})
+    with pytest.raises(DuplicateKeyError):
+        users.insert_one(
+            {"_id": 3, "email": "ada@example.com"},
+            bypass_document_validation=True,
+        )
+    with pytest.raises(DuplicateKeyError):
+        users.insert_one(
+            {"_id": 1, "email": "replacement@example.com"},
+            bypass_document_validation=True,
+        )
+    with pytest.raises(DuplicateKeyError):
+        users.insert_many(
+            [
+                {"_id": 4, "email": "grace@example.com"},
+                {"_id": 5, "email": "ada@example.com"},
+            ]
+        )
+    with pytest.raises(DuplicateKeyError):
+        users.insert_many(
+            [
+                {"_id": 6, "email": "hopper@example.com"},
+                {"_id": 7, "email": "hopper@example.com"},
+            ]
+        )
+
+    assert list(users.find({})) == [{"_id": 1, "email": "ada@example.com"}]
+
+
+def test_unique_update_replace_and_upsert_fail_atomically(durable_index_backend):
+    client = durable_index_backend.open()
+    users = client.app.users
+    users.create_index("email", unique=True)
+    users.insert_many(
+        [
+            {"_id": 1, "email": "ada@example.com", "active": True},
+            {"_id": 2, "email": "grace@example.com", "active": True},
+        ]
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        users.update_one({"_id": 2}, {"$set": {"email": "ada@example.com"}})
+    with pytest.raises(DuplicateKeyError):
+        users.update_many({}, {"$set": {"email": "shared@example.com"}})
+    with pytest.raises(DuplicateKeyError):
+        users.replace_one(
+            {"_id": 2},
+            {"email": "ada@example.com", "active": False},
+        )
+    with pytest.raises(DuplicateKeyError):
+        users.update_one(
+            {"_id": 3},
+            {"$set": {"email": "ada@example.com"}},
+            upsert=True,
+        )
+    with pytest.raises(DuplicateKeyError):
+        users.replace_one(
+            {"_id": 4},
+            {"_id": 4, "email": "ada@example.com"},
+            upsert=True,
+        )
+
+    assert list(users.find({}).sort("_id", 1)) == [
+        {"_id": 1, "email": "ada@example.com", "active": True},
+        {"_id": 2, "email": "grace@example.com", "active": True},
+    ]
+
+
+def test_unique_array_semantics(durable_index_backend):
+    client = durable_index_backend.open()
+    values = client.app.values
+    values.create_index("value", unique=True)
+
+    values.insert_one({"_id": 1, "value": ["alpha", "alpha", "beta"]})
+    values.insert_one({"_id": 2, "value": ["gamma"]})
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 3, "value": ["beta", "delta"]})
+
+    values.insert_one({"_id": 4, "value": []})
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 5, "value": []})
+
+    assert values.count_documents({}) == 3
+
+
+def test_unique_null_and_missing_values_share_one_key(durable_index_backend):
+    client = durable_index_backend.open()
+    values = client.app.values
+    values.create_index("value", unique=True)
+
+    values.insert_one({"_id": 1})
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 2, "value": None})
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 3, "value": [None]})
+
+    assert values.count_documents({}) == 1
+
+
+def test_unique_scalar_types_keep_booleans_distinct_from_numbers(
+    durable_index_backend,
+):
+    client = durable_index_backend.open()
+    values = client.app.values
+    values.create_index("value", unique=True)
+
+    values.insert_one({"_id": 1, "value": 1})
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 2, "value": 1.0})
+    values.insert_one({"_id": 3, "value": True})
+
+    assert values.count_documents({}) == 2
+
+
+def test_unique_index_rejects_unsupported_value_shapes(durable_index_backend):
+    client = durable_index_backend.open()
+    values = client.app.values
+    values.create_index("value", unique=True)
+
+    with pytest.raises(TinyMongoNotSupportedError, match="Object values"):
+        values.insert_one({"_id": 1, "value": {"nested": "object"}})
+    with pytest.raises(TinyMongoNotSupportedError, match="Nested array"):
+        values.insert_one({"_id": 2, "value": [["nested"]]})
+
+    assert values.count_documents({}) == 0
+
+
+def test_nested_unique_field_is_enforced(durable_index_backend):
+    client = durable_index_backend.open()
+    users = client.app.users
+    users.create_index("profile.email", name="nested_email", unique=True)
+    users.insert_one({"_id": 1, "profile": {"email": "ada@example.com"}})
+
+    with pytest.raises(DuplicateKeyError):
+        users.insert_one({"_id": 2, "profile": {"email": "ada@example.com"}})
+    assert users.find_one({"profile.email": "ada@example.com"})["_id"] == 1
+
+
+def test_unique_dotted_index_rejects_array_traversal(durable_index_backend):
+    client = durable_index_backend.open()
+    items = client.app.items
+    items.create_index("parts.sku", unique=True)
+
+    with pytest.raises(TinyMongoNotSupportedError, match="Array traversal"):
+        items.insert_one({"_id": 1, "parts": [{"sku": "one"}]})
+    assert items.count_documents({}) == 0
+
+
+def test_index_creation_is_idempotent_and_rejects_conflicts(
+    durable_index_backend,
+):
+    client = durable_index_backend.open()
+    users = client.app.users
+    assert (
+        users.create_index([("email", 1)], name="login_email", unique=True)
+        == "login_email"
+    )
+    assert (
+        users.create_index([("email", 1)], name="login_email", unique=True)
+        == "login_email"
+    )
+
+    assert users.create_index("email", name="other_name", unique=True) == "other_name"
+    with pytest.raises(OperationFailure, match="different options"):
+        users.create_index("username", name="login_email", unique=True)
+    with pytest.raises(OperationFailure, match="different options"):
+        users.create_index("email", name="login_email", unique=False)
+
+    assert set(_indexes_by_name(users)) == {"_id_", "login_email", "other_name"}
+
+
+def test_builtin_id_index_has_fixed_options(durable_index_backend):
+    client = durable_index_backend.open()
+    users = client.app.users
+
+    assert users.create_index("_id") == "_id_"
+    assert users.create_index("_id", name="custom_id") == "_id_"
+    with pytest.raises(OperationFailure, match="not valid") as enabled:
+        users.create_index("_id", unique=True)
+    assert enabled.value.code == 197
+    with pytest.raises(OperationFailure, match="not valid") as disabled:
+        users.create_index("_id", unique=False)
+    assert disabled.value.code == 197
+    assert users.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+
+
+def test_unsupported_index_shapes_types_and_options_leave_no_metadata(
+    durable_index_backend,
+):
+    client = durable_index_backend.open()
+    users = client.app.users
+    unsupported = [
+        ([("first", 1), ("last", 1)], {}),
+        ([("email", -1)], {}),
+        (123, {}),
+        (object(), {}),
+        ("email", {"unique": 1}),
+        ("email", {"name": ""}),
+        ("email", {"sparse": True}),
+        ("email", {"background": True}),
+    ]
+
+    for key, options in unsupported:
+        with pytest.raises(TinyMongoNotSupportedError):
+            users.create_index(key, **options)
+    with pytest.raises(TinyMongoNotSupportedError):
+        users.create_index("email", 1)
+
+    assert users.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+
+
+def test_concurrent_unique_inserts_allow_exactly_one_writer(durable_index_backend):
+    setup = durable_index_backend.open()
+    setup.app.users.create_index("email", unique=True)
+    durable_index_backend.close(setup)
+
+    workers = 4
+    barrier = threading.Barrier(workers)
+
+    def insert(worker):
+        client = tinymongo.TinyMongoClient(
+            durable_index_backend.address,
+            backend=durable_index_backend.backend,
+        )
+        try:
+            barrier.wait(timeout=10)
+            client.app.users.insert_one({"_id": worker, "email": "winner@example.com"})
+            return "inserted"
+        except DuplicateKeyError:
+            return "duplicate"
+        finally:
+            client.close()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(insert, range(workers)))
+
+    assert results.count("inserted") == 1
+    assert results.count("duplicate") == workers - 1
+    reader = durable_index_backend.open()
+    assert reader.app.users.count_documents({}) == 1
+
+
+def test_duckdb_unique_race_across_fresh_processes(tmp_path):
+    pytest.importorskip("duckdb")
+    address = str(tmp_path / "duckdb-process-race")
+    setup = tinymongo.TinyMongoClient(address, backend="duckdb")
+    setup.app.users.create_index("email", unique=True)
+    setup.close()
+
+    start = tmp_path / "start"
+    script = """
+import pathlib
+import sys
+import time
+
+import tinymongo
+from tinymongo.errors import DuplicateKeyError
+
+address, ready, start, worker = sys.argv[1:]
+pathlib.Path(ready).write_text("ready")
+deadline = time.monotonic() + 30
+while not pathlib.Path(start).exists():
+    if time.monotonic() >= deadline:
+        raise RuntimeError("timed out waiting for the race start signal")
+    time.sleep(0.01)
+client = tinymongo.TinyMongoClient(address, backend="duckdb")
+try:
+    client.app.users.insert_one(
+        {"_id": int(worker), "email": "winner@example.com"}
+    )
+    print("inserted")
+except DuplicateKeyError:
+    print("duplicate")
+finally:
+    client.close()
+"""
+    processes = []
+    ready_paths = []
+    for worker in range(4):
+        ready = tmp_path / "ready-{0}".format(worker)
+        ready_paths.append(ready)
+        processes.append(
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    script,
+                    address,
+                    str(ready),
+                    str(start),
+                    str(worker),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+
+    try:
+        deadline = time.monotonic() + 20
+        while not all(path.exists() for path in ready_paths):
+            for process, ready in zip(processes, ready_paths):
+                if not ready.exists() and process.poll() is not None:
+                    stdout, stderr = process.communicate()
+                    pytest.fail(
+                        "DuckDB race worker exited before ready: {0}{1}".format(
+                            stdout, stderr
+                        )
+                    )
+            if time.monotonic() >= deadline:
+                pytest.fail("DuckDB race workers did not become ready")
+            time.sleep(0.01)
+        start.write_text("go")
+
+        results = []
+        for process in processes:
+            stdout, stderr = process.communicate(timeout=30)
+            assert process.returncode == 0, stderr
+            results.append(stdout.strip())
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+        for process in processes:
+            try:
+                process.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate(timeout=5)
+
+    assert results.count("inserted") == 1
+    assert results.count("duplicate") == 3
+    reader = tinymongo.TinyMongoClient(address, backend="duckdb")
+    try:
+        assert reader.app.users.count_documents({}) == 1
+    finally:
+        reader.close()

--- a/tests/test_index_helpers.py
+++ b/tests/test_index_helpers.py
@@ -1,0 +1,282 @@
+import json
+
+import pytest
+
+from tinymongo.errors import DuplicateKeyError, TinyMongoNotSupportedError
+from tinymongo.indexes import (
+    INDEX_METADATA_VERSION,
+    IndexSpec,
+    index_catalog_id,
+    index_tokens,
+    parse_index_spec,
+    validate_unique_documents,
+)
+
+
+def test_catalog_identity_is_unambiguous():
+    assert index_catalog_id("a:b", "c") != index_catalog_id("a", "b:c")
+    assert json.loads(index_catalog_id("café", "名前")) == ["café", "名前"]
+
+
+def test_parse_string_index_uses_canonical_name():
+    spec = parse_index_spec("profile.email")
+
+    assert spec == IndexSpec(
+        field="profile.email",
+        direction=1,
+        unique=False,
+        name="profile.email_1",
+    )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("email", 1),
+        ["email", 1],
+        [("email", 1)],
+        [["email", 1]],
+    ],
+)
+def test_parse_accepts_one_ascending_pair(key):
+    assert parse_index_spec(key).field == "email"
+
+
+def test_parse_normalizes_supported_options():
+    spec = parse_index_spec("email", unique=True, name="login_email")
+
+    assert spec.unique is True
+    assert spec.name == "login_email"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        [],
+        [("first", 1), ("last", 1)],
+        ("email", -1),
+        ("email", "text"),
+        ("email", "hashed"),
+        ("email", True),
+        [("email", 1, "extra")],
+        [(("not-a-string",), 1)],
+        42,
+    ],
+)
+def test_parse_rejects_unsupported_keys(key):
+    with pytest.raises(TinyMongoNotSupportedError):
+        parse_index_spec(key)
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        {"expireAfterSeconds": 10},
+        {"sparse": True},
+        {"partialFilterExpression": {"active": True}},
+        {"collation": {"locale": "en"}},
+        {"wildcardProjection": {"field": 1}},
+        {"background": True},
+    ],
+)
+def test_parse_rejects_unknown_semantic_options(option):
+    with pytest.raises(TinyMongoNotSupportedError, match="Unsupported index option"):
+        parse_index_spec("email", **option)
+
+
+@pytest.mark.parametrize(
+    "field", ["", ".email", "email.", "a..b", "$**", "a.$**", "a\x00b"]
+)
+def test_parse_rejects_invalid_fields(field):
+    with pytest.raises(TinyMongoNotSupportedError):
+        parse_index_spec(field)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"unique": 1},
+        {"name": ""},
+        {"name": 1},
+        {"name": "_id"},
+        {"name": "_id_"},
+    ],
+)
+def test_parse_rejects_invalid_supported_options(options):
+    with pytest.raises(TinyMongoNotSupportedError):
+        parse_index_spec("email", **options)
+
+
+def test_metadata_is_json_safe_and_round_trips():
+    spec = parse_index_spec("profile.email", unique=True, name="profile_login")
+
+    encoded = json.loads(json.dumps(spec.to_metadata()))
+
+    assert encoded == {
+        "v": INDEX_METADATA_VERSION,
+        "name": "profile_login",
+        "key": [["profile.email", 1]],
+        "unique": True,
+    }
+    assert IndexSpec.from_metadata(encoded) == spec
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        {},
+        {"v": 2, "name": "email_1", "key": [["email", 1]], "unique": False},
+        {
+            "v": INDEX_METADATA_VERSION,
+            "name": "email_1",
+            "key": [["email", 1]],
+            "unique": False,
+            "extra": True,
+        },
+    ],
+)
+def test_invalid_metadata_is_rejected(metadata):
+    with pytest.raises(ValueError):
+        IndexSpec.from_metadata(metadata)
+
+
+def test_nested_missing_and_null_values_share_a_token():
+    assert index_tokens({}, "profile.email") == ("null:",)
+    assert index_tokens({"profile": {}}, "profile.email") == ("null:",)
+    assert index_tokens({"profile": {"email": None}}, "profile.email") == ("null:",)
+    assert index_tokens({"profile": "not-an-object"}, "profile.email") == ("null:",)
+
+
+def test_dotted_index_rejects_array_traversal():
+    with pytest.raises(TinyMongoNotSupportedError, match="Array traversal"):
+        index_tokens({"items": [{"sku": "one"}]}, "items.sku")
+
+
+def test_scalar_tokens_are_deterministic_and_type_aware():
+    documents = [
+        {"value": False},
+        {"value": 0},
+        {"value": 0.0},
+        {"value": "0"},
+        {"value": "café"},
+    ]
+
+    tokens = [index_tokens(document, "value")[0] for document in documents]
+
+    assert tokens[1] == tokens[2]
+    assert len(set(tokens)) == len(tokens) - 1
+    assert tokens[-1] == 'string:"café"'
+
+
+def test_arrays_fan_out_and_deduplicate_within_one_document():
+    assert index_tokens({"tags": ["a", "b", "a", None]}, "tags") == (
+        'string:"a"',
+        'string:"b"',
+        "null:",
+    )
+    assert index_tokens({"tags": []}, "tags") == ("undefined:",)
+
+
+def test_unique_validation_treats_equivalent_numbers_as_duplicates():
+    with pytest.raises(DuplicateKeyError):
+        validate_unique_documents(
+            [{"_id": 1, "value": 1}, {"_id": 2, "value": 1.0}],
+            [parse_index_spec("value", unique=True)],
+        )
+
+    with pytest.raises(DuplicateKeyError):
+        validate_unique_documents(
+            [{"_id": 1, "value": 0}, {"_id": 2, "value": -0.0}],
+            [parse_index_spec("value", unique=True)],
+        )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"nested": "object"},
+        [["nested", "array"]],
+        ("tuple",),
+        b"bytes",
+        float("inf"),
+        float("nan"),
+    ],
+)
+def test_unsupported_indexed_values_are_rejected(value):
+    with pytest.raises(TinyMongoNotSupportedError):
+        index_tokens({"value": value}, "value")
+
+
+def test_unique_validation_rejects_duplicate_scalar_post_images():
+    spec = parse_index_spec("email", unique=True)
+
+    with pytest.raises(DuplicateKeyError, match="email_1"):
+        validate_unique_documents(
+            [
+                {"_id": 1, "email": "a@example.com"},
+                {"_id": 2, "email": "a@example.com"},
+            ],
+            [spec],
+        )
+
+
+def test_unique_validation_treats_missing_and_null_as_duplicates():
+    spec = parse_index_spec("email", unique=True)
+
+    with pytest.raises(DuplicateKeyError):
+        validate_unique_documents([{"_id": 1}, {"_id": 2, "email": None}], [spec])
+
+
+def test_unique_validation_applies_array_tokens_across_documents():
+    spec = parse_index_spec("tags", unique=True)
+
+    with pytest.raises(DuplicateKeyError):
+        validate_unique_documents(
+            [{"_id": 1, "tags": ["a", "a"]}, {"_id": 2, "tags": ["a"]}],
+            [spec],
+        )
+
+
+def test_unique_validation_ignores_repeated_array_token_in_same_document():
+    validate_unique_documents(
+        [{"_id": 1, "tags": ["a", "a"]}],
+        [parse_index_spec("tags", unique=True)],
+    )
+
+
+def test_unique_validation_skips_non_unique_specs_and_keeps_types_distinct():
+    validate_unique_documents(
+        [
+            {"_id": 1, "email": "same", "value": True},
+            {"_id": 2, "email": "same", "value": 1},
+        ],
+        [parse_index_spec("email"), parse_index_spec("value", unique=True)],
+    )
+
+
+def test_unique_validation_checks_each_unique_index():
+    documents = [
+        {"_id": 1, "email": "one@example.com", "username": "same"},
+        {"_id": 2, "email": "two@example.com", "username": "same"},
+    ]
+
+    with pytest.raises(DuplicateKeyError, match="username_1"):
+        validate_unique_documents(
+            documents,
+            [
+                parse_index_spec("email", unique=True),
+                parse_index_spec("username", unique=True),
+            ],
+        )
+
+
+def test_unique_validation_rejects_invalid_inputs():
+    with pytest.raises(TypeError, match="IndexSpec"):
+        validate_unique_documents([], ["email"])
+    with pytest.raises(TypeError, match="mappings"):
+        validate_unique_documents(
+            ["not-a-document"], [parse_index_spec("x", unique=True)]
+        )
+    with pytest.raises(TypeError, match="mappings"):
+        index_tokens("not-a-document", "x")

--- a/tests/test_index_models.py
+++ b/tests/test_index_models.py
@@ -1,0 +1,330 @@
+import json
+
+import pytest
+
+from tinymongo.errors import TinyMongoNotSupportedError
+from tinymongo.indexes import (
+    IndexBatchPlan,
+    IndexSpec,
+    TinyMongoUnsupportedWarning,
+    emit_index_plan_warnings,
+    plan_index_model,
+    plan_index_models,
+)
+
+
+class DuckIndexModel:
+    """Minimal stand-in proving the helper does not import PyMongo."""
+
+    def __init__(self, document):
+        self.document = document
+
+
+def test_supported_duck_typed_index_model_produces_an_effective_spec():
+    plan = plan_index_model(
+        DuckIndexModel(
+            {
+                "name": "login_email",
+                "unique": True,
+                "key": {"profile.email": 1},
+            }
+        )
+    )
+
+    assert plan.name == "login_email"
+    assert plan.spec == IndexSpec(
+        field="profile.email", direction=1, unique=True, name="login_email"
+    )
+    assert plan.requested_keys == (("profile.email", 1),)
+    assert dict(plan.requested_options) == {
+        "name": "login_email",
+        "unique": True,
+    }
+    assert plan.degraded_features == ()
+    assert plan.warning is None
+    assert plan.outcome == "create"
+
+
+def test_plain_mapping_and_pair_sequence_are_supported_and_name_is_generated():
+    plan = plan_index_model({"key": [("created", -1)]})
+
+    assert plan.name == "created_-1"
+    assert plan.spec == IndexSpec(field="created", name="created_-1")
+    assert plan.degraded_features == ("descending",)
+
+
+def test_existing_index_spec_passes_through_unchanged():
+    spec = IndexSpec("email", unique=True, name="login")
+
+    plan = plan_index_model(spec)
+
+    assert plan.spec is spec
+    assert plan.name == "login"
+    assert plan.requested_keys == (("email", 1),)
+    assert plan.outcome == "create"
+
+
+@pytest.mark.parametrize(
+    ("document", "feature", "message"),
+    [
+        ({"key": {"created": -1}}, "descending", "treated as ascending"),
+        ({"key": {"token": "hashed"}}, "hashed", "ascending equality"),
+        ({"key": {"email": 1}, "sparse": True}, "sparse", "not honored"),
+        (
+            {"key": {"created": 1}, "expireAfterSeconds": 0},
+            "ttl",
+            "TTL expiration",
+        ),
+        (
+            {"key": {"email": 1}, "background": True},
+            "background",
+            "background creation",
+        ),
+    ],
+)
+def test_single_field_performance_declarations_create_a_degraded_index(
+    document, feature, message
+):
+    plan = plan_index_model(document)
+
+    assert plan.spec == IndexSpec(document["key"].copy().popitem()[0], name=plan.name)
+    assert plan.degraded_features == (feature,)
+    assert plan.outcome == "create_degraded"
+    assert message in plan.warning
+
+
+def test_false_performance_flags_require_no_degradation():
+    plan = plan_index_model({"key": {"email": 1}, "sparse": False, "background": False})
+
+    assert plan.outcome == "create"
+    assert plan.degraded_features == ()
+    assert plan.warning is None
+
+
+def test_nonunique_text_index_is_accepted_as_a_warned_noop():
+    plan = plan_index_model({"key": {"content": "text"}, "name": "content_text"})
+
+    assert plan.name == "content_text"
+    assert plan.spec is None
+    assert plan.outcome == "skip"
+    assert plan.degraded_features == ("text",)
+    assert "$text queries are not supported" in plan.warning
+    assert plan.to_metadata()["effective_spec"] is None
+
+
+def test_nonunique_compound_model_degrades_to_an_ascending_leading_field():
+    plan = plan_index_model(
+        DuckIndexModel(
+            {
+                "name": "account_recent",
+                "key": {"account_id": 1, "created": -1},
+                "sparse": True,
+                "expireAfterSeconds": 60,
+                "background": True,
+            }
+        )
+    )
+
+    assert plan.name == "account_recent"
+    assert plan.spec == IndexSpec(field="account_id", name="account_recent")
+    assert plan.outcome == "create_degraded"
+    assert plan.degraded_features == (
+        "compound",
+        "descending",
+        "sparse",
+        "ttl",
+        "background",
+    )
+    assert "created with reduced behavior" in plan.warning
+    assert "ascending leading field" in plan.warning
+    assert "descending direction" in plan.warning
+    assert "sparse membership" in plan.warning
+    assert "TTL expiration" in plan.warning
+    assert "background creation" in plan.warning
+
+    metadata = plan.to_metadata()
+    assert metadata["requested_key"] == [
+        ["account_id", 1],
+        ["created", -1],
+    ]
+    assert metadata["outcome"] == "create_degraded"
+    assert metadata["effective_spec"] == {
+        "v": 1,
+        "name": "account_recent",
+        "key": [["account_id", 1]],
+        "unique": False,
+    }
+    assert json.loads(json.dumps(metadata)) == metadata
+
+
+def test_compound_default_name_matches_pymongo_shape():
+    plan = plan_index_model({"key": [("account", 1), ("created", -1)]})
+
+    assert plan.name == "account_1_created_-1"
+
+
+def test_degraded_effective_spec_is_included_in_metadata():
+    plan = plan_index_model(
+        {"key": {"email": 1}, "name": "maybe_email", "sparse": True}
+    )
+
+    assert plan.to_metadata()["effective_spec"] == {
+        "v": 1,
+        "name": "maybe_email",
+        "key": [["email", 1]],
+        "unique": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("document", "feature"),
+    [
+        ({"key": {"first": 1, "last": 1}, "unique": True}, "compound"),
+        ({"key": {"email": "hashed"}, "unique": True}, "hashed"),
+        ({"key": {"content": "text"}, "unique": True}, "text"),
+        ({"key": {"email": 1}, "unique": True, "sparse": True}, "sparse"),
+        (
+            {"key": {"created": 1}, "unique": True, "expireAfterSeconds": 60},
+            "ttl",
+        ),
+    ],
+)
+def test_unique_semantic_combinations_are_rejected(document, feature):
+    with pytest.raises(
+        TinyMongoNotSupportedError,
+        match="cannot be degraded.*{0}".format(feature),
+    ):
+        plan_index_model(document)
+
+
+def test_unique_descending_and_background_flags_preserve_uniqueness():
+    plan = plan_index_model(
+        {
+            "key": {"email": -1},
+            "name": "unique_email_desc",
+            "unique": True,
+            "background": True,
+        }
+    )
+
+    assert plan.spec == IndexSpec("email", unique=True, name="unique_email_desc")
+    assert plan.degraded_features == ("descending", "background")
+
+
+@pytest.mark.parametrize(
+    ("model", "message"),
+    [
+        (object(), "expose a mapping-valued document"),
+        (DuckIndexModel([]), "document must be a mapping"),
+    ],
+)
+def test_invalid_index_model_containers_are_rejected(model, message):
+    with pytest.raises(TypeError, match=message):
+        plan_index_model(model)
+
+
+@pytest.mark.parametrize(
+    ("document", "message"),
+    [
+        ({}, "contain a key"),
+        ({"key": 42}, "mapping or sequence"),
+        ({"key": {}}, "at least one field"),
+        ({"key": [("email",)]}, "pairs"),
+        ({"key": [(42, 1)]}, "non-empty strings"),
+        ({"key": {"email": True}}, "directions"),
+        ({"key": {"email": "2dsphere"}}, "directions"),
+    ],
+)
+def test_invalid_index_model_keys_are_rejected(document, message):
+    with pytest.raises(TinyMongoNotSupportedError, match=message):
+        plan_index_model(document)
+
+
+@pytest.mark.parametrize(
+    ("document", "message"),
+    [
+        ({"key": {"email": 1}, "collation": {"locale": "en"}}, "option"),
+        ({"key": {"email": 1}, "unique": 1}, "unique"),
+        ({"key": {"email": 1}, "sparse": 1}, "sparse"),
+        ({"key": {"email": 1}, "background": 1}, "background"),
+        ({"key": {"email": 1}, "expireAfterSeconds": True}, "non-negative"),
+        ({"key": {"email": 1}, "expireAfterSeconds": "60"}, "non-negative"),
+        ({"key": {"email": 1}, "expireAfterSeconds": -1}, "non-negative"),
+        (
+            {"key": {"email": 1}, "expireAfterSeconds": float("inf")},
+            "non-negative",
+        ),
+        ({"key": {"email": 1}, "name": ""}, "non-empty strings"),
+        ({"key": {"email": 1}, "name": "_id_"}, "reserved"),
+    ],
+)
+def test_invalid_index_model_options_are_rejected(document, message):
+    with pytest.raises(TinyMongoNotSupportedError, match=message):
+        plan_index_model(document)
+
+
+def test_valid_fractional_ttl_is_acknowledged_with_a_warning():
+    plan = plan_index_model({"key": {"created": 1}, "expireAfterSeconds": 0.5})
+
+    assert plan.degraded_features == ("ttl",)
+
+
+def test_batch_plan_preserves_order_and_separates_effective_specs():
+    supported = DuckIndexModel({"key": {"email": 1}, "unique": True})
+    skipped = DuckIndexModel({"key": {"tenant": 1, "created": -1}})
+    degraded = DuckIndexModel({"key": {"token": "hashed"}})
+
+    batch = plan_index_models(model for model in (supported, skipped, degraded))
+
+    assert isinstance(batch, IndexBatchPlan)
+    assert tuple(batch) == batch.entries
+    assert batch.names == ("email_1", "tenant_1_created_-1", "token_hashed")
+    assert tuple(spec.name for spec in batch.specs) == (
+        "email_1",
+        "tenant_1_created_-1",
+        "token_hashed",
+    )
+    assert len(batch.warnings) == 2
+    assert "tenant_1_created_-1" in batch.warnings[0]
+    assert "token_hashed" in batch.warnings[1]
+
+
+def test_batch_planner_accepts_an_empty_batch():
+    batch = plan_index_models([])
+
+    assert batch.entries == ()
+    assert batch.names == ()
+    assert batch.specs == ()
+    assert batch.warnings == ()
+
+
+def test_batch_planner_rejects_a_noniterable():
+    with pytest.raises(TypeError, match="must be an iterable"):
+        plan_index_models(None)
+
+
+def test_batch_planner_preserves_model_type_errors():
+    with pytest.raises(TypeError, match="expose a mapping-valued document"):
+        plan_index_models([object()])
+
+
+def test_warning_emitter_uses_the_dedicated_warning_type():
+    batch = plan_index_models(
+        [
+            {"key": {"email": 1}},
+            {"key": {"created": -1}},
+            {"key": {"token": "hashed"}},
+        ]
+    )
+
+    with pytest.warns(TinyMongoUnsupportedWarning) as captured:
+        emit_index_plan_warnings(batch)
+
+    assert len(captured) == 2
+    assert "created_-1" in str(captured[0].message)
+    assert "token_hashed" in str(captured[1].message)
+
+
+def test_warning_emitter_requires_a_batch_plan():
+    with pytest.raises(TypeError, match="IndexBatchPlan"):
+        emit_index_plan_warnings(())

--- a/tests/test_memory_backend.py
+++ b/tests/test_memory_backend.py
@@ -202,7 +202,7 @@ def test_named_clients_share_collection_lifecycle_and_local_index_behavior():
     collection = writer.app.items
     try:
         collection.insert_one({"_id": 1, "name": "Ada"})
-        assert collection.create_index("name") == "name"
+        assert collection.create_index("name") == "name_1"
         assert {index["name"] for index in collection.list_indexes()} == {
             "_id_",
             "name_1",
@@ -372,6 +372,38 @@ def test_stale_cleanup_does_not_remove_a_replacement_memory_entry():
 
     try:
         storage_backends.clear_memory_namespace(namespace)
+        with storage_backends._memory_registry_lock:
+            assert storage_backends._memory_registry[address] is replacement
+    finally:
+        with storage_backends._memory_registry_lock:
+            storage_backends._memory_registry.pop(address, None)
+
+
+def test_clear_memory_database_handles_missing_and_replaced_entries():
+    address = "memory://clear-database-{0}/app".format(uuid4().hex)
+
+    storage_backends.clear_memory_database(address)
+
+    replacement = {
+        "data": {"items": {"1": {"_id": "replacement"}}},
+        "revision": 1,
+        "lock": storage_backends.threading.RLock(),
+    }
+
+    class ReplaceEntryOnAcquire:
+        def __enter__(self):
+            with storage_backends._memory_registry_lock:
+                storage_backends._memory_registry[address] = replacement
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    stale = {"data": None, "revision": 0, "lock": ReplaceEntryOnAcquire()}
+    with storage_backends._memory_registry_lock:
+        storage_backends._memory_registry[address] = stale
+
+    try:
+        storage_backends.clear_memory_database(address)
         with storage_backends._memory_registry_lock:
             assert storage_backends._memory_registry[address] is replacement
     finally:

--- a/tests/test_mongo_like.py
+++ b/tests/test_mongo_like.py
@@ -59,9 +59,8 @@ def test_projection_like():
     c = client.db.collection
 
     c.insert_one({"_id": "p", "a": 1, "b": 2, "c": 3})
-    doc = c.find_one({"_id": "p"})
-    # projection not implemented; ensure full doc available
-    assert set(doc.keys()) >= {"_id", "a", "b", "c"}
+    doc = c.find_one({"_id": "p"}, {"a": 1, "_id": 0})
+    assert doc == {"a": 1}
 
 
 def test_find_and_modify_semantics():

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -1,0 +1,284 @@
+import asyncio
+import pymongo
+import pytest
+import threading
+
+import tinymongo
+from tinymongo import patching, storage_backends
+
+
+def test_patch_context_uses_shared_isolated_memory_and_restores_client():
+    original = pymongo.MongoClient
+
+    with tinymongo.patch() as patched_client:
+        assert pymongo.MongoClient is patched_client
+
+        first = pymongo.MongoClient(
+            "mongodb://production.example",
+            backend="sqlite",
+            tinymongo_folder="ignored",
+        )
+        second = pymongo.MongoClient()
+        namespace = first._memory_namespace
+
+        assert isinstance(first, tinymongo.MongoClient)
+        assert first.server_info()["storage"] == "memory"
+        assert namespace == second._memory_namespace
+        assert namespace.startswith("memory://__tinymongo_patch__")
+
+        first.app.items.insert_one({"_id": "shared", "value": 42})
+        assert second.app.items.find_one({"_id": "shared"})["value"] == 42
+        first.close()
+        second.close()
+
+    assert pymongo.MongoClient is original
+    prefix = namespace.rstrip("/") + "/"
+    assert not any(
+        address.startswith(prefix) for address in storage_backends._memory_registry
+    )
+
+
+def test_patch_restores_client_when_body_raises():
+    original = pymongo.MongoClient
+
+    with pytest.raises(RuntimeError, match="application failed"):
+        with tinymongo.patch():
+            assert pymongo.MongoClient is not original
+            raise RuntimeError("application failed")
+
+    assert pymongo.MongoClient is original
+
+
+def test_patch_decorator_uses_explicit_folder_and_backend(tmp_path):
+    original = pymongo.MongoClient
+    folder = str(tmp_path / "patched-sqlite")
+
+    @tinymongo.patch(folder=folder, backend="sqlite")
+    def write_item(item_id):
+        client = pymongo.MongoClient(
+            "mongodb://ignored.example",
+            backend="memory",
+            tinymongo_folder="also-ignored",
+        )
+        try:
+            client.app.items.insert_one({"_id": item_id})
+            return client._foldername, client._backend
+        finally:
+            client.close()
+
+    assert write_item(1) == (folder, "sqlite")
+    assert pymongo.MongoClient is original
+    assert write_item(2) == (folder, "sqlite")
+    assert pymongo.MongoClient is original
+
+    reader = tinymongo.TinyMongoClient(folder, backend="sqlite")
+    try:
+        assert reader.app.items.count_documents({}) == 2
+    finally:
+        reader.close()
+
+
+def test_same_patch_object_can_be_nested_safely():
+    original = pymongo.MongoClient
+    patcher = tinymongo.patch()
+
+    with patcher:
+        outer_client_class = pymongo.MongoClient
+        outer = pymongo.MongoClient()
+        outer.app.items.insert_one({"_id": "outer"})
+
+        with patcher:
+            assert pymongo.MongoClient is not outer_client_class
+            inner = pymongo.MongoClient()
+            assert inner.app.items.find_one({"_id": "outer"}) is None
+            inner.close()
+
+        assert pymongo.MongoClient is outer_client_class
+        assert outer.app.items.find_one({"_id": "outer"}) is not None
+        outer.close()
+
+    assert pymongo.MongoClient is original
+
+
+def test_patch_scopes_must_exit_in_nested_order():
+    original = pymongo.MongoClient
+    outer = tinymongo.patch()
+    inner = tinymongo.patch()
+    outer_client = outer.__enter__()
+    inner_client = inner.__enter__()
+
+    try:
+        with pytest.raises(RuntimeError, match="must exit in nested order"):
+            outer.__exit__(None, None, None)
+        assert pymongo.MongoClient is inner_client
+    finally:
+        inner.__exit__(None, None, None)
+        assert pymongo.MongoClient is outer_client
+        outer.__exit__(None, None, None)
+
+    assert pymongo.MongoClient is original
+    assert patching._patch_entries == []
+    assert patching._patch_owner is None
+
+
+def test_non_memory_patch_without_folder_uses_default_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with tinymongo.patch(backend="sqlite"):
+        client = pymongo.MongoClient()
+        try:
+            assert client._foldername == "tinydb"
+            assert client._backend == "sqlite"
+        finally:
+            client.close()
+
+
+def test_patch_imports_pymongo_only_when_entered(monkeypatch):
+    calls = []
+
+    def missing_pymongo(name):
+        calls.append(name)
+        raise ModuleNotFoundError("No module named 'pymongo'", name="pymongo")
+
+    monkeypatch.setattr(patching.importlib, "import_module", missing_pymongo)
+    patcher = tinymongo.patch()
+
+    assert calls == []
+    with pytest.raises(ImportError, match="pip install pymongo"):
+        with patcher:
+            pass
+    assert calls == ["pymongo"]
+
+
+def test_overlapping_patch_scopes_in_different_threads_are_rejected():
+    original = pymongo.MongoClient
+    entered = threading.Event()
+    release = threading.Event()
+    errors = []
+
+    def hold_patch():
+        with tinymongo.patch():
+            entered.set()
+            release.wait(timeout=5)
+
+    thread = threading.Thread(target=hold_patch)
+    thread.start()
+    assert entered.wait(timeout=5)
+    try:
+        with pytest.raises(RuntimeError, match="cannot overlap across threads"):
+            with tinymongo.patch():
+                pass
+    except Exception as error:  # pragma: no cover - diagnostic cleanup
+        errors.append(error)
+    finally:
+        release.set()
+        thread.join(timeout=5)
+
+    assert not errors
+    assert not thread.is_alive()
+    assert pymongo.MongoClient is original
+
+
+def test_overlapping_patch_scopes_in_different_async_tasks_are_rejected():
+    original = pymongo.MongoClient
+
+    async def scenario():
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def hold_patch():
+            async with tinymongo.patch():
+                entered.set()
+                await release.wait()
+
+        async def attempt_overlap():
+            await entered.wait()
+            with pytest.raises(RuntimeError, match="cannot overlap"):
+                async with tinymongo.patch():
+                    pass
+            release.set()
+
+        await asyncio.gather(hold_patch(), attempt_overlap())
+
+    asyncio.run(scenario())
+
+    assert pymongo.MongoClient is original
+    assert patching._patch_entries == []
+    assert patching._patch_owner is None
+
+
+def test_clients_created_by_patch_are_closed_at_scope_exit():
+    with tinymongo.patch():
+        client = pymongo.MongoClient()
+        client.app.items.insert_one({"_id": 1})
+
+    with pytest.raises(tinymongo.InvalidOperation, match="closed"):
+        client.app.items.find_one({"_id": 1})
+
+
+def test_async_decorators_fail_clearly():
+    with pytest.raises(TypeError, match="does not decorate async functions"):
+
+        @tinymongo.patch()
+        async def async_test():
+            return True
+
+
+def test_patch_async_context_routes_and_restores_async_client():
+    original_sync = pymongo.MongoClient
+    original_async = pymongo.AsyncMongoClient
+
+    async def scenario():
+        async with tinymongo.patch() as patched_sync:
+            assert pymongo.MongoClient is patched_sync
+            assert pymongo.AsyncMongoClient is not original_async
+            client = pymongo.AsyncMongoClient("mongodb://production.example")
+            await client.app.items.insert_one({"_id": "async", "value": 42})
+            assert await client.app.items.find_one({"_id": "async"}) == {
+                "_id": "async",
+                "value": 42,
+            }
+        assert client._state.closed is True
+
+    asyncio.run(scenario())
+    assert pymongo.MongoClient is original_sync
+    assert pymongo.AsyncMongoClient is original_async
+
+
+def test_patch_supports_pymongo_without_an_async_client(monkeypatch):
+    """Older PyMongo releases only expose the synchronous client."""
+
+    original_sync = pymongo.MongoClient
+    monkeypatch.delattr(pymongo, "AsyncMongoClient")
+
+    with tinymongo.patch() as patched_sync:
+        assert pymongo.MongoClient is patched_sync
+        assert not hasattr(pymongo, "AsyncMongoClient")
+
+    assert pymongo.MongoClient is original_sync
+    assert not hasattr(pymongo, "AsyncMongoClient")
+
+
+def test_sync_patch_context_closes_async_clients():
+    with tinymongo.patch():
+        client = pymongo.AsyncMongoClient()
+        assert client._state.closed is False
+
+    assert client._state.closed is True
+
+
+def test_async_patch_context_closes_sync_clients():
+    async def scenario():
+        async with tinymongo.patch():
+            client = pymongo.MongoClient()
+            client.app.items.insert_one({"_id": "sync-in-async"})
+
+        with pytest.raises(tinymongo.InvalidOperation, match="closed"):
+            client.app.items.find_one({"_id": "sync-in-async"})
+
+    asyncio.run(scenario())
+
+
+def test_patch_exit_without_entry_fails_clearly():
+    with pytest.raises(RuntimeError, match="without being entered"):
+        tinymongo.patch().__exit__(None, None, None)

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,268 @@
+import pytest
+
+import tinymongo as tm
+from tinymongo.errors import OperationFailure, TinyMongoNotSupportedError
+from tinymongo.projection import normalize_projection, project_document
+
+
+@pytest.fixture
+def collection():
+    client = tm.TinyMongoClient(backend="memory")
+    collection = client.app.items
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "name": "Ada",
+                "secret": "x",
+                "score": 7,
+                "profile": {"email": "ada@example.com", "age": 36},
+                "items": [
+                    {"sku": "a", "qty": 1},
+                    {"qty": 2},
+                    {},
+                    "scalar",
+                    None,
+                ],
+            },
+            {
+                "_id": 2,
+                "name": "Grace",
+                "score": 9,
+                "profile": {"age": 40},
+                "items": [],
+            },
+            {"_id": 3, "name": "Lin", "score": 8, "profile": "unknown"},
+        ]
+    )
+    try:
+        yield collection
+    finally:
+        client.close()
+
+
+def test_projection_inclusion_sequences_and_id_rules(collection):
+    assert list(collection.find({}, {"name": 1}).sort("_id", 1)) == [
+        {"_id": 1, "name": "Ada"},
+        {"_id": 2, "name": "Grace"},
+        {"_id": 3, "name": "Lin"},
+    ]
+    assert collection.find_one({"_id": 1}, ["name"]) == {
+        "_id": 1,
+        "name": "Ada",
+    }
+    assert collection.find_one({"_id": 1}, ("name",)) == {
+        "_id": 1,
+        "name": "Ada",
+    }
+    assert collection.find_one({"_id": 1}, ["name", "name"]) == {
+        "_id": 1,
+        "name": "Ada",
+    }
+    assert collection.find_one({"_id": 1}, {"name"}) == {
+        "_id": 1,
+        "name": "Ada",
+    }
+    assert collection.find_one({"_id": 1}, {"name": 2, "_id": 0}) == {"name": "Ada"}
+    assert collection.find_one({"_id": 1}, {"_id": 1}) == {"_id": 1}
+    assert collection.find_one({"_id": 1}, {"_id": 0}) == {
+        "name": "Ada",
+        "secret": "x",
+        "score": 7,
+        "profile": {"email": "ada@example.com", "age": 36},
+        "items": [
+            {"sku": "a", "qty": 1},
+            {"qty": 2},
+            {},
+            "scalar",
+            None,
+        ],
+    }
+
+
+def test_projection_exclusion_nested_paths_and_id_rules(collection):
+    projected = collection.find_one(
+        {"_id": 1}, {"secret": 0, "profile.age": 0, "_id": 1}
+    )
+    assert projected == {
+        "_id": 1,
+        "name": "Ada",
+        "score": 7,
+        "profile": {"email": "ada@example.com"},
+        "items": [
+            {"sku": "a", "qty": 1},
+            {"qty": 2},
+            {},
+            "scalar",
+            None,
+        ],
+    }
+    assert "missing" not in collection.find_one({"_id": 2}, {"missing": 0})
+
+
+def test_nested_inclusion_merges_siblings_and_projects_arrays(collection):
+    assert collection.find_one(
+        {"_id": 1}, {"profile.email": 1, "profile.age": 1, "_id": 0}
+    ) == {"profile": {"email": "ada@example.com", "age": 36}}
+    assert collection.find_one({"_id": 1}, {"profile": {"email": 1}}) == {
+        "_id": 1,
+        "profile": {"email": "ada@example.com"},
+    }
+    assert collection.find_one({"_id": 2}, {"profile.email": 1}) == {
+        "_id": 2,
+        "profile": {},
+    }
+    assert collection.find_one({"_id": 3}, {"profile.email": 1}) == {"_id": 3}
+    assert collection.find_one({"_id": 1}, {"items.sku": 1}) == {
+        "_id": 1,
+        "items": [{"sku": "a"}, {}, {}],
+    }
+    assert collection.find_one({"_id": 1}, {"items.sku": 0})["items"] == [
+        {"qty": 1},
+        {"qty": 2},
+        {},
+        "scalar",
+        None,
+    ]
+
+
+def test_nested_id_projection_follows_regular_path_semantics(collection):
+    full = collection.find_one({"_id": 1})
+
+    assert collection.find_one({"_id": 1}, {"_id.missing": 1}) == {}
+    assert collection.find_one({"_id": 1}, {"_id.missing": 0}) == full
+    assert project_document(
+        {"_id": {"value": 1, "other": 2}, "name": "Ada"},
+        normalize_projection({"_id.value": 1}),
+    ) == {"_id": {"value": 1}}
+    assert project_document({"name": "Ada"}, normalize_projection({"name": 1})) == {
+        "name": "Ada"
+    }
+
+
+def test_projection_is_applied_after_sort_and_on_every_cursor_access(collection):
+    cursor = collection.find({}, {"name": 1}).sort("score", -1)
+    assert cursor.next() == {"_id": 2, "name": "Grace"}
+    assert cursor[1] == {"_id": 3, "name": "Lin"}
+
+    cursor = collection.find({}, {"name": 1}, sort=[("score", 1)])
+    assert list(cursor) == [
+        {"_id": 1, "name": "Ada"},
+        {"_id": 3, "name": "Lin"},
+        {"_id": 2, "name": "Grace"},
+    ]
+    cursor = collection.find({"name": "Ada"}, {"name": 1})
+    assert cursor[0] == {"_id": 1, "name": "Ada"}
+    assert cursor["name"] == "Ada"
+
+
+def test_projection_works_with_index_fast_path_and_is_mutation_safe(collection):
+    collection.create_index("name")
+    result = collection.find_one({"name": "Ada"}, {"profile.email": 1})
+    result["profile"]["email"] = "changed@example.com"
+
+    assert collection.find_one({"name": "Ada"})["profile"]["email"] == (
+        "ada@example.com"
+    )
+    assert list(collection.find({"name": "Ada"}, {"name": 1})) == [
+        {"_id": 1, "name": "Ada"}
+    ]
+
+
+def test_empty_projection_filter_alias_and_capability(collection):
+    full = collection.find_one({"_id": 1})
+    assert collection.find_one(filter={"_id": 1}, projection={}) == full
+    assert collection.find_one({"_id": 1}, []) == full
+    assert list(collection.find(filter={"_id": 1}, projection=[])) == [full]
+    assert collection.parent.database == "app"
+    assert tm.TinyMongoClient(backend="memory").capabilities()["projections"] is True
+
+
+@pytest.mark.parametrize(
+    "projection,code",
+    [
+        ({"name": 1, "secret": 0}, 31254),
+        ({"secret": 0, "name": 1}, 31253),
+        ({"profile": 1, "profile.email": 1}, 31249),
+        ({"profile.email": 1, "profile": 1}, 31250),
+        ({"profile": 1, "profile.email": 0}, 31249),
+        ({"profile.email": 0, "profile": 1}, 31250),
+        ({"_id": 1, "_id.value": 1}, 31249),
+        ({"_id.value": 1, "_id": 1}, 31250),
+        ({"_id": 0, "_id.value": 1}, 31249),
+        ({"profile": {"email": 1}, "profile.email": 1}, 31250),
+        ({"profile.email": 1, "profile": {"email": 1}}, 31250),
+    ],
+)
+def test_invalid_projection_combinations_raise_operation_failure(
+    collection, projection, code
+):
+    with pytest.raises(OperationFailure) as error:
+        list(collection.find({}, projection))
+    assert error.value.code == code
+
+
+@pytest.mark.parametrize("projection", [42, "name", ["name", 1], {1: 1}])
+def test_projection_requires_a_mapping_or_string_field_sequence(projection):
+    with pytest.raises(TypeError):
+        normalize_projection(projection)
+
+
+@pytest.mark.parametrize("projection", [{"": 1}, {"a..b": 1}, {"bad\x00key": 1}])
+def test_invalid_projection_paths_raise_operation_failure(projection):
+    with pytest.raises(OperationFailure):
+        normalize_projection(projection)
+
+
+@pytest.mark.parametrize(
+    "projection",
+    [
+        {"items.0.sku": 1},
+        {"items.$": 1},
+        {"name": {"$meta": "textScore"}},
+        {"name": {}},
+        {"name": "$other"},
+        {"name": None},
+        {"name": [1]},
+    ],
+)
+def test_unsupported_projection_expressions_fail_clearly(projection):
+    with pytest.raises(TinyMongoNotSupportedError):
+        normalize_projection(projection)
+
+
+def test_projector_handles_nested_arrays_and_scalar_branches():
+    document = {
+        "_id": 1,
+        "groups": [[], [{"name": "a", "other": 1}], "scalar"],
+        "scalar": "value",
+        "parent": {"scalar": "value", "kept": {"name": "yes"}},
+    }
+    spec = normalize_projection(
+        {
+            "groups.name": 1,
+            "scalar.child": 1,
+            "missing.child": 1,
+            "parent.scalar.child": 1,
+            "parent.kept.name": 1,
+        }
+    )
+    assert project_document(document, spec) == {
+        "_id": 1,
+        "groups": [[], [{"name": "a"}]],
+        "parent": {"kept": {"name": "yes"}},
+    }
+    assert project_document(None, spec) is None
+
+
+def test_projector_exclusion_skips_missing_and_scalar_branches():
+    document = {
+        "_id": 1,
+        "secret": "x",
+        "profile": "unknown",
+    }
+    spec = normalize_projection({"missing": 0, "secret": 0, "profile.email": 0})
+    assert project_document(document, spec) == {
+        "_id": 1,
+        "profile": "unknown",
+    }

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -168,7 +168,7 @@ def test_unsupported_features_fail_loudly(tmp_path):
             call([])
 
     with pytest.raises(TinyMongoNotSupportedError, match="single-field"):
-        collection.create_index([("email", 1)])
+        collection.create_index([("email", 1), ("name", 1)])
     with pytest.raises(TinyMongoNotSupportedError, match="concerns"):
         collection.with_options(type("Concern", (), {"document": {"w": 2}})())
 

--- a/tests/test_query_more.py
+++ b/tests/test_query_more.py
@@ -55,6 +55,33 @@ def test_update_many_applies_to_all_matches():
     assert c.find({"active": True}).count() == 2
 
 
+def test_write_filters_share_regex_options_semantics():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    c = client.db.collection
+    c.insert_many(
+        [
+            {"_id": 1, "name": "Alpha"},
+            {"_id": 2, "name": "amber"},
+            {"_id": 3, "name": "Beta"},
+        ]
+    )
+    starts_with_a = {"name": {"$regex": "^a", "$options": "i"}}
+
+    one = c.update_one(starts_with_a, {"$set": {"first": True}})
+    many = c.update_many(starts_with_a, {"$set": {"matched": True}})
+    replacement = c.replace_one(
+        {"name": {"$regex": "^b", "$options": "i"}},
+        {"name": "Replaced"},
+    )
+
+    assert one.matched_count == 1
+    assert many.matched_count == 2
+    assert {doc["_id"] for doc in c.find({"matched": True})} == {1, 2}
+    assert replacement.matched_count == 1
+    assert c.find_one({"_id": 3}) == {"_id": 3, "name": "Replaced"}
+
+
 def test_replace_one_replaces_single_document():
     setup_db()
     client = tm.TinyMongoClient(DB_DIR)
@@ -259,15 +286,32 @@ def test_collection_indexes_accelerate_equality_queries():
         ]
     )
 
-    assert c.create_index("email") == "email"
+    assert c.create_index("email") == "email_1"
+    assert c.create_index("secondary") == "secondary_1"
     assert {"name": "email_1", "key": [("email", 1)]} in c.list_indexes()
     assert c.find({"email": "b@example.com"})[0]["_id"] == 2
 
     c.update_one({"_id": 2}, {"$set": {"email": "c@example.com"}})
     assert c.find({"email": "c@example.com"})[0]["_id"] == 2
 
+    # A fresh collection handle exercises durable index loading before a drop;
+    # choosing the second index also verifies name/field lookup traversal.
+    client.db.collection.drop_index("secondary")
     c.drop_index("email")
     assert c.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+
+
+def test_equality_index_deduplicates_repeated_array_values():
+    setup_db()
+    client = tm.TinyMongoClient(DB_DIR)
+    collection = client.db.collection
+    collection.insert_one({"_id": 1, "tags": ["same", "same"]})
+
+    assert len(list(collection.find({"tags": "same"}))) == 1
+    collection.create_index("tags")
+    assert list(collection.find({"tags": "same"})) == [
+        {"_id": 1, "tags": ["same", "same"]}
+    ]
 
 
 def test_index_cache_is_invalidated_after_insert_and_delete():

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -7,7 +7,13 @@ import sys
 from types import SimpleNamespace
 
 import tinymongo as tm
-from tinymongo.errors import DuplicateKeyError
+from tinymongo.errors import (
+    DuplicateKeyError,
+    OperationFailure,
+    StorageCorruptionError,
+    TinyMongoNotSupportedError,
+)
+from tinymongo.indexes import parse_index_spec
 from tinymongo.table_backends import (
     DuckDBTableBackend,
     MySQLTableBackend,
@@ -22,9 +28,18 @@ from tinymongo.table_backends import (
     _duckdb_setup_sql_from_env,
     _import_optional_driver,
     _is_object_store_uri,
+    _json_loads,
     _join_uri,
+    _reject_remote_unique_arrays,
     matches_filter,
+    requires_python_filter,
 )
+
+
+def test_json_loader_accepts_remote_driver_decoded_documents():
+    document = {"_id": 1, "nested": {"value": True}}
+
+    assert _json_loads(document) is document
 
 
 def test_successful_filter_operator_branches():
@@ -47,7 +62,8 @@ def test_successful_filter_operator_branches():
 
     sql, params = SQLCompiler("sqlite").compile({"missing": {"$exists": True}})
     assert "NOT (" not in sql
-    assert params == ["$.missing"]
+    assert "$" in sql and "missing" in sql
+    assert params == []
 
 
 def test_backend_noop_update_and_object_store_initialization(tmp_path):
@@ -57,6 +73,8 @@ def test_backend_noop_update_and_object_store_initialization(tmp_path):
 
     object_backend = TableBackend("s3://bucket/db")
     assert object_backend.path == "s3://bucket/db"
+    with object_backend._write_lock():
+        assert object_backend.path == "s3://bucket/db"
 
 
 def test_legacy_migration_empty_collection_branches(tmp_path):
@@ -89,6 +107,8 @@ class FakeRemoteStore:
     def __init__(self):
         self.tables = {}
         self.metadata = set()
+        self.indexes = {}
+        self.index_ddl = []
 
 
 class FakeRemoteCursor:
@@ -101,12 +121,29 @@ class FakeRemoteCursor:
         upper = normalized.upper()
         if upper.startswith("CREATE TABLE"):
             table = self._table_from_create(normalized)
-            if "TINYMONGO_COLLECTIONS" not in table:
+            if "TINYMONGO_" not in table.upper():
                 self.store.tables.setdefault(table, {})
+        elif upper.startswith(("CREATE INDEX", "CREATE UNIQUE INDEX")):
+            self.store.index_ddl.append(normalized)
+        elif upper.startswith(("ALTER TABLE", "DROP INDEX")):
+            self.store.index_ddl.append(normalized)
+        elif upper.startswith("INSERT") and "TINYMONGO_INDEXES" in upper:
+            database, collection, name, field, unique = params
+            self.store.indexes[(database, collection, name)] = (field, bool(unique))
         elif upper.startswith("INSERT") and "TINYMONGO_COLLECTIONS" in upper:
             self.store.metadata.add(tuple(params))
         elif upper.startswith("SELECT DISTINCT"):
             self.rows = sorted({(database,) for database, _ in self.store.metadata})
+        elif upper.startswith("SELECT INDEX_NAME"):
+            database, collection = params
+            self.rows = sorted(
+                (name, field, unique)
+                for (index_database, index_collection, name), (
+                    field,
+                    unique,
+                ) in self.store.indexes.items()
+                if index_database == database and index_collection == collection
+            )
         elif upper.startswith("SELECT COLLECTION_NAME"):
             database = params[0]
             self.rows = sorted(
@@ -120,6 +157,19 @@ class FakeRemoteCursor:
             )
         elif upper.startswith("DELETE FROM") and "TINYMONGO_COLLECTIONS" in upper:
             self.store.metadata.discard(tuple(params))
+        elif upper.startswith("DELETE FROM") and "TINYMONGO_INDEXES" in upper:
+            if len(params) == 2:
+                database, collection = params
+                names = [
+                    key
+                    for key in self.store.indexes
+                    if key[:2] == (database, collection)
+                ]
+                for key in names:
+                    self.store.indexes.pop(key, None)
+            else:
+                database, collection, name = params
+                self.store.indexes.pop((database, collection, name), None)
         elif upper.startswith("DELETE FROM"):
             self.store.tables.setdefault(self._table_after(normalized, "FROM"), {}).pop(
                 params[0], None
@@ -218,12 +268,53 @@ def test_matches_filter_operator_edges():
     assert not matches_filter(doc, {"name": {"$unknown": "Ada"}})
 
 
+def test_array_equality_supports_exact_arrays_and_scalar_membership():
+    document = {"items": [1, 2], "nested": [["a", "b"], ["c"]]}
+
+    assert matches_filter(document, {"items": [1, 2]})
+    assert matches_filter(document, {"items": 2})
+    assert matches_filter(document, {"nested": ["a", "b"]})
+    assert not matches_filter(document, {"items": [2, 1]})
+
+
+def test_python_filter_error_and_option_edges():
+    doc = {"value": 5, "name": "Ada"}
+
+    assert not matches_filter(doc, {"value": {"$gt": "not-a-number"}})
+    assert not matches_filter(doc, {"name": {"$regex": "["}})
+    assert not matches_filter(doc, {"name": {"$options": "i"}})
+    assert requires_python_filter({"$where": True})
+    assert not requires_python_filter({"$and": [{"_id": 1}]})
+
+
+@pytest.mark.parametrize("backend_class", [SQLiteTableBackend, DuckDBTableBackend])
+def test_local_table_find_falls_back_when_sql_compilation_fails(
+    tmp_path, monkeypatch, backend_class
+):
+    suffix = "sqlite" if backend_class is SQLiteTableBackend else "duckdb"
+    backend = backend_class(str(tmp_path / ("fallback." + suffix)))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1, "name": "Ada"},
+            {"_id": 2, "name": "Grace"},
+        ],
+    )
+
+    def fail_compile(_filter_doc):
+        raise ValueError("forced compiler failure")
+
+    monkeypatch.setattr(backend.compiler, "compile", fail_compile)
+
+    assert backend.find("items", {"_id": 2}) == [{"_id": 2, "name": "Grace"}]
+
+
 def test_sql_compiler_branches():
     sqlite = SQLCompiler("sqlite")
     duckdb = SQLCompiler("duckdb")
 
     assert sqlite.compile({}) == ("", [])
-    assert "$.name" in sqlite.compile({"name": "Ada"})[1]
+    assert "json_extract(data, '$.\"name\"')" in sqlite.compile({"name": "Ada"})[0]
     assert duckdb.compile({"active": True})[1][-1] == "true"
     assert "_id IN" in duckdb.compile({"_id": {"$in": [1, 2]}})[0]
     assert "_id !=" in duckdb.compile({"_id": {"$ne": 1}})[0]
@@ -250,7 +341,15 @@ def test_table_backend_abstract_methods(tmp_path):
     assert backend.close() is None
     backend.find = lambda collection, filter_doc=None: [{"_id": 1}]
     assert backend.all_docs("anything") == [{"_id": 1}]
-    assert backend.create_index("anything", "field") == "field"
+    assert backend.create_index("anything", "field") == "field_1"
+    assert backend.create_index("anything", "field") == "field_1"
+    assert (
+        backend.create_index("anything", parse_index_spec("email", unique=True))
+        == "email_1"
+    )
+    assert backend.drop_index("anything", "email") is None
+    with pytest.raises(OperationFailure, match="Index not found"):
+        backend.drop_index("anything", "missing")
     assert backend.drop_index("anything", "field") is None
     assert backend.list_indexes("anything") == [{"name": "_id_", "key": [("_id", 1)]}]
     with pytest.raises(NotImplementedError):
@@ -308,14 +407,165 @@ def test_sqlite_backend_duplicate_bypass_drop_and_indexes(tmp_path):
     with pytest.raises(DuplicateKeyError):
         backend.insert_many("users", [{"_id": 1, "name": "Grace"}])
 
-    backend.insert_many(
-        "users", [{"_id": 1, "name": "Grace"}], bypass_document_validation=True
-    )
-    assert backend.find_one("users", {"_id": 1})["name"] == "Grace"
-    assert backend.create_index("users", "name") == "name"
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many(
+            "users", [{"_id": 1, "name": "Grace"}], bypass_document_validation=True
+        )
+    assert backend.find_one("users", {"_id": 1})["name"] == "Ada"
+    assert backend.create_index("users", "name") == "name_1"
     assert backend.delete_many("users", {"_id": "missing"}) == []
     assert backend.drop_collection("users") is True
     assert backend.drop_collection("users") is False
+
+
+def test_sqlite_unique_index_uses_durable_native_ddl(tmp_path):
+    path = str(tmp_path / "db.sqlite")
+    backend = SQLiteTableBackend(path)
+    spec = parse_index_spec("value", unique=True, name="typed_value")
+
+    assert backend.create_index("values", spec) == "typed_value"
+    physical_name = backend._physical_index_name("values", spec)
+    conn = sqlite3.connect(path)
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            (physical_name,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert "CREATE UNIQUE INDEX" in row[0]
+    assert "tinymongo_unique_token" in row[0]
+    backend.insert_many(
+        "values",
+        [
+            {"_id": 1, "value": 1.0},
+            {"_id": 2, "value": 1.0000000000000002},
+        ],
+    )
+    where, params = backend.compiler.compile({"value": 1.0})
+    conn = sqlite3.connect(path)
+    try:
+        plan = conn.execute(
+            'EXPLAIN QUERY PLAN SELECT data FROM "values"' + where, params
+        ).fetchall()
+    finally:
+        conn.close()
+    assert any(physical_name + "_lookup" in item[-1] for item in plan)
+    assert SQLiteTableBackend(path).list_indexes("values")[-1]["name"] == (
+        "typed_value"
+    )
+
+    backend.drop_index("values", "typed_value")
+    conn = sqlite3.connect(path)
+    try:
+        assert (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+                (physical_name,),
+            ).fetchone()
+            is None
+        )
+        assert (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+                (physical_name + "_lookup",),
+            ).fetchone()
+            is None
+        )
+    finally:
+        conn.close()
+
+
+def test_sqlite_unique_index_keeps_distinct_arbitrary_precision_integers(tmp_path):
+    backend = SQLiteTableBackend(str(tmp_path / "large-integers.sqlite"))
+    backend.insert_many(
+        "values",
+        [
+            {"_id": 1, "value": 2**63},
+            {"_id": 2, "value": 2**63 + 1},
+        ],
+    )
+
+    assert (
+        backend.create_index("values", parse_index_spec("value", unique=True))
+        == "value_1"
+    )
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many("values", [{"_id": 3, "value": 2**63 + 1}])
+
+
+def test_sqlite_public_index_lookup_unions_scalar_and_array_matches(
+    tmp_path, monkeypatch
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.people
+    collection.insert_many(
+        [
+            {"_id": 1, "email": "ada@example.com"},
+            {"_id": 2, "email": ["ada@example.com", "other@example.com"]},
+            {"_id": 3, "email": "grace@example.com"},
+        ]
+    )
+    collection.create_index("email", name="email_lookup")
+
+    backend = collection.parent.engine
+    traced_sql = []
+    original_connect = backend._connect
+
+    def traced_connect():
+        conn = original_connect()
+        conn.set_trace_callback(traced_sql.append)
+        return conn
+
+    monkeypatch.setattr(backend, "_connect", traced_connect)
+
+    assert [doc["_id"] for doc in collection.find({"email": "ada@example.com"})] == [
+        1,
+        2,
+    ]
+    assert any("json_type" in sql and "IN ('text'" in sql for sql in traced_sql)
+    assert any("json_type" in sql and "= 'array'" in sql for sql in traced_sql)
+
+    spec = parse_index_spec("email", name="email_lookup")
+    where, params = backend.compiler.compile({"email": "ada@example.com"})
+    path = "'$.\"email\"'"
+    sql = (
+        'EXPLAIN QUERY PLAN SELECT data FROM "people"'
+        + where
+        + " AND json_type(data, {0}) IN "
+        "('text', 'integer', 'real', 'true', 'false')".format(path)
+    )
+    conn = original_connect()
+    try:
+        plan = conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+    assert any(backend._physical_index_name("people", spec) in row[-1] for row in plan)
+    client.close()
+
+
+def test_sqlite_maps_native_replace_and_index_integrity_errors(tmp_path, monkeypatch):
+    backend = SQLiteTableBackend(str(tmp_path / "db.sqlite"))
+
+    class FailingConnection:
+        def execute(self, *args, **kwargs):
+            raise sqlite3.IntegrityError("native unique conflict")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(backend, "create_collection", lambda collection: None)
+    monkeypatch.setattr(backend, "find", lambda collection, filter_doc: [])
+    monkeypatch.setattr(backend, "validate_unique_post_image", lambda *args: None)
+    monkeypatch.setattr(backend, "get_index_specs", lambda collection: [])
+    monkeypatch.setattr(backend, "_connect", FailingConnection)
+
+    with pytest.raises(DuplicateKeyError, match="native unique conflict"):
+        backend.replace_one("users", 1, {"_id": 1})
+    with pytest.raises(DuplicateKeyError, match="native unique conflict"):
+        backend.create_index("users", parse_index_spec("email"))
 
 
 def test_duckdb_backend_threads_duplicate_bypass_drop(tmp_path):
@@ -326,13 +576,34 @@ def test_duckdb_backend_threads_duplicate_bypass_drop(tmp_path):
     with pytest.raises(DuplicateKeyError):
         backend.insert_many("users", [{"_id": 1, "name": "Grace"}])
 
-    backend.insert_many(
-        "users", [{"_id": 1, "name": "Grace"}], bypass_document_validation=True
-    )
-    assert backend.find_one("users", {"_id": 1})["name"] == "Grace"
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many(
+            "users", [{"_id": 1, "name": "Grace"}], bypass_document_validation=True
+        )
+    assert backend.find_one("users", {"_id": 1})["name"] == "Ada"
     assert backend.delete_many("users", {"_id": "missing"}) == []
     assert backend.drop_collection("users") is True
     assert backend.drop_collection("users") is False
+
+
+def test_duckdb_does_not_mask_non_constraint_insert_errors(tmp_path, monkeypatch):
+    pytest.importorskip("duckdb")
+    backend = DuckDBTableBackend(str(tmp_path / "db.duckdb"))
+
+    class FailingConnection:
+        def executemany(self, *args, **kwargs):
+            raise RuntimeError("duckdb execution failed")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(backend, "create_collection", lambda collection: None)
+    monkeypatch.setattr(backend, "find", lambda collection, filter_doc: [])
+    monkeypatch.setattr(backend, "validate_unique_post_image", lambda *args: None)
+    monkeypatch.setattr(backend, "_connect", FailingConnection)
+
+    with pytest.raises(RuntimeError, match="duckdb execution failed"):
+        backend.insert_many("users", [{"_id": 1}])
 
 
 def test_parquet_backend_empty_and_duplicate_paths(tmp_path):
@@ -349,12 +620,37 @@ def test_parquet_backend_empty_and_duplicate_paths(tmp_path):
     assert backend.list_collections() == ["users"]
     with pytest.raises(DuplicateKeyError):
         backend.insert_many("users", [{"_id": 1, "name": "Grace"}])
-    backend.insert_many(
-        "users", [{"_id": 1, "name": "Grace"}], bypass_document_validation=True
-    )
-    assert backend.find_one("users", {"_id": 1})["name"] == "Grace"
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many(
+            "users", [{"_id": 1, "name": "Grace"}], bypass_document_validation=True
+        )
+    assert backend.find_one("users", {"_id": 1})["name"] == "Ada"
     assert backend.drop_collection("users") is True
     assert backend.drop_collection("users") is False
+
+
+def test_parquet_empty_index_collection_and_corrupt_catalog_fail_closed(tmp_path):
+    pytest.importorskip("duckdb")
+    backend = ParquetDuckDBBackend(str(tmp_path / "parquet"))
+
+    backend.create_index("empty", parse_index_spec("email", unique=True))
+    assert "empty" in backend.list_collections()
+    assert backend.drop_collection("empty") is True
+    assert backend.get_index_specs("empty") == []
+
+    backend.create_index("metadata_only", parse_index_spec("email"))
+    os.remove(backend._collection_path("metadata_only"))
+    assert backend.drop_collection("metadata_only") is True
+    assert backend.get_index_specs("metadata_only") == []
+
+    backend.create_index("users", parse_index_spec("email", unique=True))
+    with open(backend._collection_path("__tinymongo_indexes"), "wb") as handle:
+        handle.write(b"not a parquet file")
+
+    with pytest.raises(StorageCorruptionError, match="Cannot read Parquet"):
+        backend.get_index_specs("users")
+    with pytest.raises(StorageCorruptionError, match="Cannot read Parquet"):
+        backend.insert_many("users", [{"_id": 1, "email": "same@example.com"}])
 
 
 def test_parquet_object_store_paths_and_fake_listing(monkeypatch):
@@ -431,7 +727,7 @@ def test_parquet_object_store_missing_and_drop_paths(monkeypatch):
     )
 
     assert backend.drop_collection("users") is True
-    assert written == [("users", [])]
+    assert written == [("users", []), ("__tinymongo_indexes", [])]
 
 
 def test_duckdb_object_store_connection_configuration(tmp_path, monkeypatch):
@@ -519,7 +815,7 @@ def test_tinymongo_table_backend_api_branches(tmp_path):
     collection = db.users
 
     assert collection.any_attribute is collection
-    assert collection.create_index("email") == "email"
+    assert collection.create_index("email") == "email_1"
     assert collection.drop_index("email") is None
     assert collection.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
     assert collection.drop() is True
@@ -586,7 +882,7 @@ def test_optional_driver_error_messages(monkeypatch):
         MySQLTableBackend("", database="app", dsn="mysql://db")
     assert "optional Python driver 'pymysql'" in str(mysql.value)
 
-    with pytest.raises(ImportError, match="pip install duckdb") as duckdb:
+    with pytest.raises(ImportError, match=r"tinymongo\[duckdb\]") as duckdb:
         DuckDBTableBackend("db.duckdb")
     assert "optional Python driver 'duckdb'" in str(duckdb.value)
 
@@ -621,10 +917,220 @@ def test_remote_sql_backend_defensive_edges(monkeypatch):
     assert backend._commit(BadConn()) is None
     assert backend._close_cursor(BadCursor()) is None
     assert backend._data_placeholder() == "%s"
+    with backend._write_lock():
+        pass
+
+    postgres_duplicate = RuntimeError("conflict")
+    postgres_duplicate.sqlstate = "23505"
+    assert backend._is_duplicate_error(postgres_duplicate)
+    assert backend._is_duplicate_error(RuntimeError(1062, "duplicate entry"))
+    assert backend._is_duplicate_error(RuntimeError("unique constraint failed"))
+    assert not backend._is_duplicate_error(RuntimeError("syntax error"))
 
     monkeypatch.setattr(backend, "create_collection", lambda collection: None)
     assert backend.delete_ids("users", []) is None
-    assert backend.create_index("users", "email") == "email"
+    with pytest.raises(NotImplementedError):
+        backend._create_native_index(None, "users", parse_index_spec("email"))
+    with pytest.raises(NotImplementedError):
+        backend._drop_native_index(None, "users", parse_index_spec("email"))
+
+
+def _postgres_backend(monkeypatch, store):
+    fake_psycopg = SimpleNamespace(connect=lambda dsn: FakeRemoteConnection(store))
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+    return PostgresTableBackend("", database="app", dsn="postgresql://db")
+
+
+def _mysql_backend(monkeypatch, store):
+    monkeypatch.setitem(
+        sys.modules,
+        "pymysql",
+        SimpleNamespace(connect=lambda **kwargs: FakeRemoteConnection(store)),
+    )
+    return MySQLTableBackend("", database="app", dsn="mysql://localhost/db")
+
+
+def test_postgres_indexes_are_native_durable_unique_and_droppable(monkeypatch):
+    store = FakeRemoteStore()
+    backend = _postgres_backend(monkeypatch, store)
+    backend.insert_many(
+        "users",
+        [
+            {"_id": 1, "email": "one@example.com"},
+            {"_id": 2, "email": "two@example.com"},
+        ],
+    )
+
+    spec = parse_index_spec("email", unique=True)
+    assert backend.create_index("users", spec) == "email_1"
+    ddl_count = len(store.index_ddl)
+    assert backend.create_index("users", spec) == "email_1"
+    assert len(store.index_ddl) == ddl_count
+    assert backend.list_indexes("users") == [
+        {"name": "_id_", "key": [("_id", 1)]},
+        {"name": "email_1", "key": [("email", 1)], "unique": True},
+    ]
+    assert _postgres_backend(monkeypatch, store).list_indexes("users") == (
+        backend.list_indexes("users")
+    )
+    assert any(
+        "CREATE UNIQUE INDEX" in sql
+        and "COALESCE(jsonb_extract_path(data, 'email'), 'null'::jsonb)" in sql
+        for sql in store.index_ddl
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many("users", [{"_id": 3, "email": "one@example.com"}])
+    with pytest.raises(DuplicateKeyError):
+        backend.replace_one("users", 2, {"_id": 2, "email": "one@example.com"})
+
+    backend.drop_index("users", "email_1")
+    assert backend.list_indexes("users") == [{"name": "_id_", "key": [("_id", 1)]}]
+    assert any(sql.startswith("DROP INDEX IF EXISTS") for sql in store.index_ddl)
+    with pytest.raises(OperationFailure, match="Index not found"):
+        backend.drop_index("users", "email")
+
+
+def test_remote_unique_creation_preflights_and_drop_cleans_catalog(monkeypatch):
+    store = FakeRemoteStore()
+    backend = _postgres_backend(monkeypatch, store)
+    backend.insert_many(
+        "users",
+        [
+            {"_id": 1, "email": "same@example.com"},
+            {"_id": 2, "email": "same@example.com"},
+        ],
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        backend.create_index("users", parse_index_spec("email", unique=True))
+    assert backend.list_indexes("users") == [{"name": "_id_", "key": [("_id", 1)]}]
+    assert not store.index_ddl
+
+    backend.create_index("users", parse_index_spec("email"))
+    with pytest.raises(OperationFailure, match="different options"):
+        backend.create_index("users", parse_index_spec("email", unique=True))
+    assert backend.drop_collection("users") is True
+    assert not store.indexes
+
+
+def test_remote_native_errors_are_mapped_without_hiding_other_failures(monkeypatch):
+    store = FakeRemoteStore()
+    backend = _postgres_backend(monkeypatch, store)
+    backend.insert_many("users", [{"_id": 1, "email": "one@example.com"}])
+    original_execute = backend._execute
+
+    def fail_update(message):
+        def execute(conn, sql, params=None):
+            if sql.lstrip().upper().startswith("UPDATE"):
+                raise RuntimeError(message)
+            return original_execute(conn, sql, params)
+
+        return execute
+
+    monkeypatch.setattr(backend, "_execute", fail_update("duplicate key"))
+    with pytest.raises(DuplicateKeyError):
+        backend.replace_one("users", 1, {"_id": 1, "email": "changed@example.com"})
+
+    monkeypatch.setattr(backend, "_execute", fail_update("syntax error"))
+    with pytest.raises(RuntimeError, match="syntax error"):
+        backend.replace_one("users", 1, {"_id": 1, "email": "changed@example.com"})
+
+    def fail_native(conn, collection, spec):
+        raise RuntimeError("duplicate key")
+
+    monkeypatch.setattr(backend, "_execute", original_execute)
+    monkeypatch.setattr(backend, "_create_native_index", fail_native)
+    spec = parse_index_spec("email", unique=True)
+    with pytest.raises(DuplicateKeyError):
+        backend.create_index("users", spec)
+
+    def fail_native_syntax(conn, collection, spec):
+        raise RuntimeError("syntax error")
+
+    monkeypatch.setattr(backend, "_create_native_index", fail_native_syntax)
+    with pytest.raises(RuntimeError, match="syntax error"):
+        backend.create_index("users", spec)
+
+    def fail_insert(conn, collection, rows, bypass_document_validation):
+        raise RuntimeError("insert syntax error")
+
+    monkeypatch.setattr(backend, "_insert_rows", fail_insert)
+    with pytest.raises(RuntimeError, match="insert syntax error"):
+        backend.insert_many("users", [{"_id": 2, "email": "two@example.com"}])
+
+
+def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
+    monkeypatch,
+):
+    store = FakeRemoteStore()
+    backend = _mysql_backend(monkeypatch, store)
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1, "value": True, "tags": ["a"]},
+            {"_id": 2, "value": 1, "tags": ["b"]},
+        ],
+    )
+
+    backend.create_index("items", parse_index_spec("value", unique=True))
+    with pytest.raises(TinyMongoNotSupportedError, match="does not support array"):
+        backend.create_index(
+            "items", parse_index_spec("tags", unique=True, name="unique_tags")
+        )
+
+    assert _mysql_backend(monkeypatch, store).list_indexes("items") == [
+        {"name": "_id_", "key": [("_id", 1)]},
+        {"name": "value_1", "key": [("value", 1)], "unique": True},
+    ]
+    assert any(
+        "GENERATED ALWAYS AS" in sql
+        and "JSON_TYPE(JSON_EXTRACT(data, '$.\"value\"'))" in sql
+        and "CONCAT('bool:'" in sql
+        and "AS DECIMAL(65, 30)" in sql
+        and "SHA2(CASE" in sql
+        and "CHAR(64) CHARACTER SET ascii COLLATE ascii_bin" in sql
+        for sql in store.index_ddl
+    )
+    assert sum("CREATE UNIQUE INDEX" in sql for sql in store.index_ddl) == 1
+
+    with pytest.raises(TinyMongoNotSupportedError, match="does not support array"):
+        backend.insert_many("items", [{"_id": 3, "value": [3], "tags": ["a"]}])
+
+    backend.drop_index("items", "value_1")
+    assert any(sql.startswith("DROP INDEX") for sql in store.index_ddl)
+    assert any("DROP COLUMN" in sql for sql in store.index_ddl)
+
+    backend.insert_many("numbers", [{"_id": 1, "value": 1}, {"_id": 2, "value": 1.0}])
+    with pytest.raises(DuplicateKeyError):
+        backend.create_index("numbers", parse_index_spec("value", unique=True))
+
+
+def test_remote_array_guard_ignores_nonunique_specs():
+    _reject_remote_unique_arrays(
+        [{"_id": 1, "tags": ["a", "b"]}],
+        [parse_index_spec("tags")],
+    )
+
+
+@pytest.mark.parametrize("backend_name", ["postgres", "mysql"])
+def test_remote_unique_array_writes_fail_closed_across_clients(
+    monkeypatch, backend_name
+):
+    store = FakeRemoteStore()
+    factory = _postgres_backend if backend_name == "postgres" else _mysql_backend
+    first = factory(monkeypatch, store)
+    second = factory(monkeypatch, store)
+    first.create_index("items", parse_index_spec("tags", unique=True))
+    first.insert_many("items", [{"_id": 1, "tags": "a"}])
+
+    with pytest.raises(TinyMongoNotSupportedError, match="multikey uniqueness"):
+        second.insert_many("items", [{"_id": 2, "tags": ["a", "b"]}])
+    with pytest.raises(TinyMongoNotSupportedError, match="multikey uniqueness"):
+        second.replace_one("items", 1, {"_id": 1, "tags": ["a"]})
+
+    assert second.find_one("items", {"_id": 1}) == {"_id": 1, "tags": "a"}
+    assert second.find_one("items", {"_id": 2}) is None
 
 
 def test_postgres_table_backend_with_fake_driver(monkeypatch):
@@ -637,11 +1143,13 @@ def test_postgres_table_backend_with_fake_driver(monkeypatch):
     backend.insert_many("users", [{"_id": 1, "name": "Ada", "age": 36}])
     with pytest.raises(DuplicateKeyError):
         backend.insert_many("users", [{"_id": 1, "name": "Grace"}])
-    backend.insert_many(
-        "users",
-        [{"_id": 1, "name": "Grace", "age": 40}],
-        bypass_document_validation=True,
-    )
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many(
+            "users",
+            [{"_id": 1, "name": "Grace", "age": 40}],
+            bypass_document_validation=True,
+        )
+    backend.replace_one("users", 1, {"_id": 1, "name": "Grace", "age": 40})
 
     assert backend.list_databases() == ["app"]
     assert backend.list_collections() == ["users"]
@@ -674,11 +1182,13 @@ def test_mysql_table_backend_with_fake_driver(monkeypatch):
         dsn="mysql://user:pass@localhost:3307/tinymongo?charset=utf8mb4",
     )
     backend.insert_many("users", [{"_id": "a", "name": "Ada"}])
-    backend.insert_many(
-        "users",
-        [{"_id": "a", "name": "Grace"}],
-        bypass_document_validation=True,
-    )
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many(
+            "users",
+            [{"_id": "a", "name": "Grace"}],
+            bypass_document_validation=True,
+        )
+    backend.replace_one("users", "a", {"_id": "a", "name": "Grace"})
 
     assert seen_kwargs[0]["host"] == "localhost"
     assert seen_kwargs[0]["port"] == 3307

--- a/tests/test_tinymongo_coverage_edges.py
+++ b/tests/test_tinymongo_coverage_edges.py
@@ -1,0 +1,133 @@
+"""Focused coverage for compatibility paths that are awkward to reach normally."""
+
+import pytest
+
+import tinymongo
+
+
+class _StubDatabase:
+    def __init__(self, collections=()):
+        self.collections = list(collections)
+        self.dropped = []
+        self.closed = False
+
+    def list_collection_names(self):
+        return list(self.collections)
+
+    def drop_collection(self, name):
+        self.dropped.append(name)
+
+    def close(self):
+        self.closed = True
+
+
+def test_directory_database_metadata_and_drop_cleanup(tmp_path):
+    root = tmp_path / "parquet"
+    database_path = root / "analytics.parquet"
+    nested = database_path / "partitions"
+    nested.mkdir(parents=True)
+    (database_path / "root.bin").write_bytes(b"123")
+    (nested / "part.bin").write_bytes(b"4567")
+
+    client = tinymongo.TinyMongoClient(str(root), backend="parquet")
+    database = _StubDatabase(["events"])
+    client._databases["analytics"] = database
+
+    assert client.list_databases().to_list() == [
+        {"name": "analytics", "sizeOnDisk": 7, "empty": False}
+    ]
+    assert client.drop_database("analytics") is None
+    assert database.dropped == ["events"]
+    assert database.closed is True
+    assert not database_path.exists()
+
+
+def test_drop_database_unopened_and_cleanup_bypass_paths(tmp_path, monkeypatch):
+    client = tinymongo.TinyMongoClient(str(tmp_path / "missing-path"))
+    unopened = _StubDatabase()
+    monkeypatch.setattr(client, "list_database_names", lambda: ["ghost"])
+    monkeypatch.setattr(client, "_get_db", lambda name: unopened)
+
+    assert client.drop_database("ghost") is None
+    assert unopened.closed is True
+
+    retained_root = tmp_path / "retained"
+    retained_root.mkdir()
+    retained_file = retained_root / "remote.json"
+    retained_file.write_text("{}", encoding="utf-8")
+    retained = tinymongo.TinyMongoClient(str(retained_root))
+    retained._databases["remote"] = _StubDatabase()
+    retained._storage_uri = "s3://example/prefix"
+
+    assert retained.drop_database("remote") is None
+    assert retained_file.exists()
+
+
+def test_create_indexes_skip_and_duplicate_field_drop_branches():
+    client = tinymongo.TinyMongoClient(backend="memory")
+    collection = client.app.items
+
+    with pytest.raises(TypeError, match="one iterable"):
+        collection.create_indexes([], object())
+
+    with pytest.warns(UserWarning, match="text indexing is ignored"):
+        assert collection.create_indexes(
+            [{"key": {"body": "text"}, "name": "body_text"}]
+        ) == ["body_text"]
+    assert collection.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+
+    collection.create_index("email", name="email_a")
+    collection.create_index("email", name="email_b")
+    collection.drop_index("email_a")
+    assert "email" in collection._indexes
+    assert {item["name"] for item in collection.list_indexes()} == {
+        "_id_",
+        "email_b",
+    }
+    client.close()
+
+
+def test_parse_condition_operator_construction_edges():
+    collection = tinymongo.TinyMongoClient(backend="memory").app.items
+
+    cases = [
+        ({"$ne": 1}, "value", None),
+        ({"$gt": 0, "$ne": 1}, "value", None),
+        ({"$ne": 1}, "$not", "value"),
+        ({"$not": 1}, "value", None),
+        ({"$gt": 0, "$not": 1}, "value", None),
+        ({"$not": 1}, "$not", "value"),
+        ({"$not": {"$gt": 1}}, "value", None),
+        ({"$regex": r"a\\\\b\\c"}, "value", None),
+        ({"$gt": "a", "$regex": "b"}, "value", None),
+        ({"$nin": [1, 2]}, "value", None),
+        ({"$nin": 1}, "value", None),
+        ({"$gt": 0, "$nin": [1, 2]}, "value", None),
+        ({"$and": [{"a": 1}, {"b": 2}]}, None, None),
+        ({"$or": [{"a": 1}, {"b": 2}]}, None, None),
+        ({"$nor": [{"a": 1}, {"b": 2}]}, None, None),
+        ({"$in": [1, 2]}, "value", None),
+        ({"$all": [1, 2]}, "value", None),
+        ({"$gt": 0, "$not": [1]}, "value", None),
+        ({"$unknown": []}, "value", None),
+        ({"value": [1, 2]}, None, None),
+    ]
+
+    for query, prev_key, last_prev_key in cases:
+        list(collection.parse_condition(query, prev_key, last_prev_key))
+
+
+def test_cursor_clone_and_closed_legacy_methods():
+    manual = tinymongo.TinyMongoCursor([{"_id": 1}])
+    clone = manual.clone()
+    assert clone.to_list() == [{"_id": 1}]
+
+    collection = tinymongo.TinyMongoClient(backend="memory").app.items
+    collection.insert_one({"_id": 1})
+    assert collection.find({}).clone().to_list() == [{"_id": 1}]
+
+    cursor = tinymongo.TinyMongoCursor([{"_id": 1}])
+    cursor.close()
+    assert cursor.hasNext() is False
+    with pytest.raises(StopIteration):
+        cursor.next()

--- a/tinymongo/__init__.py
+++ b/tinymongo/__init__.py
@@ -2,3 +2,16 @@ try:
     from tinymongo.tinymongo import *  # noqa
 except ImportError:  # pragma: no cover - legacy import fallback
     from tinymongo import *  # noqa
+
+from tinymongo.patching import patch  # noqa: E402,F401
+from tinymongo.indexes import TinyMongoUnsupportedWarning  # noqa: E402,F401
+from tinymongo.asyncio import (  # noqa: E402,F401
+    AsyncCollection,
+    AsyncCursor,
+    AsyncDatabase,
+    AsyncMongoClient,
+    AsyncTinyMongoClient,
+    AsyncTinyMongoCollection,
+    AsyncTinyMongoCursor,
+    AsyncTinyMongoDatabase,
+)

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -1,0 +1,656 @@
+"""Non-blocking asyncio facade for TinyMongo's synchronous implementation.
+
+The classes in this module deliberately keep the synchronous storage layer as
+the single source of truth.  Every operation which can touch storage is run in
+``asyncio.to_thread``.  Database and collection selection remain immediate,
+as they are in PyMongo, and ``find`` returns a lazy cursor without doing I/O.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import threading
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .errors import InvalidOperation, TinyMongoNotSupportedError
+from .tinymongo import (
+    _CompatibilityConcern,
+    MongoClient,
+    TinyMongoClient,
+    TinyMongoCollection,
+    TinyMongoCursor,
+)
+
+
+class _AsyncClientState:
+    """Own a lazily-created synchronous client and coordinate its shutdown."""
+
+    def __init__(self, factory: Callable[[], TinyMongoClient]):
+        self._factory = factory
+        self._client: Optional[TinyMongoClient] = None
+        self._condition = threading.Condition()
+        self._active_calls = 0
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        with self._condition:
+            return self._closed
+
+    def _begin_call(self) -> TinyMongoClient:
+        with self._condition:
+            if self._closed:
+                raise InvalidOperation("Cannot use a closed AsyncTinyMongoClient")
+            if self._client is None:
+                self._client = self._factory()
+            self._active_calls += 1
+            return self._client
+
+    def _finish_call(self) -> None:
+        with self._condition:
+            self._active_calls -= 1
+            if not self._active_calls:
+                self._condition.notify_all()
+
+    def _invoke(self, operation: Callable[[TinyMongoClient], Any]) -> Any:
+        client = self._begin_call()
+        try:
+            return operation(client)
+        finally:
+            self._finish_call()
+
+    async def call(self, operation: Callable[[TinyMongoClient], Any]) -> Any:
+        """Run one complete synchronous operation outside the event loop."""
+
+        return await asyncio.to_thread(self._invoke, operation)
+
+    def _close(self) -> None:
+        with self._condition:
+            if self._closed:
+                return
+            self._closed = True
+            while self._active_calls:
+                self._condition.wait()
+            client = self._client
+            self._client = None
+        if client is not None:
+            client.close()
+
+    async def close(self) -> None:
+        """Wait for in-flight calls, then close storage outside the event loop."""
+
+        await asyncio.to_thread(self._close)
+
+
+class _AsyncClientBase:
+    """Shared implementation for the native and PyMongo-shaped clients."""
+
+    _sync_client_class: Any = TinyMongoClient
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        sync_client_class = self._sync_client_class
+        self._state = _AsyncClientState(lambda: sync_client_class(*args, **kwargs))
+
+    def __getitem__(self, name: str) -> "AsyncTinyMongoDatabase":
+        return AsyncTinyMongoDatabase(self, name)
+
+    def __getattr__(self, name: str) -> "AsyncTinyMongoDatabase":
+        if name.startswith("_"):
+            raise AttributeError(
+                "{} object has no attribute {}".format(type(self).__name__, name)
+            )
+        return self[name]
+
+    def get_database(
+        self, name: str, *args: Any, **kwargs: Any
+    ) -> "AsyncTinyMongoDatabase":
+        """Return a database handle without opening storage."""
+
+        return self[name]
+
+    async def list_database_names(self, *args: Any, **kwargs: Any) -> List[str]:
+        return await self._state.call(lambda client: client.list_database_names())
+
+    async def list_databases(self, *args: Any, **kwargs: Any) -> "AsyncTinyMongoCursor":
+        """Return database metadata through an asynchronously iterable cursor."""
+
+        documents = await self._state.call(
+            lambda client: client.list_databases(*args, **kwargs).to_list()
+        )
+        return AsyncTinyMongoCursor(documents=documents)
+
+    async def drop_database(
+        self, name_or_database: Any, *args: Any, **kwargs: Any
+    ) -> None:
+        """Drop a database without running storage work on the event loop."""
+
+        if isinstance(name_or_database, AsyncTinyMongoDatabase):
+            name_or_database = name_or_database.name
+        await self._state.call(
+            lambda client: client.drop_database(name_or_database, *args, **kwargs)
+        )
+
+    async def database_names(self, *args: Any, **kwargs: Any) -> List[str]:
+        return await self.list_database_names(*args, **kwargs)
+
+    async def server_info(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return await self._state.call(lambda client: client.server_info())
+
+    async def capabilities(self) -> Dict[str, Any]:
+        return await self._state.call(lambda client: client.capabilities())
+
+    async def supports(self, feature: str) -> bool:
+        return await self._state.call(lambda client: client.supports(feature))
+
+    def start_session(self, *args: Any, **kwargs: Any) -> Any:
+        # PyMongo creates its async session handle synchronously.  TinyMongo
+        # cannot provide sessions, so fail at the same call boundary.
+        raise TinyMongoNotSupportedError(
+            "Sessions and transactions are not supported by TinyMongo"
+        )
+
+    async def watch(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._state.call(lambda client: client.watch(*args, **kwargs))
+
+    async def close(self) -> None:
+        await self._state.close()
+
+    async def __aenter__(self) -> "_AsyncClientBase":
+        if self._state.closed:
+            raise InvalidOperation("Cannot reuse a closed AsyncTinyMongoClient")
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type],
+        exc_value: Optional[BaseException],
+        traceback: Any,
+    ) -> None:
+        # Shield cleanup so cancellation of the surrounding task cannot leave
+        # an opened local database behind.
+        await asyncio.shield(self.close())
+
+
+class AsyncTinyMongoClient(_AsyncClientBase):
+    """Async counterpart to :class:`~tinymongo.TinyMongoClient`."""
+
+    _sync_client_class = TinyMongoClient
+
+
+class AsyncMongoClient(_AsyncClientBase):
+    """PyMongo-shaped asynchronous client backed by local TinyMongo storage."""
+
+    _sync_client_class = MongoClient
+
+
+class AsyncTinyMongoDatabase:
+    """An immediate database handle whose operations are asynchronous."""
+
+    def __init__(self, client: _AsyncClientBase, name: str):
+        self.client = client
+        self.name = name
+
+    @property
+    def database(self) -> str:
+        """Compatibility alias for TinyMongo's synchronous database name."""
+
+        return self.name
+
+    def __repr__(self) -> str:
+        return self.name
+
+    def __getitem__(self, name: str) -> "AsyncTinyMongoCollection":
+        return AsyncTinyMongoCollection(self, name)
+
+    def __getattr__(self, name: str) -> "AsyncTinyMongoCollection":
+        if name.startswith("_"):
+            raise AttributeError(
+                "{} object has no attribute {}".format(type(self).__name__, name)
+            )
+        return self[name]
+
+    def get_collection(
+        self, name: str, *args: Any, **kwargs: Any
+    ) -> "AsyncTinyMongoCollection":
+        """Return a collection handle without touching storage."""
+
+        return self[name]
+
+    async def _call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        def operation(client: TinyMongoClient) -> Any:
+            database = client[self.name]
+            return getattr(database, method)(*args, **kwargs)
+
+        return await self.client._state.call(operation)
+
+    async def collection_names(self) -> List[str]:
+        return await self._call("collection_names")
+
+    async def list_collection_names(self, *args: Any, **kwargs: Any) -> List[str]:
+        return await self._call("list_collection_names", *args, **kwargs)
+
+    async def drop_collection(self, name: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(name, AsyncTinyMongoCollection):
+            name = name.name
+        return await self._call("drop_collection", name, *args, **kwargs)
+
+    async def command(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("command", *args, **kwargs)
+
+    async def watch(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("watch", *args, **kwargs)
+
+    async def close(self) -> None:
+        await self._call("close")
+
+    async def __aenter__(self) -> "AsyncTinyMongoDatabase":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type],
+        exc_value: Optional[BaseException],
+        traceback: Any,
+    ) -> None:
+        await asyncio.shield(self.close())
+
+
+class AsyncTinyMongoCollection:
+    """Async collection facade with PyMongo-style immediate ``find``."""
+
+    def __init__(self, database: AsyncTinyMongoDatabase, name: str):
+        self.database = database
+        self.name = name
+
+    @property
+    def tablename(self) -> str:
+        """Compatibility alias for TinyMongo's synchronous collection name."""
+
+        return self.name
+
+    @property
+    def full_name(self) -> str:
+        return "{}.{}".format(self.database.name, self.name)
+
+    @property
+    def write_concern(self) -> _CompatibilityConcern:
+        return _CompatibilityConcern()
+
+    @property
+    def read_concern(self) -> _CompatibilityConcern:
+        return _CompatibilityConcern()
+
+    def __repr__(self) -> str:
+        return self.name
+
+    async def _call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        def operation(client: TinyMongoClient) -> Any:
+            collection = client[self.database.name][self.name]
+            return getattr(collection, method)(*args, **kwargs)
+
+        return await self.database.client._state.call(operation)
+
+    def find(
+        self,
+        filter: Optional[Dict[str, Any]] = None,
+        projection: Any = None,
+        skip: Optional[int] = None,
+        limit: Optional[int] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "AsyncTinyMongoCursor":
+        """Return a lazy async cursor without executing the query."""
+
+        sort = kwargs.pop("sort", None)
+        cursor = AsyncTinyMongoCursor(
+            collection=self,
+            filter=filter,
+            projection=projection,
+            find_args=args,
+            find_kwargs=kwargs,
+        )
+        if sort is not None:
+            cursor.sort(sort)
+        if skip is not None:
+            cursor.skip(skip)
+        if limit is not None:
+            cursor.limit(limit)
+        return cursor
+
+    async def find_one(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("find_one", *args, **kwargs)
+
+    async def insert(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("insert", *args, **kwargs)
+
+    async def insert_one(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("insert_one", *args, **kwargs)
+
+    async def insert_many(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("insert_many", *args, **kwargs)
+
+    async def update(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("update", *args, **kwargs)
+
+    async def update_one(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("update_one", *args, **kwargs)
+
+    async def update_many(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("update_many", *args, **kwargs)
+
+    async def replace_one(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("replace_one", *args, **kwargs)
+
+    async def find_one_and_update(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("find_one_and_update", *args, **kwargs)
+
+    async def find_one_and_replace(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("find_one_and_replace", *args, **kwargs)
+
+    async def find_one_and_delete(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("find_one_and_delete", *args, **kwargs)
+
+    async def remove(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("remove", *args, **kwargs)
+
+    async def delete_one(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("delete_one", *args, **kwargs)
+
+    async def delete_many(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("delete_many", *args, **kwargs)
+
+    async def count(self, *args: Any, **kwargs: Any) -> int:
+        return await self._call("count", *args, **kwargs)
+
+    async def count_documents(self, *args: Any, **kwargs: Any) -> int:
+        return await self._call("count_documents", *args, **kwargs)
+
+    async def estimated_document_count(self, *args: Any, **kwargs: Any) -> int:
+        return await self._call("estimated_document_count", *args, **kwargs)
+
+    async def create_index(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("create_index", *args, **kwargs)
+
+    async def create_indexes(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate plural index creation when the sync surface provides it."""
+
+        return await self._call("create_indexes", *args, **kwargs)
+
+    async def drop_index(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("drop_index", *args, **kwargs)
+
+    async def list_indexes(self, *args: Any, **kwargs: Any) -> "AsyncTinyMongoCursor":
+        """Return index metadata through a PyMongo-shaped async cursor."""
+
+        documents = await self._call("list_indexes", *args, **kwargs)
+        return AsyncTinyMongoCursor(documents=documents)
+
+    async def index_information(self, *args: Any, **kwargs: Any) -> Any:
+        """Return index metadata in the same shape as the sync collection."""
+
+        return await self._call("index_information", *args, **kwargs)
+
+    async def distinct(self, *args: Any, **kwargs: Any) -> List[Any]:
+        """Return the distinct values for a field without blocking the loop."""
+
+        return await self._call("distinct", *args, **kwargs)
+
+    async def drop(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("drop", *args, **kwargs)
+
+    async def aggregate(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("aggregate", *args, **kwargs)
+
+    async def bulk_write(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("bulk_write", *args, **kwargs)
+
+    async def watch(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._call("watch", *args, **kwargs)
+
+    def with_options(self, *args: Any, **kwargs: Any) -> "AsyncTinyMongoCollection":
+        """Return this immutable-style handle after validating local concerns."""
+
+        options = list(args) + [value for value in kwargs.values() if value is not None]
+        for option in options:
+            if getattr(option, "document", {}):
+                raise TinyMongoNotSupportedError(
+                    "Non-default read and write concerns are not supported"
+                )
+        return self
+
+
+class AsyncTinyMongoCursor:
+    """Lazy async cursor backed by one off-thread synchronous query."""
+
+    def __init__(
+        self,
+        collection: Optional[AsyncTinyMongoCollection] = None,
+        filter: Optional[Dict[str, Any]] = None,
+        projection: Any = None,
+        find_args: Tuple[Any, ...] = (),
+        find_kwargs: Optional[Dict[str, Any]] = None,
+        documents: Optional[List[Dict[str, Any]]] = None,
+    ):
+        self.collection = collection
+        self._seed_documents = copy.deepcopy(documents)
+        self._filter = copy.deepcopy(filter)
+        self._projection = copy.deepcopy(projection)
+        self._find_args = tuple(find_args)
+        self._find_kwargs = dict(find_kwargs or {})
+        self._sort: Optional[Tuple[Any, Any]] = None
+        self._skip = 0
+        self._limit = 0
+        self._documents: Optional[List[Dict[str, Any]]] = None
+        self._load_task: Optional["asyncio.Task[List[Dict[str, Any]]]"] = None
+        self._position = 0
+        self._closed = False
+
+    def _check_mutable(self) -> None:
+        if self._closed:
+            raise InvalidOperation("Cannot modify a closed cursor")
+        if self._load_task is not None or self._documents is not None:
+            raise InvalidOperation("Cannot modify a cursor after it has started")
+
+    def sort(self, key_or_list: Any, direction: Any = None) -> "AsyncTinyMongoCursor":
+        self._check_mutable()
+        # Reuse the synchronous cursor's pure validation logic now so malformed
+        # specifications fail at configuration time, like PyMongo's cursor.
+        TinyMongoCursor([]).sort(key_or_list, direction)
+        self._sort = (copy.deepcopy(key_or_list), direction)
+        return self
+
+    def skip(self, count: int) -> "AsyncTinyMongoCursor":
+        self._check_mutable()
+        if isinstance(count, bool) or not isinstance(count, int):
+            raise TypeError("skip must be an integer")
+        if count < 0:
+            raise ValueError("skip must be non-negative")
+        self._skip = count
+        return self
+
+    def limit(self, count: int) -> "AsyncTinyMongoCursor":
+        self._check_mutable()
+        if isinstance(count, bool) or not isinstance(count, int):
+            raise TypeError("limit must be an integer")
+        # Negative PyMongo limits request a single batch.  Local storage has no
+        # server batches, so the same absolute result bound is sufficient.
+        self._limit = abs(count)
+        return self
+
+    def paginate(
+        self, skip: Optional[int], limit: Optional[int]
+    ) -> "AsyncTinyMongoCursor":
+        """Configure the cursor window using TinyMongo's legacy helper."""
+
+        self._check_mutable()
+        if skip is not None:
+            if isinstance(skip, bool) or not isinstance(skip, int):
+                raise TypeError("skip must be an integer")
+            if skip < 0:
+                raise ValueError("skip must be non-negative")
+        if limit is not None:
+            if isinstance(limit, bool) or not isinstance(limit, int):
+                raise TypeError("limit must be an integer")
+        if skip is not None:
+            self._skip = skip
+        if limit is not None:
+            self._limit = abs(limit)
+        return self
+
+    def clone(self) -> "AsyncTinyMongoCursor":
+        clone = type(self)(
+            collection=self.collection,
+            filter=self._filter,
+            projection=self._projection,
+            find_args=self._find_args,
+            find_kwargs=self._find_kwargs,
+            documents=self._seed_documents,
+        )
+        clone._sort = copy.deepcopy(self._sort)
+        clone._skip = self._skip
+        clone._limit = self._limit
+        return clone
+
+    async def rewind(self) -> "AsyncTinyMongoCursor":
+        if self._closed:
+            raise InvalidOperation("Cannot rewind a closed cursor")
+        self._position = 0
+        return self
+
+    def _load_sync(self) -> List[Dict[str, Any]]:
+        if self._seed_documents is not None:
+            cursor = TinyMongoCursor(copy.deepcopy(self._seed_documents))
+            if self._sort is not None:
+                cursor.sort(self._sort[0], self._sort[1])
+            documents = list(cursor)
+            if self._skip:
+                documents = documents[self._skip :]
+            if self._limit:
+                documents = documents[: self._limit]
+            return documents
+
+        collection_handle = self.collection
+        if collection_handle is None:  # pragma: no cover - constructor invariant
+            raise InvalidOperation("Cursor has no collection or document source")
+        state = collection_handle.database.client._state
+
+        def operation(client: TinyMongoClient) -> List[Dict[str, Any]]:
+            collection: TinyMongoCollection = client[collection_handle.database.name][
+                collection_handle.name
+            ]
+            cursor = collection.find(
+                self._filter,
+                self._projection,
+                None,
+                None,
+                *self._find_args,
+                **self._find_kwargs,
+            )
+            if self._sort is not None:
+                cursor.sort(self._sort[0], self._sort[1])
+            documents = list(cursor)
+            if self._skip:
+                documents = documents[self._skip :]
+            if self._limit:
+                documents = documents[: self._limit]
+            return documents
+
+        return state._invoke(operation)
+
+    async def _ensure_loaded(self) -> List[Dict[str, Any]]:
+        if self._closed:
+            return []
+        if self._documents is not None:
+            return self._documents
+        if self._load_task is None:
+            self._load_task = asyncio.create_task(asyncio.to_thread(self._load_sync))
+        # Shield the shared load task.  Cancelling one waiter must not launch a
+        # duplicate storage query or cancel work already running in a thread.
+        documents = await asyncio.shield(self._load_task)
+        self._documents = documents
+        return documents
+
+    @property
+    def alive(self) -> bool:
+        if self._closed:
+            return False
+        if self._documents is None:
+            return True
+        return self._position < len(self._documents)
+
+    def __aiter__(self) -> "AsyncTinyMongoCursor":
+        return self
+
+    async def __anext__(self) -> Dict[str, Any]:
+        documents = await self._ensure_loaded()
+        if self._position >= len(documents):
+            raise StopAsyncIteration
+        document = documents[self._position]
+        self._position += 1
+        return copy.deepcopy(document)
+
+    async def next(self) -> Dict[str, Any]:
+        return await self.__anext__()
+
+    async def try_next(self) -> Optional[Dict[str, Any]]:
+        try:
+            return await self.__anext__()
+        except StopAsyncIteration:
+            return None
+
+    async def has_next(self) -> bool:
+        """Return whether another document is available for consumption."""
+
+        documents = await self._ensure_loaded()
+        return self._position < len(documents)
+
+    async def hasNext(self) -> bool:
+        """Compatibility alias for older TinyMongo callers."""
+
+        return await self.has_next()
+
+    async def to_list(self, length: Optional[int] = None) -> List[Dict[str, Any]]:
+        if length is not None:
+            if isinstance(length, bool) or not isinstance(length, int):
+                raise TypeError("length must be an integer or None")
+            if length < 0:
+                raise ValueError("length must be non-negative")
+        documents = await self._ensure_loaded()
+        end = len(documents) if length is None else self._position + length
+        result = copy.deepcopy(documents[self._position : end])
+        self._position += len(result)
+        return result
+
+    async def count(self, with_limit_and_skip: bool = False) -> int:
+        documents = await self._ensure_loaded()
+        return len(documents)
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._load_task is not None:
+            try:
+                await asyncio.shield(self._load_task)
+            except Exception:
+                # Closing a cursor should not replace an earlier query error.
+                pass
+        self._documents = []
+
+
+# Short names are useful to callers that already distinguish the module as
+# asynchronous, while the TinyMongo-prefixed names remain explicit and stable.
+AsyncDatabase = AsyncTinyMongoDatabase
+AsyncCollection = AsyncTinyMongoCollection
+AsyncCursor = AsyncTinyMongoCursor
+
+
+__all__ = [
+    "AsyncCollection",
+    "AsyncCursor",
+    "AsyncDatabase",
+    "AsyncMongoClient",
+    "AsyncTinyMongoClient",
+    "AsyncTinyMongoCollection",
+    "AsyncTinyMongoCursor",
+    "AsyncTinyMongoDatabase",
+]

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -1,0 +1,108 @@
+"""JSON-safe encoding for BSON-shaped values supported by TinyMongo.
+
+Storage backends keep using ordinary JSON payloads. Values JSON cannot
+represent are wrapped at the persistence boundary and restored on read, so
+callers continue to work with the original Python objects.
+"""
+
+from __future__ import absolute_import
+
+from datetime import datetime
+import json
+
+
+_TYPE_MARKER = "__tinymongo_type_v1__"
+_VALUE_MARKER = "value"
+_ESCAPED_MAPPING = "mapping"
+
+try:
+    from bson import ObjectId as _ObjectId
+except ImportError:  # pragma: no cover - environment without optional bson
+    _ObjectId = None  # type: ignore[misc,assignment]
+
+
+def bson_available():
+    """Return whether the optional BSON implementation can be used."""
+    return _ObjectId is not None
+
+
+def encode_value(value):
+    """Recursively convert supported non-JSON values into tagged JSON data."""
+    if _ObjectId is not None and isinstance(value, _ObjectId):
+        return {_TYPE_MARKER: "objectid", _VALUE_MARKER: str(value)}
+    if isinstance(value, datetime):
+        return {_TYPE_MARKER: "datetime", _VALUE_MARKER: value.isoformat()}
+    if isinstance(value, dict):
+        # A user mapping can legitimately have the same two keys as one of our
+        # scalar tags. Wrap that exact shape so it cannot be silently decoded as
+        # a datetime/ObjectId when it crosses a persistence boundary.
+        if set(value) == {_TYPE_MARKER, _VALUE_MARKER}:
+            return {
+                _TYPE_MARKER: _ESCAPED_MAPPING,
+                _VALUE_MARKER: [
+                    [str(key), encode_value(item)] for key, item in value.items()
+                ],
+            }
+        return {str(key): encode_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [encode_value(item) for item in value]
+    return value
+
+
+def decode_value(value):
+    """Recursively restore values previously produced by :func:`encode_value`."""
+    if isinstance(value, dict):
+        if set(value) == {_TYPE_MARKER, _VALUE_MARKER}:
+            kind = value[_TYPE_MARKER]
+            payload = value[_VALUE_MARKER]
+            if kind == "datetime":
+                return datetime.fromisoformat(payload)
+            if kind == "objectid":
+                if _ObjectId is None:
+                    raise ImportError(
+                        "Reading BSON ObjectId values requires the optional "
+                        "'pymongo' package. Install it with: "
+                        "pip install 'tinymongo[bson]'"
+                    )
+                return _ObjectId(payload)
+            if kind == _ESCAPED_MAPPING:
+                if not isinstance(payload, list):
+                    return {key: decode_value(item) for key, item in value.items()}
+                try:
+                    return {str(key): decode_value(item) for key, item in payload}
+                except (TypeError, ValueError):
+                    return {key: decode_value(item) for key, item in value.items()}
+        return {key: decode_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [decode_value(item) for item in value]
+    return value
+
+
+def dumps(value, **kwargs):
+    """Serialize a TinyMongo value as JSON with BSON-compatible tagging."""
+    return json.dumps(encode_value(value), **kwargs)
+
+
+def loads(value):
+    """Deserialize JSON data and restore tagged BSON-compatible values."""
+    if isinstance(value, (str, bytes, bytearray)):
+        value = json.loads(value)
+    return decode_value(value)
+
+
+def clone(value):
+    """Return an isolated copy using the same rules as persistent storage."""
+    return loads(dumps(value, ensure_ascii=False))
+
+
+def contains_extended_value(value):
+    """Return whether a filter contains a value requiring Python comparison."""
+    if isinstance(value, datetime):
+        return True
+    if _ObjectId is not None and isinstance(value, _ObjectId):
+        return True
+    if isinstance(value, dict):
+        return any(contains_extended_value(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(contains_extended_value(item) for item in value)
+    return False

--- a/tinymongo/errors.py
+++ b/tinymongo/errors.py
@@ -1,64 +1,99 @@
-"""Exceptions raised by TinyMongo."""
+"""Exceptions raised by TinyMongo.
+
+When PyMongo is installed, TinyMongo exceptions also inherit from the matching
+PyMongo exception classes.  PyMongo remains optional, while applications that
+already catch ``PyMongoError`` continue to catch TinyMongo failures.
+"""
+
+try:  # Keep PyMongo an optional runtime integration.
+    from pymongo import errors as _pymongo_errors
+except ImportError:  # pragma: no cover - exercised in dependency-free installs
+
+    class _PyMongoError(Exception):
+        """Dependency-free stand-in for ``pymongo.errors.PyMongoError``."""
+
+    class _ConnectionFailure(_PyMongoError):
+        pass
+
+    class _ConfigurationError(_PyMongoError):
+        pass
+
+    class _OperationFailure(_PyMongoError):
+        def __init__(self, error, code=None, details=None, max_wire_version=None):
+            super(_OperationFailure, self).__init__(error)
+            self.__code = code
+            self.__details = details
+            self.__max_wire_version = max_wire_version
+
+        @property
+        def code(self):
+            return self.__code
+
+        @property
+        def details(self):
+            return self.__details
+
+        @property
+        def max_wire_version(self):
+            return self.__max_wire_version
+
+    class _CursorNotFound(_OperationFailure):
+        pass
+
+    class _WriteError(_OperationFailure):
+        pass
+
+    class _DuplicateKeyError(_WriteError):
+        pass
+
+    class _InvalidOperation(_PyMongoError):
+        pass
+
+else:
+    _PyMongoError = _pymongo_errors.PyMongoError  # type: ignore[misc,assignment]
+    _ConnectionFailure = _pymongo_errors.ConnectionFailure  # type: ignore[misc,assignment]
+    _ConfigurationError = _pymongo_errors.ConfigurationError  # type: ignore[misc,assignment]
+    _OperationFailure = _pymongo_errors.OperationFailure  # type: ignore[misc,assignment]
+    _CursorNotFound = _pymongo_errors.CursorNotFound  # type: ignore[misc,assignment]
+    _WriteError = _pymongo_errors.WriteError  # type: ignore[misc,assignment]
+    _DuplicateKeyError = _pymongo_errors.DuplicateKeyError  # type: ignore[misc,assignment]
+    _InvalidOperation = _pymongo_errors.InvalidOperation  # type: ignore[misc,assignment]
 
 
-class TinyMongoError(Exception):
+class TinyMongoError(_PyMongoError):
     """Base class for all TinyMongo exceptions."""
 
 
-class ConnectionFailure(TinyMongoError):
-    """Raised when a connection to the database file cannot be made or is lost."""
+class ConnectionFailure(_ConnectionFailure, TinyMongoError):
+    """Raised when a connection to storage cannot be made or is lost."""
 
 
-class ConfigurationError(TinyMongoError):
+class ConfigurationError(_ConfigurationError, TinyMongoError):
     """Raised when something is incorrectly configured."""
 
 
-class OperationFailure(TinyMongoError):
+class OperationFailure(_OperationFailure, TinyMongoError):
     """Raised when a database operation fails."""
 
-    def __init__(self, error, code=None, details=None):
-        self.__code = code
-        self.__details = details
-        TinyMongoError.__init__(self, error)
 
-    @property
-    def code(self):
-        """The error code returned by the server, if any."""
-        return self.__code
-
-    @property
-    def details(self):
-        """The complete error document returned by the server.
-
-        Depending on the error that occurred, the error document
-        may include useful information beyond just the error
-        message. When connected to a mongos the error document
-        may contain one or more subdocuments if errors occurred
-        on multiple shards.
-        """
-        return self.__details
+class CursorNotFound(_CursorNotFound, OperationFailure):
+    """Raised while iterating results after a cursor is invalidated."""
 
 
-class CursorNotFound(OperationFailure):
-    """Raised while iterating query results if the cursor is
-    invalidated on the server.
-    """
-
-
-class WriteError(OperationFailure):
+class WriteError(_WriteError, OperationFailure):
     """Base exception type for errors raised during write operations."""
 
 
-class DuplicateKeyError(WriteError):
-    """Raised when an insert or update fails due to a duplicate key error."""
+class DuplicateKeyError(_DuplicateKeyError, WriteError):
+    """Raised when a write violates a unique key constraint."""
 
 
-class InvalidOperation(TinyMongoError):
-    """Raised when a client attempts to perform an invalid operation."""
+class InvalidOperation(_InvalidOperation, TinyMongoError):
+    """Raised when a client attempts an invalid operation."""
 
 
 class TinyMongoNotSupportedError(TinyMongoError, NotImplementedError):
-    """Raised when TinyMongo cannot honor the requested database semantics."""
+    """Raised when TinyMongo cannot honor requested database semantics."""
 
 
 class StorageError(TinyMongoError):

--- a/tinymongo/indexes.py
+++ b/tinymongo/indexes.py
@@ -1,0 +1,487 @@
+"""Backend-independent helpers for TinyMongo index definitions and keys."""
+
+import json
+import math
+import warnings
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Mapping, Optional
+
+from .errors import DuplicateKeyError, TinyMongoNotSupportedError
+
+
+INDEX_METADATA_VERSION = 1
+INDEX_CATALOG_TABLE = "__tinymongo_indexes"
+MISSING = object()
+_ALLOWED_OPTIONS = {"name", "unique"}
+_MODEL_ALLOWED_OPTIONS = {
+    "background",
+    "expireAfterSeconds",
+    "name",
+    "sparse",
+    "unique",
+}
+
+
+class TinyMongoUnsupportedWarning(UserWarning):
+    """Warn that an index declaration was accepted with reduced behavior."""
+
+
+def _unsupported(message):
+    raise TinyMongoNotSupportedError(message)
+
+
+def _validate_field(field):
+    if not isinstance(field, str) or not field:
+        _unsupported("Index fields must be non-empty strings")
+    if "\x00" in field or any(not part for part in field.split(".")):
+        _unsupported("Index fields must use valid non-empty dotted paths")
+    if any(part.startswith("$") for part in field.split(".")):
+        _unsupported("Index field components cannot start with '$'")
+
+
+def _parse_key(key):
+    if isinstance(key, str):
+        return key, 1
+
+    pair = None
+    if isinstance(key, (list, tuple)) and len(key) == 2 and isinstance(key[0], str):
+        pair = key
+    elif isinstance(key, (list, tuple)):
+        if len(key) != 1:
+            _unsupported("Only single-field indexes are supported")
+        candidate = key[0]
+        if isinstance(candidate, (list, tuple)) and len(candidate) == 2:
+            pair = candidate
+
+    if pair is None:
+        _unsupported("Index keys must be a field string or one (field, direction) pair")
+
+    field, direction = pair
+    if not isinstance(field, str):
+        _unsupported("Index fields must be non-empty strings")
+    return field, direction
+
+
+def _validate_index_name(name, field=None):
+    if not isinstance(name, str) or not name or "\x00" in name:
+        _unsupported("Index names must be non-empty strings")
+    if field != "_id" and name in ("_id", "_id_"):
+        _unsupported("The built-in _id index names are reserved")
+
+
+def _default_index_name(keys):
+    return "_".join("{0}_{1}".format(field, direction) for field, direction in keys)
+
+
+@dataclass(frozen=True)
+class IndexSpec:
+    """A normalized index definition supported by TinyMongo."""
+
+    field: str
+    direction: int = 1
+    unique: bool = False
+    name: Optional[str] = None
+
+    def __post_init__(self):
+        _validate_field(self.field)
+        if self.direction != 1 or isinstance(self.direction, bool):
+            _unsupported("Only ascending index direction 1 is supported")
+        if not isinstance(self.unique, bool):
+            _unsupported("The unique index option must be a boolean")
+
+        name = self.name
+        if name is None:
+            name = "{0}_1".format(self.field)
+        _validate_index_name(name, self.field)
+        object.__setattr__(self, "name", name)
+
+    def to_metadata(self):
+        """Return a JSON-safe durable representation of this index."""
+        return {
+            "v": INDEX_METADATA_VERSION,
+            "name": self.name,
+            "key": [[self.field, self.direction]],
+            "unique": self.unique,
+        }
+
+    @classmethod
+    def from_metadata(cls, metadata):
+        """Restore and validate an index from durable metadata."""
+        if not isinstance(metadata, Mapping):
+            raise ValueError("Index metadata must be a mapping")
+        if metadata.get("v") != INDEX_METADATA_VERSION:
+            raise ValueError("Unsupported index metadata version")
+        required = {"v", "name", "key", "unique"}
+        if set(metadata) != required:
+            raise ValueError("Index metadata has missing or unknown fields")
+        return parse_index_spec(
+            metadata["key"],
+            name=metadata["name"],
+            unique=metadata["unique"],
+        )
+
+
+def parse_index_spec(key, **options):
+    """Normalize a supported single-field ascending index definition."""
+    unknown = sorted(set(options) - _ALLOWED_OPTIONS)
+    if unknown:
+        _unsupported("Unsupported index option(s): {0}".format(", ".join(unknown)))
+
+    field, direction = _parse_key(key)
+    return IndexSpec(
+        field=field,
+        direction=direction,
+        unique=options.get("unique", False),
+        name=options.get("name"),
+    )
+
+
+@dataclass(frozen=True)
+class IndexModelPlan:
+    """One normalized outcome from a PyMongo-style index declaration.
+
+    ``spec`` is the effective index TinyMongo can create. Compound indexes use
+    their ascending leading-field prefix, matching MongoDB's leftmost-prefix
+    behavior as closely as a single-field backend can. It is ``None`` when no
+    useful safe fallback exists, such as a text index. ``degraded_features``
+    records every requested feature that is not honored.
+    """
+
+    name: str
+    requested_keys: tuple
+    requested_options: tuple
+    spec: Optional[IndexSpec]
+    degraded_features: tuple = ()
+    warning: Optional[str] = None
+
+    @property
+    def outcome(self):
+        """Return ``create``, ``create_degraded``, or ``skip``."""
+        if self.spec is None:
+            return "skip"
+        if self.degraded_features:
+            return "create_degraded"
+        return "create"
+
+    def to_metadata(self):
+        """Return JSON-safe planning metadata for diagnostics and tests."""
+        return {
+            "name": self.name,
+            "requested_key": [list(pair) for pair in self.requested_keys],
+            "requested_options": dict(self.requested_options),
+            "outcome": self.outcome,
+            "degraded_features": list(self.degraded_features),
+            "effective_spec": None if self.spec is None else self.spec.to_metadata(),
+        }
+
+
+@dataclass(frozen=True)
+class IndexBatchPlan:
+    """Ordered index-model outcomes suitable for ``create_indexes`` wiring."""
+
+    entries: tuple
+
+    def __iter__(self):
+        return iter(self.entries)
+
+    @property
+    def names(self):
+        """Return requested index names in input order."""
+        return tuple(entry.name for entry in self.entries)
+
+    @property
+    def specs(self):
+        """Return only effective index specs that should be created."""
+        return tuple(entry.spec for entry in self.entries if entry.spec is not None)
+
+    @property
+    def warnings(self):
+        """Return warning messages in input order."""
+        return tuple(entry.warning for entry in self.entries if entry.warning)
+
+
+def _index_model_document(model):
+    if isinstance(model, Mapping):
+        document = model
+    else:
+        try:
+            document = model.document
+        except AttributeError:
+            raise TypeError(
+                "Index models must expose a mapping-valued document attribute"
+            ) from None
+    if not isinstance(document, Mapping):
+        raise TypeError("Index model document must be a mapping")
+    return document
+
+
+def _index_model_keys(key_document):
+    if isinstance(key_document, Mapping):
+        keys = tuple(key_document.items())
+    elif isinstance(key_document, (list, tuple)):
+        keys = tuple(key_document)
+    else:
+        _unsupported("IndexModel key must be a mapping or sequence of pairs")
+    if not keys:
+        _unsupported("IndexModel key must contain at least one field")
+
+    normalized = []
+    for pair in keys:
+        if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+            _unsupported("IndexModel keys must contain (field, direction) pairs")
+        field, direction = pair
+        _validate_field(field)
+        if isinstance(direction, bool) or direction not in (1, -1, "hashed", "text"):
+            _unsupported(
+                "IndexModel directions must be 1, -1, 'hashed', or 'text'; got "
+                "{0!r}".format(direction)
+            )
+        normalized.append((field, direction))
+    return tuple(normalized)
+
+
+def _validate_model_options(options):
+    unknown = sorted(set(options) - _MODEL_ALLOWED_OPTIONS)
+    if unknown:
+        _unsupported("Unsupported index option(s): {0}".format(", ".join(unknown)))
+
+    unique = options.get("unique", False)
+    if not isinstance(unique, bool):
+        _unsupported("The unique index option must be a boolean")
+
+    for option in ("sparse", "background"):
+        if option in options and not isinstance(options[option], bool):
+            _unsupported("The {0} index option must be a boolean".format(option))
+
+    if "expireAfterSeconds" in options:
+        seconds = options["expireAfterSeconds"]
+        if (
+            isinstance(seconds, bool)
+            or not isinstance(seconds, (int, float))
+            or not math.isfinite(seconds)
+            or seconds < 0
+        ):
+            _unsupported("The expireAfterSeconds index option must be non-negative")
+
+
+def _degraded_feature_message(feature):
+    messages = {
+        "background": "background creation is ignored",
+        "compound": "compound indexing is reduced to its ascending leading field",
+        "descending": "descending direction is treated as ascending",
+        "hashed": "hashed indexing is replaced by ascending equality indexing",
+        "sparse": "sparse membership is not honored",
+        "text": "text indexing is ignored because $text queries are not supported",
+        "ttl": "TTL expiration is not performed",
+    }
+    return messages[feature]
+
+
+def _plan_warning(name, features):
+    details = "; ".join(_degraded_feature_message(item) for item in features)
+    return "Index {0!r} was created with reduced behavior: {1}.".format(name, details)
+
+
+def plan_index_model(model):
+    """Plan one duck-typed PyMongo ``IndexModel`` declaration.
+
+    PyMongo is deliberately not imported. Any object whose ``document``
+    attribute is a mapping with ``key`` and index options is accepted. A plain
+    mapping is also accepted for adapters and contract tests.
+    """
+    if isinstance(model, IndexSpec):
+        return IndexModelPlan(
+            name=model.name,
+            requested_keys=((model.field, model.direction),),
+            requested_options=(("name", model.name), ("unique", model.unique)),
+            spec=model,
+        )
+
+    document = _index_model_document(model)
+    if "key" not in document:
+        _unsupported("IndexModel document must contain a key definition")
+    keys = _index_model_keys(document["key"])
+    options = {key: value for key, value in document.items() if key != "key"}
+    _validate_model_options(options)
+
+    name = options.get("name")
+    if name is None:
+        name = _default_index_name(keys)
+    first_field = keys[0][0] if len(keys) == 1 else None
+    _validate_index_name(name, first_field)
+
+    unique = options.get("unique", False)
+    features = []
+    if len(keys) > 1:
+        features.append("compound")
+    if any(direction == -1 for _, direction in keys):
+        features.append("descending")
+    if any(direction == "hashed" for _, direction in keys):
+        features.append("hashed")
+    if any(direction == "text" for _, direction in keys):
+        features.append("text")
+    if options.get("sparse", False):
+        features.append("sparse")
+    if "expireAfterSeconds" in options:
+        features.append("ttl")
+    if options.get("background", False):
+        features.append("background")
+
+    unsafe_unique_features = {"compound", "hashed", "sparse", "text", "ttl"}
+    unsafe = [item for item in features if item in unsafe_unique_features]
+    if unique and unsafe:
+        _unsupported(
+            "Unique index {0!r} cannot be degraded because {1} would change its "
+            "semantics".format(name, ", ".join(unsafe))
+        )
+
+    spec = None
+    if "text" not in features:
+        spec = IndexSpec(
+            field=keys[0][0],
+            direction=1,
+            unique=unique,
+            name=name,
+        )
+    degraded = tuple(features)
+    warning = _plan_warning(name, degraded) if degraded else None
+    return IndexModelPlan(
+        name=name,
+        requested_keys=keys,
+        requested_options=tuple(options.items()),
+        spec=spec,
+        degraded_features=degraded,
+        warning=warning,
+    )
+
+
+def plan_index_models(models):
+    """Return ordered outcomes for a ``create_indexes`` model iterable."""
+    try:
+        entries = tuple(plan_index_model(model) for model in models)
+    except TypeError as exc:
+        if "not iterable" not in str(exc):
+            raise
+        raise TypeError("Index models must be an iterable") from None
+    return IndexBatchPlan(entries)
+
+
+def emit_index_plan_warnings(plan, stacklevel=2):
+    """Emit dedicated warnings for every degraded batch entry."""
+    if not isinstance(plan, IndexBatchPlan):
+        raise TypeError("Index warning emission requires an IndexBatchPlan")
+    for message in plan.warnings:
+        warnings.warn(
+            message,
+            TinyMongoUnsupportedWarning,
+            stacklevel=stacklevel,
+        )
+
+
+def index_catalog_id(collection, index_name):
+    """Encode an unambiguous durable identity for a collection index."""
+    return json.dumps(
+        [str(collection), str(index_name)],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _nested_value(document, path):
+    current = document
+    for part in path.split("."):
+        if isinstance(current, (list, tuple)):
+            _unsupported("Array traversal inside dotted index paths is not supported")
+        if not isinstance(current, Mapping) or part not in current:
+            return MISSING
+        current = current[part]
+    return current
+
+
+def _scalar_token(value):
+    if value is MISSING or value is None:
+        return "null:"
+    if isinstance(value, bool):
+        return "bool:{0}".format("true" if value else "false")
+    if isinstance(value, int):
+        if value == 0:
+            return "number:0"
+        return "number:{0}".format(Decimal(value).normalize())
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            _unsupported("Non-finite numbers cannot be indexed")
+        if value == 0:
+            return "number:0"
+        return "number:{0}".format(Decimal(str(value)).normalize())
+    if isinstance(value, str):
+        return "string:{0}".format(
+            json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+        )
+    if isinstance(value, Mapping):
+        _unsupported("Object values cannot be indexed")
+    if isinstance(value, (list, tuple)):
+        _unsupported("Nested array values cannot be indexed")
+    _unsupported("Unsupported indexed value type: {0}".format(type(value).__name__))
+
+
+def index_tokens(document, field):
+    """Return deterministic index tokens for a document's nested field."""
+    if not isinstance(document, Mapping):
+        raise TypeError("Indexed documents must be mappings")
+    _validate_field(field)
+
+    value = _nested_value(document, field)
+    values = value if isinstance(value, list) else [value]
+    if not values:
+        return ("undefined:",)
+    tokens = []
+    seen = set()
+    for item in values:
+        token = _scalar_token(item)
+        if token not in seen:
+            tokens.append(token)
+            seen.add(token)
+    return tuple(tokens)
+
+
+def validate_unique_documents(documents, indexes):
+    """Raise when post-image documents conflict on a unique index."""
+    docs = list(documents)
+    specs = list(indexes)
+    for spec in specs:
+        if not isinstance(spec, IndexSpec):
+            raise TypeError("Unique index validation requires IndexSpec values")
+        if not spec.unique:
+            continue
+
+        owners = {}
+        for position, document in enumerate(docs):
+            if not isinstance(document, Mapping):
+                raise TypeError("Indexed documents must be mappings")
+            identity = document.get("_id", "position {0}".format(position))
+            for token in index_tokens(document, spec.field):
+                if token in owners:
+                    raise DuplicateKeyError(
+                        "duplicate key for unique index {0}: documents {1!r} and "
+                        "{2!r}".format(spec.name, owners[token], identity)
+                    )
+                owners[token] = identity
+
+
+__all__ = [
+    "INDEX_METADATA_VERSION",
+    "INDEX_CATALOG_TABLE",
+    "IndexBatchPlan",
+    "IndexModelPlan",
+    "IndexSpec",
+    "MISSING",
+    "TinyMongoUnsupportedWarning",
+    "emit_index_plan_warnings",
+    "index_catalog_id",
+    "index_tokens",
+    "parse_index_spec",
+    "plan_index_model",
+    "plan_index_models",
+    "validate_unique_documents",
+]

--- a/tinymongo/parquet_storage.py
+++ b/tinymongo/parquet_storage.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 from tinydb.storages import Storage
@@ -6,6 +5,8 @@ import threading
 from typing import Any, Dict
 
 from .errors import StorageCorruptionError
+from .bson_codec import dumps as json_dumps
+from .bson_codec import loads as json_loads
 
 try:
     import pyarrow as _pa
@@ -61,7 +62,9 @@ def _acquire_rlock(rlock):
     first_acquire = rlock.acquire(blocking=False)
     if not first_acquire:
         rlock.acquire()
-        return False
+        # A different thread owned the process-local lock. This thread is now
+        # the outer owner and must acquire the cross-process file lock too.
+        return True
     return True
 
 
@@ -100,7 +103,7 @@ class ParquetStorage(Storage):
                 data_arr = table.column("data").to_pylist()
                 if not data_arr:
                     return {}
-                return json.loads(data_arr[0])
+                return json_loads(data_arr[0])
             except Exception as exc:
                 raise StorageCorruptionError(
                     "Cannot read Parquet database {0}: {1}".format(self.path, exc)
@@ -118,7 +121,7 @@ class ParquetStorage(Storage):
 
     def write(self, data):
         # serialize the entire TinyDB dict to a JSON string
-        json_str = json.dumps(data or {}, ensure_ascii=False)
+        json_str = json_dumps(data or {}, ensure_ascii=False)
 
         # ensure parent dir exists
         dname = os.path.dirname(self.path) or "."
@@ -149,7 +152,7 @@ class ParquetStorage(Storage):
                     if "data" in table.column_names:  # pragma: no branch
                         data_arr = table.column("data").to_pylist()
                         if data_arr:  # pragma: no branch
-                            existing = json.loads(data_arr[0])
+                            existing = json_loads(data_arr[0])
                 except Exception as exc:
                     raise StorageCorruptionError(
                         "Cannot update Parquet database {0}: {1}".format(self.path, exc)
@@ -166,11 +169,11 @@ class ParquetStorage(Storage):
                 incoming_table = {str(k): v for k, v in (table_data or {}).items()}
                 existing_table = merged.get(t, {})
 
-                id_to_eid = {
-                    v.get("_id"): k
+                ids_and_eids = [
+                    (v.get("_id"), k)
                     for k, v in existing_table.items()
                     if isinstance(v, dict) and "_id" in v
-                }
+                ]
                 try:
                     next_eid = max(int(k) for k in existing_table.keys()) + 1
                 except Exception:
@@ -178,15 +181,23 @@ class ParquetStorage(Storage):
 
                 for k, v in incoming_table.items():
                     doc_id = v.get("_id") if isinstance(v, dict) else None
-                    if doc_id is not None and doc_id in id_to_eid:
-                        existing_table[id_to_eid[doc_id]] = v
+                    existing_eid = next(
+                        (
+                            eid
+                            for existing_id, eid in ids_and_eids
+                            if existing_id == doc_id
+                        ),
+                        None,
+                    )
+                    if doc_id is not None and existing_eid is not None:
+                        existing_table[existing_eid] = v
                     else:
                         existing_table[str(next_eid)] = v
                         next_eid += 1
 
                 merged[t] = existing_table
 
-            json_str = json.dumps(merged, ensure_ascii=False)
+            json_str = json_dumps(merged, ensure_ascii=False)
 
             # write Parquet with single column 'data'
             arr = pa.array([json_str], type=pa.string())

--- a/tinymongo/patching.py
+++ b/tinymongo/patching.py
@@ -1,0 +1,199 @@
+"""Temporarily route PyMongo client construction to TinyMongo."""
+
+from contextlib import ContextDecorator
+import asyncio
+import importlib
+import inspect
+import threading
+from uuid import uuid4
+
+from .asyncio import AsyncMongoClient
+from .storage_backends import clear_memory_namespace
+from .tinymongo import MongoClient
+
+
+_patch_state_lock = threading.RLock()
+_patch_owner = None
+_patch_entries = []
+
+
+def _patch_context_owner():
+    """Identify the thread and, when applicable, the current asyncio task."""
+
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        task = None
+    return threading.get_ident(), task
+
+
+def _import_pymongo():
+    """Import PyMongo only when patching is requested."""
+    try:
+        return importlib.import_module("pymongo")
+    except ImportError as exc:
+        raise ImportError(
+            "tinymongo.patch requires the optional PyMongo package. "
+            "Install it with: pip install pymongo"
+        ) from exc
+
+
+def _patch_folder(folder, backend):
+    """Resolve storage for one patch entry and its optional cleanup target."""
+    if folder is not None:
+        return folder, None
+    if str(backend).lower() == "memory":
+        namespace = "memory://__tinymongo_patch__{0}".format(uuid4().hex)
+        return namespace, namespace
+    return "tinydb", None
+
+
+def _configured_client(folder, backend, clients):
+    """Build a class that forces the patch scope's TinyMongo configuration."""
+
+    class ConfiguredMongoClient(MongoClient):
+        def __init__(self, *args, **kwargs):
+            options = dict(kwargs)
+            options["backend"] = backend
+            options["tinymongo_folder"] = folder
+            super(ConfiguredMongoClient, self).__init__(*args, **options)
+            clients.append(self)
+
+    ConfiguredMongoClient.__name__ = "MongoClient"
+    ConfiguredMongoClient.__qualname__ = "MongoClient"
+    return ConfiguredMongoClient
+
+
+def _configured_async_client(folder, backend, clients):
+    """Build an async client class forced to the patch scope's storage."""
+
+    class ConfiguredAsyncMongoClient(AsyncMongoClient):
+        def __init__(self, *args, **kwargs):
+            options = dict(kwargs)
+            options["backend"] = backend
+            options["tinymongo_folder"] = folder
+            super(ConfiguredAsyncMongoClient, self).__init__(*args, **options)
+            clients.append(self)
+
+    ConfiguredAsyncMongoClient.__name__ = "AsyncMongoClient"
+    ConfiguredAsyncMongoClient.__qualname__ = "AsyncMongoClient"
+    return ConfiguredAsyncMongoClient
+
+
+class _TinyMongoPatch(ContextDecorator):
+    """Reusable context/decorator implementation for :func:`patch`."""
+
+    def __init__(self, folder=None, backend="memory"):
+        self.folder = folder
+        self.backend = backend
+        self._restore_stack = []
+
+    def __enter__(self):
+        global _patch_owner
+
+        owner = _patch_context_owner()
+        with _patch_state_lock:
+            if _patch_owner is not None and _patch_owner != owner:
+                raise RuntimeError(
+                    "tinymongo.patch changes process-global PyMongo state and "
+                    "cannot overlap across threads or async tasks"
+                )
+
+            clients = []
+            async_clients = []
+            pymongo = _import_pymongo()
+            folder, cleanup_namespace = _patch_folder(self.folder, self.backend)
+            original = pymongo.MongoClient
+            replacement = _configured_client(folder, self.backend, clients)
+            pymongo.MongoClient = replacement
+            original_async = getattr(pymongo, "AsyncMongoClient", None)
+            if original_async is not None:
+                pymongo.AsyncMongoClient = _configured_async_client(
+                    folder, self.backend, async_clients
+                )
+            entry = (
+                self,
+                pymongo,
+                original,
+                original_async,
+                cleanup_namespace,
+                clients,
+                async_clients,
+            )
+            _patch_entries.append(entry)
+            _patch_owner = owner
+            self._restore_stack.append(entry)
+            return replacement
+
+    def _restore(self):
+        global _patch_owner
+
+        with _patch_state_lock:
+            if not self._restore_stack or not _patch_entries:
+                raise RuntimeError("tinymongo.patch scope exited without being entered")
+            entry = self._restore_stack[-1]
+            if _patch_entries[-1] is not entry:
+                raise RuntimeError("tinymongo.patch scopes must exit in nested order")
+
+            self._restore_stack.pop()
+            _patch_entries.pop()
+            (
+                _,
+                pymongo,
+                original,
+                original_async,
+                cleanup_namespace,
+                clients,
+                async_clients,
+            ) = entry
+            pymongo.MongoClient = original
+            if original_async is not None:
+                pymongo.AsyncMongoClient = original_async
+            if not _patch_entries:
+                _patch_owner = None
+        return cleanup_namespace, clients, async_clients
+
+    @staticmethod
+    def _cleanup_namespace(cleanup_namespace):
+        if cleanup_namespace is not None:
+            clear_memory_namespace(cleanup_namespace)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        cleanup_namespace, clients, async_clients = self._restore()
+        for client in clients:
+            client.close()
+        for client in async_clients:
+            client._state._close()
+        self._cleanup_namespace(cleanup_namespace)
+        return False
+
+    async def __aenter__(self):
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        cleanup_namespace, clients, async_clients = self._restore()
+        for client in clients:
+            client.close()
+        for client in async_clients:
+            await client.close()
+        self._cleanup_namespace(cleanup_namespace)
+        return False
+
+    def __call__(self, function):
+        if inspect.iscoroutinefunction(function):
+            raise TypeError(
+                "tinymongo.patch does not decorate async functions; "
+                "use a with block inside the async function"
+            )
+        return super(_TinyMongoPatch, self).__call__(function)
+
+
+def patch(folder=None, backend="memory"):
+    """Temporarily replace ``pymongo.MongoClient`` with TinyMongo.
+
+    The default memory backend is isolated to one patch scope while clients
+    created inside that scope share data. Pass ``folder`` and ``backend`` to
+    select persistent storage instead. The returned object works as both a
+    context manager and a decorator.
+    """
+    return _TinyMongoPatch(folder=folder, backend=backend)

--- a/tinymongo/projection.py
+++ b/tinymongo/projection.py
@@ -1,0 +1,181 @@
+"""Mongo-style inclusion and exclusion projections."""
+
+import copy
+from collections.abc import Mapping, Sequence, Set
+from numbers import Number
+
+from .errors import OperationFailure, TinyMongoNotSupportedError
+
+
+_LEAF = object()
+_OMIT = object()
+
+
+class ProjectionSpec(object):
+    """Normalized basic projection used by every storage backend."""
+
+    __slots__ = ("mode", "tree", "include_id")
+
+    def __init__(self, mode, tree, include_id):
+        self.mode = mode
+        self.tree = tree
+        self.include_id = include_id
+
+
+def _projection_path(path):
+    if not isinstance(path, str):
+        raise TypeError("projection field names must be strings")
+    if not path or "\x00" in path:
+        raise OperationFailure("Projection field names cannot be empty", code=40352)
+
+    parts = path.split(".")
+    if any(not part for part in parts):
+        raise OperationFailure(
+            "Projection field paths cannot contain empty components", code=15998
+        )
+    if any(part.startswith("$") for part in parts):
+        raise TinyMongoNotSupportedError(
+            "Projection operators and positional projection are not supported"
+        )
+    if any(part.lstrip("-").isdigit() for part in parts):
+        raise TinyMongoNotSupportedError(
+            "Projection through numeric array indexes is not supported"
+        )
+    return parts
+
+
+def _flatten_mapping(mapping, prefix=None):
+    flattened = []
+    for key, value in mapping.items():
+        parts = _projection_path(key)
+        path = ".".join(([prefix] if prefix else []) + parts)
+        if isinstance(value, Mapping):
+            if not value:
+                raise TinyMongoNotSupportedError(
+                    "Empty and expression projection mappings are not supported"
+                )
+            flattened.extend(_flatten_mapping(value, path))
+        elif isinstance(value, Number):
+            flattened.append((path, bool(value)))
+        else:
+            raise TinyMongoNotSupportedError(
+                "Only numeric inclusion and exclusion projection flags are supported"
+            )
+    return flattened
+
+
+def _projection_items(projection):
+    if isinstance(projection, Mapping):
+        return _flatten_mapping(projection)
+    if isinstance(projection, (Sequence, Set)) and not isinstance(
+        projection, (str, bytes, bytearray)
+    ):
+        paths = (".".join(_projection_path(path)) for path in projection)
+        return [(path, True) for path in dict.fromkeys(paths)]
+    raise TypeError("projection must be a mapping or list of field names")
+
+
+def _add_path(tree, path):
+    node = tree
+    for part in path.split("."):
+        if _LEAF in node:
+            raise OperationFailure("Path collision at {0}".format(path), code=31249)
+        node = node.setdefault(part, {})
+    if node:
+        raise OperationFailure("Path collision at {0}".format(path), code=31250)
+    node[_LEAF] = True
+
+
+def normalize_projection(projection):
+    """Validate and normalize a basic MongoDB projection document."""
+    if projection is None:
+        return None
+
+    items = _projection_items(projection)
+    if not items:
+        return None
+
+    mode = None
+    include_id = True
+    paths = []
+    collision_tree = {}
+    for path, include in items:
+        _add_path(collision_tree, path)
+        if path == "_id":
+            include_id = include
+            continue
+        if mode is None:
+            mode = "include" if include else "exclude"
+        elif (mode == "include") != include:
+            code = 31254 if mode == "include" else 31253
+            raise OperationFailure(
+                "Cannot mix inclusion and exclusion in a projection", code=code
+            )
+        paths.append(path)
+
+    if mode is None:
+        mode = "include" if include_id else "exclude"
+
+    tree = {}
+    for path in paths:
+        _add_path(tree, path)
+    return ProjectionSpec(mode, tree, include_id)
+
+
+def _include_value(value, tree):
+    if _LEAF in tree:
+        return copy.deepcopy(value)
+    if isinstance(value, dict):
+        result = {}
+        for key, child_tree in tree.items():
+            if key in value:
+                child = _include_value(value[key], child_tree)
+                if child is not _OMIT:
+                    result[key] = child
+        return result
+    if isinstance(value, list):
+        result = []
+        for item in value:
+            if not isinstance(item, (dict, list)):
+                continue
+            result.append(_include_value(item, tree))
+        return result
+    return _OMIT
+
+
+def _exclude_value(value, tree):
+    if isinstance(value, dict):
+        for key, child_tree in tree.items():
+            if key not in value:
+                continue
+            if _LEAF in child_tree:
+                value.pop(key, None)
+            else:
+                _exclude_value(value[key], child_tree)
+    elif isinstance(value, list):
+        for item in value:
+            _exclude_value(item, tree)
+
+
+def project_document(document, projection):
+    """Return a projected copy of *document* using a normalized spec."""
+    if document is None or projection is None:
+        return document
+
+    if projection.mode == "exclude":
+        result = copy.deepcopy(document)
+        _exclude_value(result, projection.tree)
+        if not projection.include_id:
+            result.pop("_id", None)
+        return result
+
+    result = {}
+    if projection.include_id and "_id" in document and "_id" not in projection.tree:
+        result["_id"] = copy.deepcopy(document["_id"])
+    for key, tree in projection.tree.items():
+        if key not in document:
+            continue
+        value = _include_value(document[key], tree)
+        if value is not _OMIT:
+            result[key] = value
+    return result

--- a/tinymongo/serializers.py
+++ b/tinymongo/serializers.py
@@ -2,11 +2,11 @@ from datetime import datetime
 
 try:
     from tinydb_serialization import Serializer
-except ImportError:
+except ImportError as exc:
     raise RuntimeError(
-        "Cannot import tinydb_serialization due to {0} "
-        'install it with `pip install "tinymongo[serialization]"`'
-    )
+        "Cannot import tinydb_serialization. Install it with: "
+        'pip install "tinymongo[serialization]"'
+    ) from exc
 
 
 class DateTimeSerializer(Serializer):

--- a/tinymongo/storage_backends.py
+++ b/tinymongo/storage_backends.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import os
 import sqlite3
 import tempfile
@@ -7,6 +6,9 @@ import threading
 from typing import Any
 from tinydb.storages import Storage
 from urllib.parse import urlparse
+from .bson_codec import clone as clone_document
+from .bson_codec import dumps as json_dumps
+from .bson_codec import loads as json_loads
 from .parquet_storage import _acquire_rlock, _fsync_dir, _local_rlocks, portalocker
 from .errors import StorageCorruptionError
 
@@ -61,6 +63,18 @@ def clear_memory_namespace(namespace):
                     _memory_registry.pop(address, None)
 
 
+def clear_memory_database(address):
+    """Remove one named database from the process-local storage registry."""
+    with _memory_registry_lock:
+        entry = _memory_registry.get(str(address))
+    if entry is None:
+        return
+    with entry["lock"]:
+        with _memory_registry_lock:
+            if _memory_registry.get(str(address)) is entry:
+                _memory_registry.pop(str(address), None)
+
+
 def is_object_storage_uri(value):
     return urlparse(str(value or "")).scheme.lower() in OBJECT_STORAGE_SCHEMES
 
@@ -112,7 +126,7 @@ class AtomicJSONStorage(Storage):
             if not os.path.exists(self.path) or os.path.getsize(self.path) == 0:
                 return {}
             with open(self.path, "r", encoding="utf8") as handle:
-                return json.load(handle)
+                return json_loads(handle.read())
         except (OSError, ValueError, TypeError) as exc:
             raise StorageCorruptionError(
                 "Cannot read JSON database {0}: {1}".format(self.path, exc)
@@ -133,11 +147,11 @@ class AtomicJSONStorage(Storage):
                 str(key): value for key, value in (table_data or {}).items()
             }
             existing_table = merged.get(table, {})
-            id_to_eid = {
-                value.get("_id"): key
+            ids_and_eids = [
+                (value.get("_id"), key)
                 for key, value in existing_table.items()
                 if isinstance(value, dict) and "_id" in value
-            }
+            ]
             try:
                 next_eid = max(int(key) for key in existing_table.keys()) + 1
             except Exception:
@@ -145,8 +159,12 @@ class AtomicJSONStorage(Storage):
 
             for value in incoming_table.values():
                 doc_id = value.get("_id") if isinstance(value, dict) else None
-                if doc_id is not None and doc_id in id_to_eid:
-                    existing_table[id_to_eid[doc_id]] = value
+                existing_eid = next(
+                    (eid for existing_id, eid in ids_and_eids if existing_id == doc_id),
+                    None,
+                )
+                if doc_id is not None and existing_eid is not None:
+                    existing_table[existing_eid] = value
                 else:
                     existing_table[str(next_eid)] = value
                     next_eid += 1
@@ -164,14 +182,14 @@ class AtomicJSONStorage(Storage):
                 try:
                     with open(self.path, "r", encoding="utf8") as handle:
                         payload_data = self._merge_data(
-                            json.load(handle) or {}, payload_data
+                            json_loads(handle.read()) or {}, payload_data
                         )
                 except (OSError, ValueError, TypeError) as exc:
                     raise StorageCorruptionError(
                         "Cannot update JSON database {0}: {1}".format(self.path, exc)
                     ) from exc
 
-            payload = json.dumps(payload_data, ensure_ascii=False)
+            payload = json_dumps(payload_data, ensure_ascii=False)
             with os.fdopen(fd, "w", encoding="utf8") as handle:
                 handle.write(payload)
                 handle.flush()
@@ -214,7 +232,7 @@ class MemoryStorage(AtomicJSONStorage):
 
     def write(self, data):
         with self.collection_lock:
-            payload = json.loads(json.dumps(data or {}, ensure_ascii=False))
+            payload = clone_document(data or {})
             if self.merge_writes and self._entry["data"] is not None:
                 payload = self._merge_data(self._entry["data"], payload)
             self._entry["data"] = copy.deepcopy(payload)
@@ -245,14 +263,14 @@ class SQLiteStorage(Storage):
             conn.close()
             if row is None or row[0] is None:
                 return {}
-            return json.loads(row[0])
+            return json_loads(row[0])
         except (sqlite3.DatabaseError, ValueError, TypeError, OSError) as exc:
             raise StorageCorruptionError(
                 "Cannot read SQLite database {0}: {1}".format(self.path, exc)
             ) from exc
 
     def write(self, data):
-        json_str = json.dumps(data or {}, ensure_ascii=False)
+        json_str = json_dumps(data or {}, ensure_ascii=False)
         dname = os.path.dirname(self.path) or "."
         os.makedirs(dname, exist_ok=True)
 
@@ -301,14 +319,14 @@ class DuckDBStorage(Storage):
             conn.close()
             if result is None or result[0] is None:
                 return {}
-            return json.loads(result[0])
+            return json_loads(result[0])
         except Exception as exc:
             raise StorageCorruptionError(
                 "Cannot read DuckDB database {0}: {1}".format(self.path, exc)
             ) from exc
 
     def write(self, data):
-        json_str = json.dumps(data or {}, ensure_ascii=False)
+        json_str = json_dumps(data or {}, ensure_ascii=False)
         dname = os.path.dirname(self.path) or "."
         os.makedirs(dname, exist_ok=True)
 

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -1,20 +1,49 @@
-import json
+import hashlib
 import importlib
+import json
 import os
 import re
 import sqlite3
 import tempfile
 import threading
 from contextlib import contextmanager
+from functools import wraps
 from urllib.parse import parse_qs, unquote, urlparse
 from typing import Optional
 
-from .errors import DuplicateKeyError
+from .bson_codec import contains_extended_value
+from .bson_codec import dumps as bson_json_dumps
+from .bson_codec import loads as bson_json_loads
+from .errors import (
+    DuplicateKeyError,
+    OperationFailure,
+    StorageCorruptionError,
+    TinyMongoNotSupportedError,
+)
+from .indexes import (
+    INDEX_CATALOG_TABLE,
+    IndexSpec,
+    index_catalog_id,
+    index_tokens,
+    parse_index_spec,
+    validate_unique_documents,
+)
 from .parquet_storage import _acquire_rlock, _local_rlocks, portalocker
 
 
 _MISSING = object()
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
+
+
+def _write_locked(method):
+    """Serialize a backend read-check-write operation."""
+
+    @wraps(method)
+    def wrapped(self, *args, **kwargs):
+        with self._write_lock():
+            return method(self, *args, **kwargs)
+
+    return wrapped
 
 
 def _import_optional_driver(module_name, backend_name, install_hint):
@@ -43,6 +72,12 @@ def _sql_literal(value):
     if isinstance(value, bool):
         return "true" if value else "false"
     return "'" + str(value).replace("'", "''") + "'"
+
+
+def _json_path(field):
+    return "$" + "".join(
+        "." + json.dumps(part, ensure_ascii=False) for part in field.split(".")
+    )
 
 
 def _env_first(*names):
@@ -117,11 +152,15 @@ def _duckdb_setup_sql_from_env():
 
 
 def _json_dumps(doc):
-    return json.dumps(doc, ensure_ascii=False, separators=(",", ":"))
+    return bson_json_dumps(doc, ensure_ascii=False, separators=(",", ":"))
 
 
 def _json_loads(value):
-    return json.loads(value)
+    decoded = bson_json_loads(value)
+    if not isinstance(value, (str, bytes, bytearray)) and decoded == value:
+        # Remote JSON drivers may already return an ordinary decoded mapping.
+        return value
+    return decoded
 
 
 def _quote_identifier(name):
@@ -139,8 +178,149 @@ def _get_nested(doc, path, default=_MISSING):
 
 def _value_matches(actual, expected):
     if isinstance(actual, list):
-        return expected in actual
+        return actual == expected or expected in actual
     return actual == expected
+
+
+def _sqlite_unique_token(data, field):
+    """Return the same lossless unique token used by Python validation."""
+    document = _json_loads(data)
+    return json.dumps(
+        index_tokens(document, field),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _simple_scalar_equality(filter_doc):
+    """Return one SQL-safe equality pair, or ``None`` for richer filters."""
+    if not isinstance(filter_doc, dict) or len(filter_doc) != 1:
+        return None
+    field, expected = next(iter(filter_doc.items()))
+    if (
+        not isinstance(field, str)
+        or field.startswith("$")
+        or field == "_id"
+        or expected is None
+        or isinstance(expected, (dict, list, tuple))
+        or not isinstance(expected, (bool, int, float, str))
+    ):
+        return None
+    return field, expected
+
+
+def _reject_remote_unique_arrays(documents, specs):
+    """Fail closed where remote native constraints cannot protect multikey races."""
+    for spec in specs:
+        if not spec.unique:
+            continue
+        for document in documents:
+            value = _get_nested(document, spec.field)
+            if isinstance(value, (list, tuple)):
+                raise TinyMongoNotSupportedError(
+                    "Remote SQL unique index {0!r} does not support array values; "
+                    "cross-process multikey uniqueness cannot be guaranteed".format(
+                        spec.name
+                    )
+                )
+
+
+def _comparison_matches(actual, operand, comparison):
+    values = actual if isinstance(actual, list) else [actual]
+    for value in values:
+        try:
+            if comparison(value, operand):
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _regex_matches(actual, pattern, options=""):
+    flags = 0
+    for option, flag in (
+        ("i", re.IGNORECASE),
+        ("m", re.MULTILINE),
+        ("s", re.DOTALL),
+        ("x", re.VERBOSE),
+    ):
+        if option in str(options):
+            flags |= flag
+    try:
+        expression = re.compile(pattern, flags)
+    except (TypeError, ValueError, re.error):
+        return False
+    values = actual if isinstance(actual, list) else [actual]
+    return any(
+        isinstance(value, str) and expression.search(value) is not None
+        for value in values
+    )
+
+
+def _field_matches(actual, expected):
+    exists = actual is not _MISSING
+    if not isinstance(expected, dict) or not any(
+        str(key).startswith("$") for key in expected
+    ):
+        return exists and _value_matches(actual, expected)
+
+    options = expected.get("$options", "")
+    for operator, operand in expected.items():
+        if operator == "$options":
+            if "$regex" not in expected:
+                return False
+        elif operator == "$exists":
+            if bool(operand) != exists:
+                return False
+        elif operator == "$gt":
+            if not exists or not _comparison_matches(
+                actual, operand, lambda a, b: a > b
+            ):
+                return False
+        elif operator == "$gte":
+            if not exists or not _comparison_matches(
+                actual, operand, lambda a, b: a >= b
+            ):
+                return False
+        elif operator == "$lt":
+            if not exists or not _comparison_matches(
+                actual, operand, lambda a, b: a < b
+            ):
+                return False
+        elif operator == "$lte":
+            if not exists or not _comparison_matches(
+                actual, operand, lambda a, b: a <= b
+            ):
+                return False
+        elif operator == "$ne":
+            if exists and _value_matches(actual, operand):
+                return False
+        elif operator == "$in":
+            values = operand if isinstance(operand, list) else [operand]
+            if not exists or not any(_value_matches(actual, item) for item in values):
+                return False
+        elif operator == "$nin":
+            values = operand if isinstance(operand, list) else [operand]
+            if exists and any(_value_matches(actual, item) for item in values):
+                return False
+        elif operator == "$all":
+            if not isinstance(actual, list) or not all(
+                item in actual for item in operand
+            ):
+                return False
+        elif operator == "$regex":
+            if not exists or not _regex_matches(actual, operand, options):
+                return False
+        elif operator == "$not":
+            nested = operand if isinstance(operand, dict) else {"$eq": operand}
+            if exists and _field_matches(actual, nested):
+                return False
+        elif operator == "$eq":
+            if not exists or not _value_matches(actual, operand):
+                return False
+        else:
+            return False
+    return True
 
 
 def matches_filter(doc, filter_doc):
@@ -151,72 +331,58 @@ def matches_filter(doc, filter_doc):
 
     for key, expected in filter_doc.items():
         if key == "$and":
-            return all(matches_filter(doc, spec) for spec in expected)
-        if key == "$or":
-            return any(matches_filter(doc, spec) for spec in expected)
-        if key == "$nor":
-            return not any(matches_filter(doc, spec) for spec in expected)
-
-        actual = _get_nested(doc, key)
-        if isinstance(expected, dict):
-            for operator, operand in expected.items():
-                exists = actual is not _MISSING
-                if operator == "$exists":
-                    if bool(operand) != exists:
-                        return False
-                elif operator == "$gt":
-                    if not exists or not actual > operand:
-                        return False
-                elif operator == "$gte":
-                    if not exists or not actual >= operand:
-                        return False
-                elif operator == "$lt":
-                    if not exists or not actual < operand:
-                        return False
-                elif operator == "$lte":
-                    if not exists or not actual <= operand:
-                        return False
-                elif operator == "$ne":
-                    if exists and _value_matches(actual, operand):
-                        return False
-                elif operator == "$in":
-                    values = operand if isinstance(operand, list) else [operand]
-                    if not exists or not any(
-                        _value_matches(actual, item) for item in values
-                    ):
-                        return False
-                elif operator == "$nin":
-                    values = operand if isinstance(operand, list) else [operand]
-                    if exists and any(_value_matches(actual, item) for item in values):
-                        return False
-                elif operator == "$all":
-                    if not isinstance(actual, list) or not all(
-                        item in actual for item in operand
-                    ):
-                        return False
-                elif operator == "$regex":
-                    if not exists or re.search(operand, str(actual)) is None:
-                        return False
-                elif operator == "$not":
-                    if matches_filter(
-                        {key: actual},
-                        {
-                            key: (
-                                operand
-                                if isinstance(operand, dict)
-                                else {"$eq": operand}
-                            )
-                        },
-                    ):
-                        return False
-                elif operator == "$eq":
-                    if not exists or not _value_matches(actual, operand):
-                        return False
-                else:
-                    return False
-        elif not _value_matches(actual, expected):
-            return False
+            if not all(matches_filter(doc, spec) for spec in expected):
+                return False
+        elif key == "$or":
+            if not any(matches_filter(doc, spec) for spec in expected):
+                return False
+        elif key == "$nor":
+            if any(matches_filter(doc, spec) for spec in expected):
+                return False
+        else:
+            actual = _get_nested(doc, key)
+            if not _field_matches(actual, expected):
+                return False
     return True
+
+
+def requires_python_filter(filter_doc):
+    """Return whether SQL JSON scalar comparison could change query meaning."""
+    if not filter_doc or not isinstance(filter_doc, dict):
+        return False
+    if contains_extended_value(filter_doc):
+        return True
+    for field, expected in filter_doc.items():
+        if field in ("$and", "$or", "$nor"):
+            if any(requires_python_filter(item) for item in expected):
+                return True
+        else:
+            if field.startswith("$"):
+                return True
+            if field != "_id" and not isinstance(expected, dict):
+                # A JSON scalar comparison cannot also see members of array fields.
+                return True
+            if isinstance(expected, dict):
+                if not any(str(operator).startswith("$") for operator in expected):
+                    # Literal embedded-document equality is not an operator
+                    # expression and TinyDB/SQL parsers otherwise treat its keys
+                    # as field or operator names.
+                    return True
+                if any(
+                    operator in expected
+                    for operator in (
+                        "$eq",
+                        "$ne",
+                        "$in",
+                        "$nin",
+                        "$all",
+                        "$regex",
+                        "$not",
+                        "$options",
+                    )
+                ):
+                    return True
+    return False
 
 
 class SQLCompiler(object):
@@ -224,18 +390,18 @@ class SQLCompiler(object):
         self.dialect = dialect
 
     def json_value(self, field, value=None, numeric=False):
-        path = "$." + field
+        path = _json_path(field)
         if self.dialect == "sqlite":
-            expression = "json_extract(data, ?)"
-            return expression, [path]
+            expression = "json_extract(data, {0})".format(_sql_literal(path))
+            return expression, []
         if numeric:
             return "CAST(json_extract_string(data, ?) AS DOUBLE)", [path]
         return "json_extract_string(data, ?)", [path]
 
     def json_exists(self, field):
-        path = "$." + field
+        path = _json_path(field)
         if self.dialect == "sqlite":
-            return "json_type(data, ?) IS NOT NULL", [path]
+            return "json_type(data, {0}) IS NOT NULL".format(_sql_literal(path)), []
         return "json_exists(data, ?)", [path]
 
     def compile(self, filter_doc):
@@ -361,11 +527,34 @@ class TableBackend(object):
         self.database = database
         self.dsn = dsn
         self.compiler = SQLCompiler(self.dialect)
+        self._ephemeral_indexes = {}
         if not _is_object_store_uri(path):
             os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
 
     def close(self):
         pass
+
+    @contextmanager
+    def _write_lock(self):
+        """Serialize local backend writes across threads and processes."""
+        if _is_object_store_uri(self.path):
+            yield
+            return
+
+        directory = os.path.dirname(self.path) or "."
+        lock_path = os.path.join(directory, ".tinymongo.lock")
+        rlock = _local_rlocks.setdefault(lock_path, threading.RLock())
+        first_acquire = _acquire_rlock(rlock)
+        file_lock = None
+        try:
+            if first_acquire and portalocker is not None:  # pragma: no branch
+                file_lock = portalocker.Lock(lock_path, timeout=30)
+                file_lock.acquire()
+            yield
+        finally:
+            if file_lock is not None:  # pragma: no branch
+                file_lock.release()
+            rlock.release()
 
     def list_collections(self):  # pragma: no cover - abstract backend contract
         raise NotImplementedError
@@ -397,6 +586,7 @@ class TableBackend(object):
         docs = self.find(collection, filter_doc, limit=1)
         return docs[0] if docs else None
 
+    @_write_locked
     def update_many(self, collection, filter_doc, update_doc, multi=True):
         matches = self.find(collection, filter_doc)
         if not multi:
@@ -414,6 +604,7 @@ class TableBackend(object):
     ):  # pragma: no cover - abstract backend contract
         raise NotImplementedError
 
+    @_write_locked
     def delete_many(self, collection, filter_doc, multi=True):
         matches = self.find(collection, filter_doc)
         if not multi:
@@ -427,14 +618,55 @@ class TableBackend(object):
     ):  # pragma: no cover - abstract backend contract
         raise NotImplementedError
 
-    def create_index(self, collection, field):
-        return field
+    def get_index_specs(self, collection):
+        return list(self._ephemeral_indexes.get(collection, {}).values())
 
-    def drop_index(self, collection, field):
-        return None
+    def _coerce_index_spec(self, spec):
+        return spec if isinstance(spec, IndexSpec) else parse_index_spec(spec)
+
+    def _check_index_compatibility(self, collection, spec):
+        specs = self.get_index_specs(collection)
+        existing = next(
+            (current for current in specs if current.name == spec.name),
+            None,
+        )
+        if existing is not None and existing != spec:
+            raise OperationFailure(
+                "An index with the same name or key has different options"
+            )
+        return existing
+
+    def create_index(self, collection, spec):
+        spec = self._coerce_index_spec(spec)
+        existing = self._check_index_compatibility(collection, spec)
+        if existing is not None:
+            return existing.name
+        if spec.unique:
+            validate_unique_documents(self.find(collection, {}), [spec])
+        self._ephemeral_indexes.setdefault(collection, {})[spec.name] = spec
+        return spec.name
+
+    def drop_index(self, collection, name_or_field):
+        indexes = self._ephemeral_indexes.get(collection, {})
+        for name, spec in list(indexes.items()):
+            if name_or_field in (name, spec.field):
+                indexes.pop(name, None)
+                return None
+        raise OperationFailure("Index not found: {0}".format(name_or_field))
 
     def list_indexes(self, collection):
-        return [{"name": "_id_", "key": [("_id", 1)]}]
+        indexes = [{"name": "_id_", "key": [("_id", 1)]}]
+        for spec in sorted(
+            self.get_index_specs(collection), key=lambda item: item.name
+        ):
+            metadata = {"name": spec.name, "key": [(spec.field, spec.direction)]}
+            if spec.unique:
+                metadata["unique"] = True
+            indexes.append(metadata)
+        return indexes
+
+    def validate_unique_post_image(self, collection, documents):
+        validate_unique_documents(documents, self.get_index_specs(collection))
 
     def apply_update(self, doc, update_doc):
         from .tinymongo import _apply_update_document
@@ -445,12 +677,54 @@ class TableBackend(object):
 class SQLiteTableBackend(TableBackend):
     dialect = "sqlite"
     extension = ".sqlite"
+    index_catalog_table = "__tinymongo_indexes"
+
+    def _physical_index_name(self, collection, spec):
+        identity = "{0}\x00{1}\x00{2}".format(
+            self.database or "default", collection, spec.name
+        )
+        digest = hashlib.sha256(identity.encode("utf8")).hexdigest()[:32]
+        return "__tm_idx_{0}".format(digest)
 
     def _connect(self):
         conn = sqlite3.connect(self.path)
+        conn.create_function(
+            "tinymongo_unique_token",
+            2,
+            _sqlite_unique_token,
+            deterministic=True,
+        )
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=30000")
         return conn
+
+    def _ensure_index_catalog(self, conn):
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS {0} ("
+            "collection_name TEXT NOT NULL, index_name TEXT NOT NULL, "
+            "field_name TEXT NOT NULL, unique_flag INTEGER NOT NULL, "
+            "PRIMARY KEY (collection_name, index_name))".format(
+                _quote_identifier(self.index_catalog_table)
+            )
+        )
+
+    def get_index_specs(self, collection):
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            rows = conn.execute(
+                "SELECT index_name, field_name, unique_flag FROM {0} "
+                "WHERE collection_name = ? ORDER BY index_name".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (collection,),
+            ).fetchall()
+            return [
+                IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
+                for row in rows
+            ]
+        finally:
+            conn.close()
 
     def _migrate_legacy_blob(self):
         conn = self._connect()
@@ -513,26 +787,36 @@ class SQLiteTableBackend(TableBackend):
         finally:
             conn.close()
 
+    @_write_locked
     def drop_collection(self, collection):
         existed = collection in self.list_collections()
         conn = self._connect()
         try:
+            self._ensure_index_catalog(conn)
             conn.execute(
                 "DROP TABLE IF EXISTS {0}".format(_quote_identifier(collection))
+            )
+            conn.execute(
+                "DELETE FROM {0} WHERE collection_name = ?".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (collection,),
             )
             conn.commit()
             return existed
         finally:
             conn.close()
 
+    @_write_locked
     def insert_many(self, collection, docs, bypass_document_validation=False):
         self.create_collection(collection)
+        existing_docs = self.find(collection, {})
+        self.validate_unique_post_image(collection, existing_docs + docs)
         rows = [(str(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
-            sql = "INSERT {0} INTO {1} (_id, data) VALUES (?, ?)".format(
-                "OR REPLACE" if bypass_document_validation else "",
-                _quote_identifier(collection),
+            sql = "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
+                _quote_identifier(collection)
             )
             conn.executemany(sql, rows)
             conn.commit()
@@ -544,6 +828,15 @@ class SQLiteTableBackend(TableBackend):
 
     def find(self, collection, filter_doc=None, sort=None, skip=None, limit=None):
         self.create_collection(collection)
+        indexed = self._find_indexed_scalar_with_array_union(collection, filter_doc)
+        if indexed is not None:
+            return indexed
+        if requires_python_filter(filter_doc):
+            return [
+                doc
+                for doc in self._all_docs_unfiltered(collection)
+                if matches_filter(doc, filter_doc)
+            ]
         try:
             where, params = self.compiler.compile(filter_doc)
             sql = "SELECT data FROM {0}{1}".format(_quote_identifier(collection), where)
@@ -560,6 +853,38 @@ class SQLiteTableBackend(TableBackend):
                 if matches_filter(doc, filter_doc)
             ]
 
+    def _find_indexed_scalar_with_array_union(self, collection, filter_doc):
+        equality = _simple_scalar_equality(filter_doc)
+        if equality is None:
+            return None
+        field, _ = equality
+        if not any(spec.field == field for spec in self.get_index_specs(collection)):
+            return None
+
+        where, params = self.compiler.compile(filter_doc)
+        path = _sql_literal(_json_path(field))
+        scalar_sql = (
+            "SELECT data FROM {table}{where} "
+            "AND json_type(data, {path}) IN "
+            "('text', 'integer', 'real', 'true', 'false')"
+        ).format(
+            table=_quote_identifier(collection),
+            where=where,
+            path=path,
+        )
+        array_sql = (
+            "SELECT data FROM {table} WHERE json_type(data, {path}) = 'array'"
+        ).format(table=_quote_identifier(collection), path=path)
+        conn = self._connect()
+        try:
+            scalar_rows = conn.execute(scalar_sql, params).fetchall()
+            array_rows = conn.execute(array_sql).fetchall()
+        finally:
+            conn.close()
+
+        candidates = [_json_loads(row[0]) for row in scalar_rows + array_rows]
+        return [doc for doc in candidates if matches_filter(doc, filter_doc)]
+
     def _all_docs_unfiltered(self, collection):
         self.create_collection(collection)
         conn = self._connect()
@@ -571,20 +896,32 @@ class SQLiteTableBackend(TableBackend):
         finally:
             conn.close()
 
+    @_write_locked
     def replace_one(self, collection, doc_id, replacement):
         self.create_collection(collection)
+        self.validate_unique_post_image(
+            collection,
+            [
+                replacement if doc.get("_id") == doc_id else doc
+                for doc in self.find(collection, {})
+            ],
+        )
         conn = self._connect()
         try:
-            conn.execute(
-                "UPDATE {0} SET data = ? WHERE _id = ?".format(
-                    _quote_identifier(collection)
-                ),
-                (_json_dumps(replacement), str(doc_id)),
-            )
-            conn.commit()
+            try:
+                conn.execute(
+                    "UPDATE {0} SET data = ? WHERE _id = ?".format(
+                        _quote_identifier(collection)
+                    ),
+                    (_json_dumps(replacement), str(doc_id)),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as exc:
+                raise DuplicateKeyError(str(exc))
         finally:
             conn.close()
 
+    @_write_locked
     def delete_ids(self, collection, ids):
         if not ids:
             return
@@ -599,26 +936,97 @@ class SQLiteTableBackend(TableBackend):
         finally:
             conn.close()
 
-    def create_index(self, collection, field):
+    @_write_locked
+    def create_index(self, collection, spec):
+        spec = self._coerce_index_spec(spec)
         self.create_collection(collection)
-        name = "{0}_{1}_idx".format(collection, field.replace(".", "_"))
-        path = "'$." + field.replace("'", "''") + "'"
+        existing = self._check_index_compatibility(collection, spec)
+        if existing is not None:
+            return existing.name
+        if spec.unique:
+            validate_unique_documents(self.find(collection, {}), [spec])
+        name = self._physical_index_name(collection, spec)
+        path = _sql_literal(_json_path(spec.field))
+        expression = "json_extract(data, {0})".format(path)
+        if spec.unique:
+            expression = "tinymongo_unique_token(data, {0})".format(
+                _sql_literal(spec.field)
+            )
         conn = self._connect()
         try:
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS {0} ON {1} (json_extract(data, {2}))".format(
-                    _quote_identifier(name), _quote_identifier(collection), path
+            try:
+                self._ensure_index_catalog(conn)
+                conn.execute(
+                    "CREATE {0}INDEX IF NOT EXISTS {1} ON {2} "
+                    "({3})".format(
+                        "UNIQUE " if spec.unique else "",
+                        _quote_identifier(name),
+                        _quote_identifier(collection),
+                        expression,
+                    )
                 )
+                if spec.unique:
+                    conn.execute(
+                        "CREATE INDEX IF NOT EXISTS {0} ON {1} "
+                        "(json_extract(data, {2}))".format(
+                            _quote_identifier(name + "_lookup"),
+                            _quote_identifier(collection),
+                            path,
+                        )
+                    )
+                conn.execute(
+                    "INSERT INTO {0} (collection_name, index_name, field_name, unique_flag) "
+                    "VALUES (?, ?, ?, ?)".format(
+                        _quote_identifier(self.index_catalog_table)
+                    ),
+                    (collection, spec.name, spec.field, int(spec.unique)),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as exc:
+                raise DuplicateKeyError(str(exc))
+        finally:
+            conn.close()
+        return spec.name
+
+    @_write_locked
+    def drop_index(self, collection, name_or_field):
+        spec = next(
+            (
+                item
+                for item in self.get_index_specs(collection)
+                if name_or_field in (item.name, item.field)
+            ),
+            None,
+        )
+        if spec is None:
+            raise OperationFailure("Index not found: {0}".format(name_or_field))
+        physical_name = self._physical_index_name(collection, spec)
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            conn.execute(
+                "DROP INDEX IF EXISTS {0}".format(_quote_identifier(physical_name))
+            )
+            conn.execute(
+                "DROP INDEX IF EXISTS {0}".format(
+                    _quote_identifier(physical_name + "_lookup")
+                )
+            )
+            conn.execute(
+                "DELETE FROM {0} WHERE collection_name = ? AND index_name = ?".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (collection, spec.name),
             )
             conn.commit()
         finally:
             conn.close()
-        return field
 
 
 class DuckDBTableBackend(TableBackend):
     dialect = "duckdb"
     extension = ".duckdb"
+    index_catalog_table = "__tinymongo_indexes"
 
     def __init__(
         self,
@@ -631,7 +1039,7 @@ class DuckDBTableBackend(TableBackend):
         duckdb = _import_optional_driver(
             "duckdb",
             "duckdb/parquet",
-            "pip install duckdb or pip install tinymongo",
+            'pip install "tinymongo[duckdb]"',
         )
         self.duckdb = duckdb
         super(DuckDBTableBackend, self).__init__(
@@ -648,6 +1056,34 @@ class DuckDBTableBackend(TableBackend):
             conn.execute("PRAGMA threads={0}".format(int(self.threads)))
         self._configure_duckdb_connection(conn)
         return conn
+
+    def _ensure_index_catalog(self, conn):
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS {0} ("
+            "collection_name VARCHAR NOT NULL, index_name VARCHAR NOT NULL, "
+            "field_name VARCHAR NOT NULL, unique_flag BOOLEAN NOT NULL, "
+            "PRIMARY KEY (collection_name, index_name))".format(
+                _quote_identifier(self.index_catalog_table)
+            )
+        )
+
+    def get_index_specs(self, collection):
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            rows = conn.execute(
+                "SELECT index_name, field_name, unique_flag FROM {0} "
+                "WHERE collection_name = ? ORDER BY index_name".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (collection,),
+            ).fetchall()
+            return [
+                IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
+                for row in rows
+            ]
+        finally:
+            conn.close()
 
     def _configure_duckdb_connection(self, conn):
         for key, value in (self.duckdb_config or {}).items():
@@ -719,44 +1155,56 @@ class DuckDBTableBackend(TableBackend):
         finally:
             conn.close()
 
+    @_write_locked
     def drop_collection(self, collection):
         existed = collection in self.list_collections()
         conn = self._connect()
         try:
+            self._ensure_index_catalog(conn)
             conn.execute(
                 "DROP TABLE IF EXISTS {0}".format(_quote_identifier(collection))
+            )
+            conn.execute(
+                "DELETE FROM {0} WHERE collection_name = ?".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (collection,),
             )
             return existed
         finally:
             conn.close()
 
+    @_write_locked
     def insert_many(self, collection, docs, bypass_document_validation=False):
         self.create_collection(collection)
+        existing_docs = self.find(collection, {})
+        self.validate_unique_post_image(collection, existing_docs + docs)
         rows = [(str(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
-            if bypass_document_validation:
-                conn.executemany(
-                    "INSERT OR REPLACE INTO {0} (_id, data) VALUES (?, ?)".format(
-                        _quote_identifier(collection)
-                    ),
-                    rows,
-                )
-            else:
-                conn.executemany(
-                    "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
-                        _quote_identifier(collection)
-                    ),
-                    rows,
-                )
+            conn.executemany(
+                "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
+                    _quote_identifier(collection)
+                ),
+                rows,
+            )
             return list(range(len(rows)))
         except Exception as exc:
-            raise DuplicateKeyError(str(exc))
+            constraint_error = getattr(self.duckdb, "ConstraintException", ())
+            if constraint_error and isinstance(exc, constraint_error):
+                raise DuplicateKeyError(str(exc))
+            raise
         finally:
             conn.close()
 
     def find(self, collection, filter_doc=None, sort=None, skip=None, limit=None):
         self.create_collection(collection)
+        if requires_python_filter(filter_doc):
+            return [
+                doc
+                for doc in self._all_docs_unfiltered(collection)
+                if matches_filter(doc, filter_doc)
+            ]
         try:
             where, params = self.compiler.compile(filter_doc)
             sql = "SELECT data FROM {0}{1}".format(_quote_identifier(collection), where)
@@ -784,8 +1232,16 @@ class DuckDBTableBackend(TableBackend):
         finally:
             conn.close()
 
+    @_write_locked
     def replace_one(self, collection, doc_id, replacement):
         self.create_collection(collection)
+        self.validate_unique_post_image(
+            collection,
+            [
+                replacement if doc.get("_id") == doc_id else doc
+                for doc in self.find(collection, {})
+            ],
+        )
         conn = self._connect()
         try:
             conn.execute(
@@ -797,6 +1253,7 @@ class DuckDBTableBackend(TableBackend):
         finally:
             conn.close()
 
+    @_write_locked
     def delete_ids(self, collection, ids):
         if not ids:
             return
@@ -806,6 +1263,52 @@ class DuckDBTableBackend(TableBackend):
             conn.executemany(
                 "DELETE FROM {0} WHERE _id = ?".format(_quote_identifier(collection)),
                 [(str(doc_id),) for doc_id in ids],
+            )
+        finally:
+            conn.close()
+
+    @_write_locked
+    def create_index(self, collection, spec):
+        spec = self._coerce_index_spec(spec)
+        self.create_collection(collection)
+        existing = self._check_index_compatibility(collection, spec)
+        if existing is not None:
+            return existing.name
+        if spec.unique:
+            validate_unique_documents(self.find(collection, {}), [spec])
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            conn.execute(
+                "INSERT INTO {0} VALUES (?, ?, ?, ?)".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (collection, spec.name, spec.field, spec.unique),
+            )
+        finally:
+            conn.close()
+        return spec.name
+
+    @_write_locked
+    def drop_index(self, collection, name_or_field):
+        spec = next(
+            (
+                item
+                for item in self.get_index_specs(collection)
+                if name_or_field in (item.name, item.field)
+            ),
+            None,
+        )
+        if spec is None:
+            raise OperationFailure("Index not found: {0}".format(name_or_field))
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            conn.execute(
+                "DELETE FROM {0} WHERE collection_name = ? AND index_name = ?".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (collection, spec.name),
             )
         finally:
             conn.close()
@@ -891,6 +1394,7 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
                 os.path.basename(row[0])[: -len(".parquet")]
                 for row in rows
                 if str(row[0]).endswith(".parquet")
+                and not os.path.basename(row[0]).startswith("__tinymongo_")
             )
 
         if not os.path.isdir(self.directory):
@@ -898,7 +1402,7 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
         return sorted(
             name[: -len(".parquet")]
             for name in os.listdir(self.directory)
-            if name.endswith(".parquet")
+            if name.endswith(".parquet") and not name.startswith("__tinymongo_")
         )
 
     def create_collection(self, collection):
@@ -907,18 +1411,35 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
 
     def drop_collection(self, collection):
         path = self._collection_path(collection)
-        existed = (
-            collection in self.list_collections()
-            if self._is_object_store
-            else os.path.exists(path)
-        )
-        if existed:
-            with self._write_lock():
+        with self._write_lock():
+            data_exists = (
+                collection in self.list_collections()
+                if self._is_object_store
+                else os.path.exists(path)
+            )
+            metadata_exists = bool(self.get_index_specs(collection))
+            if not data_exists and not metadata_exists:
+                return False
+            if data_exists:
                 if self._is_object_store:
                     self._write_rows(collection, [])
                 else:
                     os.remove(path)
-        return existed
+            metadata_rows = [
+                row
+                for row in self._read_all_rows(INDEX_CATALOG_TABLE)
+                if _json_loads(row[1]).get("collection") != collection
+            ]
+            self._write_rows(INDEX_CATALOG_TABLE, metadata_rows)
+            return True
+
+    def get_index_specs(self, collection):
+        specs = []
+        for _, data in self._read_all_rows(INDEX_CATALOG_TABLE):
+            document = _json_loads(data)
+            if document.get("collection") == collection:
+                specs.append(IndexSpec.from_metadata(document["spec"]))
+        return specs
 
     def _read_all_rows(self, collection):
         path = self._collection_path(collection)
@@ -929,7 +1450,11 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
             return conn.execute(
                 "SELECT _id, data FROM read_parquet(?)", (path,)
             ).fetchall()
-        except Exception:
+        except Exception as exc:
+            if not self._is_object_store and os.path.exists(path):
+                raise StorageCorruptionError(
+                    "Cannot read Parquet collection {0}: {1}".format(collection, exc)
+                ) from exc
             return []
         finally:
             conn.close()
@@ -965,14 +1490,14 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
     def insert_many(self, collection, docs, bypass_document_validation=False):
         with self._write_lock():
             rows = self._read_all_rows(collection)
+            existing_docs = [_json_loads(row[1]) for row in rows]
+            self.validate_unique_post_image(collection, existing_docs + docs)
             existing = {row[0] for row in rows}
             new_rows = []
             for doc in docs:
                 doc_id = str(doc["_id"])
-                if not bypass_document_validation and doc_id in existing:
+                if doc_id in existing:
                     raise DuplicateKeyError("_id:{0} already exists".format(doc["_id"]))
-                if bypass_document_validation and doc_id in existing:
-                    rows = [row for row in rows if row[0] != doc_id]
                 new_rows.append((doc_id, _json_dumps(doc)))
                 existing.add(doc_id)
             self._write_rows(collection, rows + new_rows)
@@ -982,6 +1507,12 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
         path = self._collection_path(collection)
         if not self._is_object_store and not os.path.exists(path):
             return []
+        if requires_python_filter(filter_doc):
+            return [
+                _json_loads(row[1])
+                for row in self._read_all_rows(collection)
+                if matches_filter(_json_loads(row[1]), filter_doc)
+            ]
         try:
             where, params = self.compiler.compile(filter_doc)
             conn = self._connect()
@@ -1002,9 +1533,17 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
 
     def replace_one(self, collection, doc_id, replacement):
         with self._write_lock():
+            current_rows = self._read_all_rows(collection)
+            self.validate_unique_post_image(
+                collection,
+                [
+                    replacement if row_id == str(doc_id) else _json_loads(data)
+                    for row_id, data in current_rows
+                ],
+            )
             rows = [
                 (row_id, _json_dumps(replacement) if row_id == str(doc_id) else data)
-                for row_id, data in self._read_all_rows(collection)
+                for row_id, data in current_rows
             ]
             self._write_rows(collection, rows)
 
@@ -1016,6 +1555,50 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
             ]
             self._write_rows(collection, rows)
 
+    def create_index(self, collection, spec):
+        spec = self._coerce_index_spec(spec)
+        with self._write_lock():
+            path = self._collection_path(collection)
+            if (
+                collection not in self.list_collections()
+                if self._is_object_store
+                else not os.path.exists(path)
+            ):
+                self._write_rows(collection, [])
+            existing = self._check_index_compatibility(collection, spec)
+            if existing is not None:
+                return existing.name
+            if spec.unique:
+                validate_unique_documents(self.find(collection, {}), [spec])
+            rows = self._read_all_rows(INDEX_CATALOG_TABLE)
+            document = {
+                "_id": index_catalog_id(collection, spec.name),
+                "collection": collection,
+                "spec": spec.to_metadata(),
+            }
+            rows.append((document["_id"], _json_dumps(document)))
+            self._write_rows(INDEX_CATALOG_TABLE, rows)
+        return spec.name
+
+    def drop_index(self, collection, name_or_field):
+        with self._write_lock():
+            spec = next(
+                (
+                    item
+                    for item in self.get_index_specs(collection)
+                    if name_or_field in (item.name, item.field)
+                ),
+                None,
+            )
+            if spec is None:
+                raise OperationFailure("Index not found: {0}".format(name_or_field))
+            rows = [
+                row
+                for row in self._read_all_rows(INDEX_CATALOG_TABLE)
+                if row[0] != index_catalog_id(collection, spec.name)
+            ]
+            self._write_rows(INDEX_CATALOG_TABLE, rows)
+
 
 class RemoteSQLTableBackend(TableBackend):
     """Shared table backend for remote transactional SQL databases."""
@@ -1023,6 +1606,7 @@ class RemoteSQLTableBackend(TableBackend):
     placeholder = "%s"
     json_type = "TEXT"
     metadata_table = "__tinymongo_collections"
+    index_catalog_table = "__tinymongo_indexes"
 
     def __init__(
         self,
@@ -1044,6 +1628,11 @@ class RemoteSQLTableBackend(TableBackend):
 
     def _connect(self):  # pragma: no cover - implemented by concrete drivers
         raise NotImplementedError
+
+    @contextmanager
+    def _write_lock(self):
+        """Let the remote transaction and native unique index serialize writes."""
+        yield
 
     def _quote(self, name):
         return _quote_identifier(name)
@@ -1087,6 +1676,17 @@ class RemoteSQLTableBackend(TableBackend):
         except Exception:
             pass
 
+    def _is_duplicate_error(self, error):
+        sqlstate = getattr(error, "sqlstate", None) or getattr(error, "pgcode", None)
+        code = error.args[0] if getattr(error, "args", ()) else None
+        message = str(error).lower()
+        return (
+            sqlstate == "23505"
+            or code == 1062
+            or "duplicate key" in message
+            or "unique constraint" in message
+        )
+
     def _ensure_metadata(self, conn):
         self._execute(
             conn,
@@ -1098,6 +1698,63 @@ class RemoteSQLTableBackend(TableBackend):
             ),
         )
         self._commit(conn)
+
+    def _ensure_index_catalog(self, conn):
+        self._execute(
+            conn,
+            "CREATE TABLE IF NOT EXISTS {0} "
+            "(database_name VARCHAR(255) NOT NULL, "
+            "collection_name VARCHAR(255) NOT NULL, "
+            "index_name VARCHAR(255) NOT NULL, "
+            "field_name VARCHAR(512) NOT NULL, "
+            "unique_flag BOOLEAN NOT NULL, "
+            "PRIMARY KEY (database_name, collection_name, index_name))".format(
+                self._quote(self.index_catalog_table)
+            ),
+        )
+        self._commit(conn)
+
+    def get_index_specs(self, collection):
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            cursor = self._execute(
+                conn,
+                "SELECT index_name, field_name, unique_flag FROM {0} "
+                "WHERE database_name = {1} AND collection_name = {1} "
+                "ORDER BY index_name".format(
+                    self._quote(self.index_catalog_table), self.placeholder
+                ),
+                (self.database, collection),
+            )
+            try:
+                return [
+                    IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
+                    for row in cursor.fetchall()
+                ]
+            finally:
+                self._close_cursor(cursor)
+        finally:
+            conn.close()
+
+    def _physical_index_name(self, collection, spec):
+        identity = "{0}\x00{1}\x00{2}".format(
+            self.database or "default", collection, spec.name
+        )
+        digest = hashlib.sha256(identity.encode("utf8")).hexdigest()[:32]
+        return "__tm_idx_{0}".format(digest)
+
+    def _create_native_index(self, conn, collection, spec):
+        raise NotImplementedError  # pragma: no cover - implemented by drivers
+
+    def validate_unique_post_image(self, collection, documents):
+        documents = list(documents)
+        specs = self.get_index_specs(collection)
+        _reject_remote_unique_arrays(documents, specs)
+        validate_unique_documents(documents, specs)
+
+    def _drop_native_index(self, conn, collection, spec):
+        raise NotImplementedError  # pragma: no cover - implemented by drivers
 
     def _record_collection(self, conn, collection):
         self._ensure_metadata(conn)
@@ -1162,6 +1819,7 @@ class RemoteSQLTableBackend(TableBackend):
         existed = collection in self.list_collections()
         conn = self._connect()
         try:
+            self._ensure_index_catalog(conn)
             self._execute(
                 conn,
                 "DROP TABLE IF EXISTS {0}".format(
@@ -1175,6 +1833,13 @@ class RemoteSQLTableBackend(TableBackend):
                 ),
                 (self.database, collection),
             )
+            self._execute(
+                conn,
+                "DELETE FROM {0} WHERE database_name = {1} AND collection_name = {1}".format(
+                    self._quote(self.index_catalog_table), self.placeholder
+                ),
+                (self.database, collection),
+            )
             self._commit(conn)
             return existed
         finally:
@@ -1182,6 +1847,8 @@ class RemoteSQLTableBackend(TableBackend):
 
     def insert_many(self, collection, docs, bypass_document_validation=False):
         self.create_collection(collection)
+        current = self._all_docs_unfiltered(collection)
+        self.validate_unique_post_image(collection, current + docs)
         rows = [(str(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
@@ -1189,7 +1856,9 @@ class RemoteSQLTableBackend(TableBackend):
             self._commit(conn)
             return list(range(len(rows)))
         except Exception as exc:
-            raise DuplicateKeyError(str(exc))
+            if self._is_duplicate_error(exc):
+                raise DuplicateKeyError(str(exc))
+            raise
         finally:
             conn.close()
 
@@ -1248,18 +1917,30 @@ class RemoteSQLTableBackend(TableBackend):
 
     def replace_one(self, collection, doc_id, replacement):
         self.create_collection(collection)
+        self.validate_unique_post_image(
+            collection,
+            [
+                replacement if str(doc.get("_id")) == str(doc_id) else doc
+                for doc in self._all_docs_unfiltered(collection)
+            ],
+        )
         conn = self._connect()
         try:
-            self._execute(
-                conn,
-                "UPDATE {0} SET data = {1} WHERE _id = {2}".format(
-                    self._quote(self._table_name(collection)),
-                    self._data_placeholder(),
-                    self.placeholder,
-                ),
-                (_json_dumps(replacement), str(doc_id)),
-            )
-            self._commit(conn)
+            try:
+                self._execute(
+                    conn,
+                    "UPDATE {0} SET data = {1} WHERE _id = {2}".format(
+                        self._quote(self._table_name(collection)),
+                        self._data_placeholder(),
+                        self.placeholder,
+                    ),
+                    (_json_dumps(replacement), str(doc_id)),
+                )
+                self._commit(conn)
+            except Exception as exc:
+                if self._is_duplicate_error(exc):
+                    raise DuplicateKeyError(str(exc))
+                raise
         finally:
             conn.close()
 
@@ -1280,9 +1961,66 @@ class RemoteSQLTableBackend(TableBackend):
         finally:
             conn.close()
 
-    def create_index(self, collection, field):
+    def create_index(self, collection, spec):
+        spec = self._coerce_index_spec(spec)
         self.create_collection(collection)
-        return field
+        existing = self._check_index_compatibility(collection, spec)
+        if existing is not None:
+            return existing.name
+        if spec.unique:
+            documents = self.find(collection, {})
+            _reject_remote_unique_arrays(documents, [spec])
+            validate_unique_documents(documents, [spec])
+
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            self._create_native_index(conn, collection, spec)
+            self._execute(
+                conn,
+                "INSERT INTO {0} "
+                "(database_name, collection_name, index_name, field_name, unique_flag) "
+                "VALUES ({1}, {1}, {1}, {1}, {1})".format(
+                    self._quote(self.index_catalog_table), self.placeholder
+                ),
+                (self.database, collection, spec.name, spec.field, spec.unique),
+            )
+            self._commit(conn)
+        except Exception as exc:
+            if spec.unique and self._is_duplicate_error(exc):
+                raise DuplicateKeyError(str(exc))
+            raise
+        finally:
+            conn.close()
+        return spec.name
+
+    def drop_index(self, collection, name_or_field):
+        spec = next(
+            (
+                item
+                for item in self.get_index_specs(collection)
+                if name_or_field in (item.name, item.field)
+            ),
+            None,
+        )
+        if spec is None:
+            raise OperationFailure("Index not found: {0}".format(name_or_field))
+
+        conn = self._connect()
+        try:
+            self._ensure_index_catalog(conn)
+            self._drop_native_index(conn, collection, spec)
+            self._execute(
+                conn,
+                "DELETE FROM {0} WHERE database_name = {1} "
+                "AND collection_name = {1} AND index_name = {1}".format(
+                    self._quote(self.index_catalog_table), self.placeholder
+                ),
+                (self.database, collection, spec.name),
+            )
+            self._commit(conn)
+        finally:
+            conn.close()
 
 
 class PostgresTableBackend(RemoteSQLTableBackend):
@@ -1310,6 +2048,31 @@ class PostgresTableBackend(RemoteSQLTableBackend):
     def _data_placeholder(self):
         return self.placeholder + "::jsonb"
 
+    def _create_native_index(self, conn, collection, spec):
+        path = ", ".join(_sql_literal(part) for part in spec.field.split("."))
+        expression = "COALESCE(jsonb_extract_path(data, {0}), 'null'::jsonb)".format(
+            path
+        )
+        # JSONB equality is type-aware and normalizes equivalent numbers. Arrays
+        # are indexed whole; Python validation supplies Mongo-like multikey fan-out.
+        self._execute(
+            conn,
+            "CREATE {0}INDEX {1} ON {2} (({3}))".format(
+                "UNIQUE " if spec.unique else "",
+                self._quote(self._physical_index_name(collection, spec)),
+                self._quote(self._table_name(collection)),
+                expression,
+            ),
+        )
+
+    def _drop_native_index(self, conn, collection, spec):
+        self._execute(
+            conn,
+            "DROP INDEX IF EXISTS {0}".format(
+                self._quote(self._physical_index_name(collection, spec))
+            ),
+        )
+
     def _insert_metadata(self, conn, collection):
         self._execute(
             conn,
@@ -1321,21 +2084,11 @@ class PostgresTableBackend(RemoteSQLTableBackend):
         )
 
     def _insert_rows(self, conn, collection, rows, bypass_document_validation):
-        if bypass_document_validation:
-            sql = (
-                "INSERT INTO {0} (_id, data) VALUES ({1}, {2}) "
-                "ON CONFLICT (_id) DO UPDATE SET data = EXCLUDED.data"
-            ).format(
-                self._quote(self._table_name(collection)),
-                self.placeholder,
-                self._data_placeholder(),
-            )
-        else:
-            sql = "INSERT INTO {0} (_id, data) VALUES ({1}, {2})".format(
-                self._quote(self._table_name(collection)),
-                self.placeholder,
-                self._data_placeholder(),
-            )
+        sql = "INSERT INTO {0} (_id, data) VALUES ({1}, {2})".format(
+            self._quote(self._table_name(collection)),
+            self.placeholder,
+            self._data_placeholder(),
+        )
         self._executemany(conn, sql, rows)
 
 
@@ -1376,6 +2129,63 @@ class MySQLTableBackend(RemoteSQLTableBackend):
             return self.pymysql.connect(**kwargs)
         return self.pymysql.connect(host=self.dsn)
 
+    def _generated_index_column(self, collection, spec):
+        return self._physical_index_name(collection, spec).replace("_idx_", "_key_")
+
+    def _create_native_index(self, conn, collection, spec):
+        json_path = "$" + "".join(
+            "." + json.dumps(part, ensure_ascii=False) for part in spec.field.split(".")
+        )
+        value = "JSON_EXTRACT(data, {0})".format(_sql_literal(json_path))
+        value_type = "JSON_TYPE({0})".format(value)
+        token_expression = (
+            "CASE "
+            "WHEN {value} IS NULL OR {value_type} = 'NULL' THEN 'null:' "
+            "WHEN {value_type} = 'BOOLEAN' "
+            "THEN CONCAT('bool:', JSON_UNQUOTE({value})) "
+            "WHEN {value_type} IN ('INTEGER', 'DOUBLE', 'DECIMAL') "
+            "THEN CONCAT('number:', CAST(CAST(JSON_UNQUOTE({value}) "
+            "AS DECIMAL(65, 30)) AS CHAR)) "
+            "WHEN {value_type} = 'STRING' "
+            "THEN CONCAT('string:', CAST({value} AS CHAR)) "
+            "ELSE CONCAT('json:', CAST({value} AS CHAR)) END"
+        ).format(value=value, value_type=value_type)
+        expression = "SHA2({0}, 256)".format(token_expression)
+        # The typed scalar token mirrors Python uniqueness checks. Arrays remain
+        # whole JSON values here, so native race protection is scalar-only.
+        table = self._quote(self._table_name(collection))
+        column = self._quote(self._generated_index_column(collection, spec))
+        self._execute(
+            conn,
+            "ALTER TABLE {0} ADD COLUMN {1} CHAR(64) "
+            "CHARACTER SET ascii COLLATE ascii_bin "
+            "GENERATED ALWAYS AS ({2}) STORED".format(table, column, expression),
+        )
+        self._execute(
+            conn,
+            "CREATE {0}INDEX {1} ON {2} ({3})".format(
+                "UNIQUE " if spec.unique else "",
+                self._quote(self._physical_index_name(collection, spec)),
+                table,
+                column,
+            ),
+        )
+
+    def _drop_native_index(self, conn, collection, spec):
+        table = self._quote(self._table_name(collection))
+        self._execute(
+            conn,
+            "DROP INDEX {0} ON {1}".format(
+                self._quote(self._physical_index_name(collection, spec)), table
+            ),
+        )
+        self._execute(
+            conn,
+            "ALTER TABLE {0} DROP COLUMN {1}".format(
+                table, self._quote(self._generated_index_column(collection, spec))
+            ),
+        )
+
     def _insert_metadata(self, conn, collection):
         self._execute(
             conn,
@@ -1387,12 +2197,7 @@ class MySQLTableBackend(RemoteSQLTableBackend):
         )
 
     def _insert_rows(self, conn, collection, rows, bypass_document_validation):
-        if bypass_document_validation:
-            sql = "REPLACE INTO {0} (_id, data) VALUES ({1}, {1})".format(
-                self._quote(self._table_name(collection)), self.placeholder
-            )
-        else:
-            sql = "INSERT INTO {0} (_id, data) VALUES ({1}, {1})".format(
-                self._quote(self._table_name(collection)), self.placeholder
-            )
+        sql = "INSERT INTO {0} (_id, data) VALUES ({1}, {1})".format(
+            self._quote(self._table_name(collection)), self.placeholder
+        )
         self._executemany(conn, sql, rows)

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -5,14 +5,16 @@
 from __future__ import absolute_import
 
 import copy
-from functools import reduce
+from functools import reduce, wraps
 import logging
 import os
-from math import ceil
+import shutil
 from uuid import uuid4
 
-from tinydb import Query, TinyDB, where
+from tinydb import Query, TinyDB, where  # type: ignore[attr-defined]
+from .bson_codec import bson_available
 from .storage_backends import (
+    clear_memory_database,
     clear_memory_namespace,
     get_storage_class,
     get_table_backend,
@@ -26,7 +28,23 @@ from .storage_backends import (
 # from .results import InsertOneResult, InsertManyResult, UpdateResult, DeleteResult
 # from .errors import DuplicateKeyError
 from .results import InsertOneResult, InsertManyResult, UpdateResult, DeleteResult
-from .errors import DuplicateKeyError, InvalidOperation, TinyMongoNotSupportedError
+from .errors import (
+    DuplicateKeyError,
+    InvalidOperation,
+    OperationFailure,
+    TinyMongoNotSupportedError,
+)
+from .indexes import (
+    INDEX_CATALOG_TABLE,
+    IndexSpec,
+    emit_index_plan_warnings,
+    index_catalog_id,
+    parse_index_spec,
+    plan_index_models,
+    validate_unique_documents,
+)
+from .projection import normalize_projection, project_document
+from .table_backends import matches_filter, requires_python_filter
 
 basestring = str
 
@@ -223,6 +241,20 @@ def _memory_namespace(foldername):
     return "memory://{0}".format(name), True
 
 
+def _engine_write_locked(method):
+    """Hold a table backend's write lock across collection-level preflights."""
+
+    @wraps(method)
+    def wrapped(self, *args, **kwargs):
+        engine = getattr(getattr(self, "parent", None), "engine", None)
+        if engine is None:
+            return method(self, *args, **kwargs)
+        with engine._write_lock():
+            return method(self, *args, **kwargs)
+
+    return wrapped
+
+
 class TinyMongoClient(object):
     """Represents the Tiny `db` client"""
 
@@ -274,6 +306,10 @@ class TinyMongoClient(object):
     def __getitem__(self, key):
         """Gets a new or existing database based in key"""
         return self._get_db(key)
+
+    def get_database(self, name, *args, **kwargs):
+        """Return a database handle while accepting compatibility options."""
+        return self[name]
 
     def _get_db_path(self, key):
         if self._memory_namespace is not None:
@@ -351,14 +387,15 @@ class TinyMongoClient(object):
             "object_storage": object_storage,
             "table_native": is_table_backend(backend),
             "multiprocess_writes": backend != "memory" and not object_storage,
-            "native_indexes": backend == "sqlite",
-            "projections": False,
+            "native_indexes": backend
+            in ("sqlite", "postgres", "postgresql", "mysql", "mariadb"),
+            "projections": True,
             "bulk_writes": False,
             "aggregation": False,
             "sessions": False,
             "transactions": False,
             "change_streams": False,
-            "bson_types": False,
+            "bson_types": bson_available(),
         }
 
     def supports(self, feature):
@@ -408,6 +445,58 @@ class TinyMongoClient(object):
             if filename.endswith(extension):
                 names.append(filename[: -len(extension)])
         return sorted(names)
+
+    def list_databases(self, *args, **kwargs):
+        """Return PyMongo-shaped metadata for each embedded database."""
+        _reject_session(kwargs)
+        databases = []
+        for name in self.list_database_names():
+            path = self._get_db_path(name)
+            size = 0
+            if isinstance(path, str) and os.path.isfile(path):
+                size = os.path.getsize(path)
+            elif isinstance(path, str) and os.path.isdir(path):
+                size = sum(
+                    os.path.getsize(os.path.join(root, filename))
+                    for root, _, filenames in os.walk(path)
+                    for filename in filenames
+                )
+            database = self[name]
+            databases.append(
+                {
+                    "name": name,
+                    "sizeOnDisk": size,
+                    "empty": not bool(database.list_collection_names()),
+                }
+            )
+        return TinyMongoCursor(databases)
+
+    def drop_database(self, name_or_database, *args, **kwargs):
+        """Drop all collections and storage belonging to one database."""
+        _reject_session(kwargs)
+        name = getattr(name_or_database, "database", name_or_database)
+        if not isinstance(name, str):
+            raise TypeError("database name must be a string or TinyMongoDatabase")
+        if name not in self.list_database_names() and name not in self._databases:
+            return None
+
+        database = self._databases.pop(name, None)
+        if database is None:
+            database = self[name]
+            self._databases.pop(name, None)
+        for collection_name in list(database.list_collection_names()):
+            database.drop_collection(collection_name)
+        database.close()
+
+        path = self._get_db_path(name)
+        if self._memory_namespace is not None:
+            clear_memory_database(path)
+        elif not is_remote_sql_backend(self._backend) and not self._storage_uri:
+            if os.path.isfile(path):
+                os.remove(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+        return None
 
     def database_names(self):
         """Compatibility alias for older PyMongo versions."""
@@ -486,6 +575,11 @@ class TinyMongoDatabase(object):
         self.tinydb = None if engine is not None else TinyDB(path, storage=storage)
         self._memory_revision = self._current_memory_revision()
 
+    @property
+    def name(self):
+        """Return the PyMongo-style database name."""
+        return self.database
+
     def _current_memory_revision(self):
         storage = getattr(self.tinydb, "_storage", None)
         return getattr(storage, "revision", None)
@@ -532,8 +626,10 @@ class TinyMongoDatabase(object):
     def collection_names(self):
         """Get a list of all the collection names in this database"""
         if self.engine is not None:
-            return self.engine.list_collections()
-        return list(self.tinydb.tables())
+            names = self.engine.list_collections()
+        else:
+            names = list(self.tinydb.tables())
+        return [name for name in names if not name.startswith("__tinymongo_")]
 
     def list_collection_names(self):
         """Compatibility alias for modern PyMongo."""
@@ -570,12 +666,28 @@ class TinyMongoCollection(object):
         self.table = None
         self.parent = parent
         self._indexes = set()
+        self._index_specs = {}
         self._index_cache = {}
         self._memory_revision = None
 
     def __repr__(self):
         """Return collection name"""
         return self.tablename
+
+    @property
+    def name(self):
+        """Return the PyMongo-style collection name."""
+        return self.tablename
+
+    @property
+    def database(self):
+        """Return this collection's parent database."""
+        return self.parent
+
+    @property
+    def full_name(self):
+        """Return the dotted database and collection name."""
+        return "{0}.{1}".format(self.parent.name, self.tablename)
 
     @property
     def write_concern(self):
@@ -630,6 +742,7 @@ class TinyMongoCollection(object):
             self.parent.engine.create_collection(self.tablename)
             return
         self.table = self.parent.tinydb.table(self.tablename)
+        self._load_durable_indexes()
         self._remember_memory_revision()
 
     def _refresh_table(self):
@@ -637,6 +750,7 @@ class TinyMongoCollection(object):
         self.parent._refresh_table()
         self.table = self.parent.tinydb.table(self.tablename)
         self._index_cache = {}
+        self._load_durable_indexes()
         self._remember_memory_revision()
 
     def _remember_memory_revision(self):
@@ -649,33 +763,158 @@ class TinyMongoCollection(object):
         if revision is not None and revision != self._memory_revision:
             self._refresh_table()
 
+    def _load_durable_indexes(self):
+        if INDEX_CATALOG_TABLE in self.parent.tinydb.tables():
+            catalog = self.parent.tinydb.table(INDEX_CATALOG_TABLE)
+            specs = []
+            for document in catalog.all():
+                if document.get("collection") == self.tablename:
+                    specs.append(IndexSpec.from_metadata(document["spec"]))
+        else:
+            specs = []
+        self._index_specs = {spec.name: spec for spec in specs}
+        self._indexes = {spec.field for spec in specs}
+
+    def _index_document(self, spec):
+        return {
+            "_id": index_catalog_id(self.tablename, spec.name),
+            "collection": self.tablename,
+            "spec": spec.to_metadata(),
+        }
+
+    def _find_index_spec(self, name_or_field):
+        for spec in self._index_specs.values():
+            if name_or_field in (spec.name, spec.field):
+                return spec
+        return None
+
+    def _validate_index_compatibility(self, spec):
+        by_name = self._index_specs.get(spec.name)
+        existing = by_name
+        if existing is not None and existing != spec:
+            raise OperationFailure(
+                "An index with the same name or key has different options"
+            )
+        return existing
+
+    def _validate_unique_post_image(self, documents, extra_specs=()):
+        specs = list(self._index_specs.values()) + list(extra_specs)
+        validate_unique_documents(documents, specs)
+
+    @_engine_write_locked
     def create_index(self, key, *args, **kwargs):
-        """Create an in-memory equality index for this collection instance."""
-        if not isinstance(key, str) or args or kwargs:
+        """Create a durable single-field ascending equality index."""
+        if args:
             raise TinyMongoNotSupportedError(
                 "Only single-field ascending equality indexes are supported"
             )
+        spec = parse_index_spec(key, **kwargs)
+        if spec.field == "_id":
+            if "unique" in kwargs:
+                raise OperationFailure(
+                    "The unique option is not valid for the built-in _id index",
+                    code=197,
+                )
+            return "_id_"
         if self.parent.engine is not None:
-            return self.parent.engine.create_index(self.tablename, key)
-        self._indexes.add(key)
-        self._index_cache.pop(key, None)
-        return key
+            return self.parent.engine.create_index(self.tablename, spec)
 
+        rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            if self.table is None:
+                self.build_table()
+            self._refresh_table()
+            existing = self._validate_index_compatibility(spec)
+            if existing is not None:
+                return existing.name
+            if spec.unique:
+                self._validate_unique_post_image(self.table.all(), [spec])
+            self.parent.tinydb.table(INDEX_CATALOG_TABLE).insert(
+                self._index_document(spec)
+            )
+            self._index_specs[spec.name] = spec
+            self._indexes.add(spec.field)
+            self._index_cache.pop(spec.field, None)
+            return spec.name
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
+
+    def create_indexes(self, indexes, *args, **kwargs):
+        """Create a validated batch of PyMongo-style index models."""
+        if args:
+            raise TypeError("create_indexes accepts one iterable of index models")
+        _reject_session(kwargs)
+        batch = plan_index_models(indexes)
+        for entry in batch:
+            if entry.spec is None:
+                continue
+            options = {"name": entry.spec.name}
+            if entry.spec.unique:
+                options["unique"] = True
+            self.create_index([(entry.spec.field, ASCENDING)], **options)
+        emit_index_plan_warnings(batch, stacklevel=3)
+        return list(batch.names)
+
+    @_engine_write_locked
     def drop_index(self, key):
-        """Drop an in-memory equality index for this collection instance."""
+        """Drop a durable index by its name or legacy field name."""
+        if key in ("_id", "_id_"):
+            raise OperationFailure("The _id index cannot be dropped")
         if self.parent.engine is not None:
             return self.parent.engine.drop_index(self.tablename, key)
-        self._indexes.discard(key)
-        self._index_cache.pop(key, None)
+
+        rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            if self.table is None:
+                self.build_table()
+            self._refresh_table()
+            spec = self._find_index_spec(key)
+            if spec is None:
+                raise OperationFailure("Index not found: {0}".format(key))
+            catalog = self.parent.tinydb.table(INDEX_CATALOG_TABLE)
+            self._set_storage_merge_writes(False)
+            try:
+                catalog.remove(where("_id") == self._index_document(spec)["_id"])
+            finally:
+                self._set_storage_merge_writes(True)
+            self._index_specs.pop(spec.name, None)
+            if not any(
+                current.field == spec.field for current in self._index_specs.values()
+            ):
+                self._indexes.discard(spec.field)
+            self._index_cache.pop(spec.field, None)
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
 
     def list_indexes(self):
-        """Return index metadata for this collection instance."""
+        """Return durable index metadata for this collection."""
         if self.parent.engine is not None:
             return self.parent.engine.list_indexes(self.tablename)
-        indexes = [{"name": "_id_", "key": [("_id", 1)]}]
-        for key in sorted(self._indexes):
-            indexes.append({"name": "{0}_1".format(key), "key": [(key, 1)]})
-        return indexes
+        rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            if self.table is None:
+                self.build_table()
+            self._refresh_table()
+            indexes = [{"name": "_id_", "key": [("_id", 1)]}]
+            for spec in sorted(self._index_specs.values(), key=lambda item: item.name):
+                metadata = {"name": spec.name, "key": [(spec.field, spec.direction)]}
+                if spec.unique:
+                    metadata["unique"] = True
+                indexes.append(metadata)
+            return indexes
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
+
+    def index_information(self):
+        """Return durable index metadata keyed by index name."""
+        return {
+            metadata["name"]: {
+                key: copy.deepcopy(value)
+                for key, value in metadata.items()
+                if key != "name"
+            }
+            for metadata in self.list_indexes()
+        }
 
     def _invalidate_indexes(self):
         self._index_cache = {}
@@ -685,16 +924,18 @@ class TinyMongoCollection(object):
             return None
         if key in self._index_cache:
             return self._index_cache[key]
-        if self.table is None:
-            self.build_table()
         index = {}
         for doc in self.table.all():
             value = _get_nested(doc, key)
             if value is _MISSING:
                 continue
             values = value if isinstance(value, list) else [value]
+            seen = set()
             for item in values:
                 try:
+                    if item in seen:
+                        continue
+                    seen.add(item)
                     index.setdefault(item, []).append(doc)
                 except TypeError:
                     continue
@@ -766,6 +1007,7 @@ class TinyMongoCollection(object):
         """Return the local collection size."""
         return self.count_documents({})
 
+    @_engine_write_locked
     def drop(self, **kwargs):
         """
         Removes a collection from the database.
@@ -776,12 +1018,13 @@ class TinyMongoCollection(object):
         _reject_session(kwargs)
         if self.parent.engine is not None:
             return self.parent.engine.drop_collection(self.tablename)
-        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        rlock, portalocker_lock = self._acquire_collection_lock()
         try:
+            self.parent._refresh_table()
             if self.tablename not in self.parent.collection_names():
                 return False
-            if self.table is None:
-                self.build_table()
+            self.table = self.parent.tinydb.table(self.tablename)
+            self._load_durable_indexes()
             self._set_storage_merge_writes(False)
             try:
                 drop_table = getattr(self.parent.tinydb, "drop_table", None)
@@ -789,7 +1032,14 @@ class TinyMongoCollection(object):
                     drop_table(self.tablename)
                 else:
                     self.parent.tinydb.purge_table(self.tablename)
+                if INDEX_CATALOG_TABLE in self.parent.tinydb.tables():
+                    self.parent.tinydb.table(INDEX_CATALOG_TABLE).remove(
+                        where("collection") == self.tablename
+                    )
                 self.table = None
+                self._index_specs = {}
+                self._indexes = set()
+                self._index_cache = {}
                 return True
             finally:
                 self._set_storage_merge_writes(True)
@@ -803,6 +1053,7 @@ class TinyMongoCollection(object):
         else:
             return self.insert_one(docs, *args, **kwargs)
 
+    @_engine_write_locked
     def insert_one(self, doc, *args, **kwargs):
         """
         Inserts one document into the collection
@@ -818,6 +1069,10 @@ class TinyMongoCollection(object):
                 _id = doc["_id"] = doc["_id"]
             else:
                 _id = doc["_id"] = generate_id()
+            self.parent.engine.validate_unique_post_image(
+                self.tablename,
+                self.parent.engine.find(self.tablename, {}) + [doc],
+            )
             result = self.parent.engine.insert_many(
                 self.tablename,
                 [doc],
@@ -841,26 +1096,23 @@ class TinyMongoCollection(object):
             else:
                 _id = doc["_id"] = generate_id()
 
-            bypass_document_validation = kwargs.get("bypass_document_validation")
-            if bypass_document_validation is True:
-                # insert doc without validation of duplicated `_id`
+            existing = self.find_one({"_id": _id})
+            if existing is None:
+                self._validate_unique_post_image(self.table.all() + [doc])
                 eid = self.table.insert(doc)
             else:
-                existing = self.find_one({"_id": _id})
-                if existing is None:
-                    eid = self.table.insert(doc)
-                else:
-                    raise DuplicateKeyError(
-                        "_id:{0} already exists in collection:{1}".format(
-                            _id, self.tablename
-                        )
+                raise DuplicateKeyError(
+                    "_id:{0} already exists in collection:{1}".format(
+                        _id, self.tablename
                     )
+                )
 
             self._invalidate_indexes()
             return InsertOneResult(eid=eid, inserted_id=_id)
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
+    @_engine_write_locked
     def insert_many(self, docs, *args, **kwargs):
         """
         Inserts several documents into the collection
@@ -878,6 +1130,10 @@ class TinyMongoCollection(object):
                 else:
                     _id = doc["_id"] = generate_id()
                 _ids.append(_id)
+            self.parent.engine.validate_unique_post_image(
+                self.tablename,
+                self.parent.engine.find(self.tablename, {}) + docs,
+            )
             results = self.parent.engine.insert_many(
                 self.tablename,
                 docs,
@@ -894,10 +1150,9 @@ class TinyMongoCollection(object):
             if not isinstance(docs, list):
                 raise ValueError('"insert_many" requires a list input')
 
-            bypass_document_validation = kwargs.get("bypass_document_validation")
-            if bypass_document_validation is not True:
-                # get all _id in once, to reduce I/O. (without projection)
-                existing = [doc["_id"] for doc in self.find({})]
+            # Get all _id values once to reduce I/O. Document-validation bypass
+            # never bypasses MongoDB's built-in unique _id constraint.
+            existing = [doc["_id"] for doc in self.find({})]
 
             _ids = list()
             for doc in docs:
@@ -909,17 +1164,17 @@ class TinyMongoCollection(object):
                 else:
                     _id = doc["_id"] = generate_id()
 
-                if bypass_document_validation is not True:
-                    if _id in existing:
-                        raise DuplicateKeyError(
-                            "_id:{0} already exists in collection:{1}".format(
-                                _id, self.tablename
-                            )
+                if _id in existing:
+                    raise DuplicateKeyError(
+                        "_id:{0} already exists in collection:{1}".format(
+                            _id, self.tablename
                         )
-                    existing.append(_id)
+                    )
+                existing.append(_id)
 
                 _ids.append(_id)
 
+            self._validate_unique_post_image(self.table.all() + docs)
             results = self.table.insert_multiple(docs)
             self._invalidate_indexes()
 
@@ -1155,6 +1410,7 @@ class TinyMongoCollection(object):
         else:
             return self.update_many(query, doc, *args, **kwargs)
 
+    @_engine_write_locked
     def update_one(self, query, doc, *args, **kwargs):
         """
         Updates one element of the collection
@@ -1172,6 +1428,10 @@ class TinyMongoCollection(object):
             if not matches:
                 if upsert:
                     inserted = _document_for_upsert(query, doc)
+                    self.parent.engine.validate_unique_post_image(
+                        self.tablename,
+                        self.parent.engine.find(self.tablename, {}) + [inserted],
+                    )
                     self.parent.engine.insert_many(self.tablename, [inserted])
                     return UpdateResult(
                         raw_result=[],
@@ -1180,7 +1440,15 @@ class TinyMongoCollection(object):
                         upserted_id=inserted["_id"],
                     )
                 return UpdateResult(raw_result=[], matched_count=0, modified_count=0)
-            modified = self.parent.engine.apply_update(matches[0], doc) != matches[0]
+            updated = self.parent.engine.apply_update(matches[0], doc)
+            modified = updated != matches[0]
+            self.parent.engine.validate_unique_post_image(
+                self.tablename,
+                [
+                    updated if item.get("_id") == matches[0].get("_id") else item
+                    for item in self.parent.engine.find(self.tablename, {})
+                ],
+            )
             self.parent.engine.update_many(self.tablename, query, doc, multi=False)
             return UpdateResult(
                 raw_result={
@@ -1198,12 +1466,23 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            allcond = self.parse_query(query)
-            item = self.table.get(allcond)
+            if requires_python_filter(query):
+                item = next(
+                    (
+                        candidate
+                        for candidate in self.table.all()
+                        if matches_filter(candidate, query)
+                    ),
+                    None,
+                )
+            else:
+                allcond = self.parse_query(query)
+                item = self.table.get(allcond)
 
             if item is None:
                 if upsert:
                     inserted = _document_for_upsert(query, doc)
+                    self._validate_unique_post_image(self.table.all() + [inserted])
                     self.table.insert(inserted)
                     self._invalidate_indexes()
                     return UpdateResult(
@@ -1217,6 +1496,11 @@ class TinyMongoCollection(object):
             updated = _apply_update_document(item, doc)
             modified = updated != item
             if modified:
+                post_image = [
+                    updated if current.get("_id") == item.get("_id") else current
+                    for current in self.table.all()
+                ]
+                self._validate_unique_post_image(post_image)
                 self.table.update(updated, where("_id") == item["_id"])
                 self._invalidate_indexes()
 
@@ -1232,6 +1516,7 @@ class TinyMongoCollection(object):
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
+    @_engine_write_locked
     def update_many(self, query, doc, *args, **kwargs):
         """
         Updates all elements matching the query
@@ -1248,6 +1533,10 @@ class TinyMongoCollection(object):
             matches = self.parent.engine.find(self.tablename, query)
             if not matches and upsert:
                 inserted = _document_for_upsert(query, doc)
+                self.parent.engine.validate_unique_post_image(
+                    self.tablename,
+                    self.parent.engine.find(self.tablename, {}) + [inserted],
+                )
                 self.parent.engine.insert_many(self.tablename, [inserted])
                 return UpdateResult(
                     raw_result=[],
@@ -1255,8 +1544,23 @@ class TinyMongoCollection(object):
                     modified_count=0,
                     upserted_id=inserted["_id"],
                 )
-            modified_count = sum(
-                self.parent.engine.apply_update(item, doc) != item for item in matches
+            updates = [
+                (item, self.parent.engine.apply_update(item, doc)) for item in matches
+            ]
+            modified_count = sum(updated != item for item, updated in updates)
+            self.parent.engine.validate_unique_post_image(
+                self.tablename,
+                [
+                    next(
+                        (
+                            updated
+                            for original, updated in updates
+                            if original.get("_id") == item.get("_id")
+                        ),
+                        item,
+                    )
+                    for item in self.parent.engine.find(self.tablename, {})
+                ],
             )
             result = self.parent.engine.update_many(
                 self.tablename, query, doc, multi=True
@@ -1273,10 +1577,18 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            allcond = self.parse_query(query)
-            items = list(self.table.search(allcond))
+            if requires_python_filter(query):
+                items = [
+                    candidate
+                    for candidate in self.table.all()
+                    if matches_filter(candidate, query)
+                ]
+            else:
+                allcond = self.parse_query(query)
+                items = list(self.table.search(allcond))
             if not items and upsert:
                 inserted = _document_for_upsert(query, doc)
+                self._validate_unique_post_image(self.table.all() + [inserted])
                 self.table.insert(inserted)
                 self._invalidate_indexes()
                 return UpdateResult(
@@ -1285,10 +1597,23 @@ class TinyMongoCollection(object):
                     modified_count=0,
                     upserted_id=inserted["_id"],
                 )
+            updates = [(item, _apply_update_document(item, doc)) for item in items]
+            self._validate_unique_post_image(
+                [
+                    next(
+                        (
+                            updated
+                            for original, updated in updates
+                            if original.get("_id") == item.get("_id")
+                        ),
+                        item,
+                    )
+                    for item in self.table.all()
+                ]
+            )
             result = []
             modified_count = 0
-            for item in items:
-                updated = _apply_update_document(item, doc)
+            for item, updated in updates:
                 if updated != item:
                     modified_count += 1
                     result.extend(
@@ -1305,6 +1630,7 @@ class TinyMongoCollection(object):
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
+    @_engine_write_locked
     def replace_one(self, query, replacement, *args, **kwargs):
         """
         Replaces one document matching the query with the replacement document.
@@ -1316,6 +1642,10 @@ class TinyMongoCollection(object):
                 if kwargs.get("upsert") is True:
                     inserted = copy.deepcopy(replacement)
                     inserted.setdefault("_id", generate_id())
+                    self.parent.engine.validate_unique_post_image(
+                        self.tablename,
+                        self.parent.engine.find(self.tablename, {}) + [inserted],
+                    )
                     self.parent.engine.insert_many(self.tablename, [inserted])
                     return UpdateResult(
                         raw_result=[],
@@ -1328,6 +1658,13 @@ class TinyMongoCollection(object):
             updated["_id"] = item["_id"]
             modified = updated != item
             if modified:
+                self.parent.engine.validate_unique_post_image(
+                    self.tablename,
+                    [
+                        updated if current.get("_id") == item.get("_id") else current
+                        for current in self.parent.engine.find(self.tablename, {})
+                    ],
+                )
                 self.parent.engine.replace_one(self.tablename, item["_id"], updated)
             return UpdateResult(
                 raw_result=[item["_id"]] if modified else [],
@@ -1341,12 +1678,23 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            allcond = self.parse_query(query)
-            item = self.table.get(allcond)
+            if requires_python_filter(query):
+                item = next(
+                    (
+                        candidate
+                        for candidate in self.table.all()
+                        if matches_filter(candidate, query)
+                    ),
+                    None,
+                )
+            else:
+                allcond = self.parse_query(query)
+                item = self.table.get(allcond)
             if item is None:
                 if kwargs.get("upsert") is True:
                     inserted = copy.deepcopy(replacement)
                     inserted.setdefault("_id", generate_id())
+                    self._validate_unique_post_image(self.table.all() + [inserted])
                     self.table.insert(inserted)
                     self._invalidate_indexes()
                     return UpdateResult(
@@ -1361,6 +1709,11 @@ class TinyMongoCollection(object):
             updated["_id"] = item["_id"]
             modified = updated != item
             if modified:
+                post_image = [
+                    updated if current.get("_id") == item.get("_id") else current
+                    for current in self.table.all()
+                ]
+                self._validate_unique_post_image(post_image)
                 self.table.remove(where("_id") == item["_id"])
                 self.table.insert(updated)
                 self._invalidate_indexes()
@@ -1374,45 +1727,102 @@ class TinyMongoCollection(object):
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
+    @_engine_write_locked
     def find_one_and_update(self, query, update, *args, **kwargs):
         """
         Mimics MongoDB's findOneAndUpdate by returning the document before update.
         """
         _reject_session(kwargs)
-        if self.parent.engine is not None:
-            item = self.parent.engine.find_one(self.tablename, query)
+        return_after = kwargs.get("return_document", False)
+        if not isinstance(return_after, bool):
+            raise ValueError(
+                "return_document must be ReturnDocument.BEFORE or "
+                "ReturnDocument.AFTER"
+            )
+        projection = normalize_projection(kwargs.get("projection"))
+        sort = kwargs.get("sort")
+        write_kwargs = dict(kwargs)
+        for option in ("projection", "return_document", "sort"):
+            write_kwargs.pop(option, None)
+
+        rlock = portalocker_lock = None
+        if self.parent.engine is None:
+            rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            item = self.find_one(query, sort=sort)
             if item is None:
-                result = self.update_one(query, update, *args, **kwargs)
-                if result.upserted_id is None:
+                result = self.update_one(query, update, *args, **write_kwargs)
+                if result.upserted_id is None or not return_after:
                     return None
-                return self.find_one({"_id": result.upserted_id})
-            self.update_one(query, update, *args, **kwargs)
-            return self.find_one(query) if kwargs.get("return_document") else item
+                returned = self.find_one({"_id": result.upserted_id})
+            else:
+                self.update_one({"_id": item["_id"]}, update, *args, **write_kwargs)
+                returned = self.find_one({"_id": item["_id"]}) if return_after else item
+            return project_document(returned, projection)
+        finally:
+            if self.parent.engine is None:
+                self._release_collection_lock(rlock, portalocker_lock)
 
-        item = self.find_one(query)
-        if item is None:
-            result = self.update_one(query, update, *args, **kwargs)
-            if result.upserted_id is None:
-                return None
-            return self.find_one({"_id": result.upserted_id})
-
-        self.update_one(query, update, *args, **kwargs)
-        return self.find_one(query) if kwargs.get("return_document") else item
-
+    @_engine_write_locked
     def find_one_and_replace(self, query, replacement, *args, **kwargs):
         """Replace one document and return its previous or resulting value."""
         _reject_session(kwargs)
-        previous = self.find_one(query)
-        result = self.replace_one(query, replacement, *args, **kwargs)
-        if previous is None:
-            if result.upserted_id is None:
-                return None
-            return self.find_one({"_id": result.upserted_id})
-        if kwargs.get("return_document"):
-            return self.find_one({"_id": previous["_id"]})
-        return previous
+        return_after = kwargs.get("return_document", False)
+        if not isinstance(return_after, bool):
+            raise ValueError(
+                "return_document must be ReturnDocument.BEFORE or "
+                "ReturnDocument.AFTER"
+            )
+        projection = normalize_projection(kwargs.get("projection"))
+        sort = kwargs.get("sort")
+        write_kwargs = dict(kwargs)
+        for option in ("projection", "return_document", "sort"):
+            write_kwargs.pop(option, None)
 
-    def find(self, _filter=None, sort=None, skip=None, limit=None, *args, **kwargs):
+        rlock = portalocker_lock = None
+        if self.parent.engine is None:
+            rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            previous = self.find_one(query, sort=sort)
+            target = query if previous is None else {"_id": previous["_id"]}
+            result = self.replace_one(target, replacement, *args, **write_kwargs)
+            if previous is None:
+                if result.upserted_id is None or not return_after:
+                    return None
+                returned = self.find_one({"_id": result.upserted_id})
+            else:
+                returned = (
+                    self.find_one({"_id": previous["_id"]})
+                    if return_after
+                    else previous
+                )
+            return project_document(returned, projection)
+        finally:
+            if self.parent.engine is None:
+                self._release_collection_lock(rlock, portalocker_lock)
+
+    @_engine_write_locked
+    def find_one_and_delete(self, query, *args, **kwargs):
+        """Delete one matching document and return its pre-delete value."""
+        _reject_session(kwargs)
+        projection = kwargs.get("projection")
+        sort = kwargs.get("sort")
+        rlock = portalocker_lock = None
+        if self.parent.engine is None:
+            rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            item = self.find_one(query, sort=sort)
+            if item is None:
+                return None
+            self.delete_one({"_id": item["_id"]})
+            return project_document(item, normalize_projection(projection))
+        finally:
+            if self.parent.engine is None:
+                self._release_collection_lock(rlock, portalocker_lock)
+
+    def find(
+        self, _filter=None, projection=None, skip=None, limit=None, *args, **kwargs
+    ):
         """
         Finds all matching results
 
@@ -1421,13 +1831,23 @@ class TinyMongoCollection(object):
         :return: cursor containing the search results
         """
         _reject_session(kwargs)
+        if _filter is None and "filter" in kwargs:
+            _filter = kwargs["filter"]
+        projection = normalize_projection(projection)
+        sort = kwargs.get("sort")
         if self.parent.engine is not None:
             result = self.parent.engine.find(self.tablename, _filter)
             return TinyMongoCursor(
-                result, sort=sort, skip=skip, limit=limit, collection=self
+                result,
+                sort=sort,
+                skip=skip,
+                limit=limit,
+                collection=self,
+                projection=projection,
+                query=_filter,
             )
 
-        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             if self.table is None:
                 self.build_table()
@@ -1448,21 +1868,36 @@ class TinyMongoCollection(object):
                             skip=skip,
                             limit=limit,
                             collection=self,
+                            projection=projection,
+                            query=_filter,
                         )
-                allcond = self.parse_query(_filter)
+                if requires_python_filter(_filter):
+                    result = [
+                        document
+                        for document in self.table.all()
+                        if matches_filter(document, _filter)
+                    ]
+                else:
+                    allcond = self.parse_query(_filter)
 
-                try:
-                    result = self.table.search(allcond)
-                except (AttributeError, TypeError):
-                    result = []
+                    try:
+                        result = self.table.search(allcond)
+                    except (AttributeError, TypeError):
+                        result = []
 
             return TinyMongoCursor(
-                result, sort=sort, skip=skip, limit=limit, collection=self
+                result,
+                sort=sort,
+                skip=skip,
+                limit=limit,
+                collection=self,
+                projection=projection,
+                query=_filter,
             )
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
-    def find_one(self, _filter=None, *args, **kwargs):
+    def find_one(self, _filter=None, projection=None, *args, **kwargs):
         """
         Finds one matching query element
 
@@ -1470,21 +1905,36 @@ class TinyMongoCollection(object):
         :return: the resulting document (if found)
         """
         _reject_session(kwargs)
-        if self.parent.engine is not None:
-            return self.parent.engine.find_one(self.tablename, _filter)
-
-        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        if _filter is None and "filter" in kwargs:
+            _filter = kwargs["filter"]
+        sort = kwargs.get("sort")
+        cursor = self.find(
+            _filter,
+            projection,
+            limit=1,
+            sort=sort,
+        )
         try:
-            if self.table is None:
-                self.build_table()
+            return cursor.next()
+        except (IndexError, StopIteration):
+            return None
 
-            self._refresh_stale_memory_table()
-
-            allcond = self.parse_query(_filter)
-
-            return self.table.get(allcond)
-        finally:
-            self._release_collection_lock(rlock, portalocker_lock)
+    def distinct(self, key, filter=None, *args, **kwargs):
+        """Return unique values for a field among matching documents."""
+        _reject_session(kwargs)
+        values = []
+        for document in self.find(filter or {}):
+            value = _get_nested(document, key)
+            if value is _MISSING:
+                continue
+            candidates = value if isinstance(value, list) else [value]
+            for candidate in candidates:
+                if not any(
+                    type(candidate) is type(existing) and candidate == existing
+                    for existing in values
+                ):
+                    values.append(copy.deepcopy(candidate))
+        return values
 
     def remove(self, spec_or_id, multi=True, *args, **kwargs):
         """Backwards compatibility with remove"""
@@ -1492,6 +1942,7 @@ class TinyMongoCollection(object):
             return self.delete_many(spec_or_id)
         return self.delete_one(spec_or_id)
 
+    @_engine_write_locked
     def delete_one(self, query, *args, **kwargs):
         """
         Deletes one document from the collection
@@ -1504,7 +1955,7 @@ class TinyMongoCollection(object):
             result = self.parent.engine.delete_many(self.tablename, query, multi=False)
             return DeleteResult(raw_result=result)
 
-        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             item = self.find_one(query)
             if item is None:
@@ -1520,6 +1971,7 @@ class TinyMongoCollection(object):
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
+    @_engine_write_locked
     def delete_many(self, query, *args, **kwargs):
         """
         Removes all items matching the mongo query
@@ -1532,7 +1984,7 @@ class TinyMongoCollection(object):
             result = self.parent.engine.delete_many(self.tablename, query, multi=True)
             return DeleteResult(raw_result=result)
 
-        rlock, portalocker_lock = self._acquire_memory_collection_lock()
+        rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             items = self.find(query)
             self._set_storage_merge_writes(False)
@@ -1556,16 +2008,28 @@ class TinyMongoCollection(object):
 class TinyMongoCursor(object):
     """Mongo iterable cursor"""
 
-    def __init__(self, cursordat, sort=None, skip=None, limit=None, collection=None):
+    def __init__(
+        self,
+        cursordat,
+        sort=None,
+        skip=None,
+        limit=None,
+        collection=None,
+        projection=None,
+        query=None,
+    ):
         """Initialize the mongo iterable cursor with data"""
-        self.cursordat = cursordat
+        self._source_data = list(cursordat)
+        self.cursordat = list(self._source_data)
         self.collection = collection
+        self.projection = projection
+        self.query = copy.deepcopy(query)
+        self._sort_spec = None
+        self._skip = 0
+        self._limit = 0
+        self._closed = False
         self.cursorpos = -1
-
-        if len(self.cursordat) == 0:
-            self.currentrec = None
-        else:
-            self.currentrec = self.cursordat[self.cursorpos]
+        self.currentrec = None
 
         if sort:
             self.sort(sort)
@@ -1575,26 +2039,42 @@ class TinyMongoCursor(object):
     def __getitem__(self, key):
         """Gets record by index or value by key"""
         if isinstance(key, int):
-            return self.cursordat[key]
-        return self.currentrec[key]
+            return self._project(self.cursordat[key])
+        return self._project(self.currentrec)[key]
+
+    def _project(self, document):
+        if self.projection is None:
+            return copy.deepcopy(document)
+        return project_document(document, self.projection)
 
     def paginate(self, skip, limit):
         """Paginate list of records"""
-        if not self.count() or not limit:
-            return
-        skip = skip or 0
-        pages = int(ceil(self.count() / float(limit)))
-        limits = {}
-        last = 0
-        for i in range(pages):
-            current = limit * i
-            limits[last] = current
-            last = current
-        # example with count == 62
-        # {0: 20, 20: 40, 40: 60, 60: 62}
-        if limit and limit < self.count():
-            limit = limits.get(skip, self.count())
-            self.cursordat = self.cursordat[skip:limit]
+        if skip is not None:
+            self._validate_skip(skip)
+            self._skip = skip
+        if limit is not None:
+            self._validate_limit(limit)
+            self._limit = abs(limit)
+        self._refresh_view()
+        return self
+
+    @staticmethod
+    def _validate_skip(value):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("skip must be an integer")
+        if value < 0:
+            raise ValueError("skip must be non-negative")
+
+    @staticmethod
+    def _validate_limit(value):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("limit must be an integer")
+
+    def _refresh_view(self):
+        end = None if self._limit == 0 else self._skip + self._limit
+        self.cursordat = self._source_data[self._skip : end]
+        self.cursorpos = -1
+        self.currentrec = self.cursordat[-1] if self.cursordat else None
 
     def _order(self, value, is_reverse=None):
         """Parsing data to a sortable form
@@ -1713,9 +2193,11 @@ class TinyMongoCursor(object):
                 " or pass a list of (key, direction) pairs."
             )
 
+        self._sort_spec = (copy.deepcopy(key_or_list), direction)
+
         # sorting
 
-        _cursordat = self.cursordat
+        _cursordat = list(self._source_data)
 
         total = len(_cursordat)
         pre_sect_stack = list()
@@ -1797,28 +2279,89 @@ class TinyMongoCursor(object):
 
         # done
 
-        self.cursordat = _cursordat
+        self._source_data = _cursordat
+        self._refresh_view()
 
         return self
 
     def limit(self, n):
-        self.cursordat = self.cursordat[:n]
+        self._validate_limit(n)
+        self._limit = abs(n)
+        self._refresh_view()
         return self
+
+    def skip(self, n):
+        """Skip the first ``n`` records without changing the result source."""
+        self._validate_skip(n)
+        self._skip = n
+        self._refresh_view()
+        return self
+
+    def clone(self):
+        """Return an independently consumable copy of this cursor."""
+        if self.collection is None:
+            clone = type(self)(
+                copy.deepcopy(self._source_data),
+                projection=copy.deepcopy(self.projection),
+                query=copy.deepcopy(self.query),
+            )
+        else:
+            clone = self.collection.find(copy.deepcopy(self.query))
+            clone.projection = copy.deepcopy(self.projection)
+            if self._sort_spec is not None:
+                clone.sort(
+                    copy.deepcopy(self._sort_spec[0]),
+                    self._sort_spec[1],
+                )
+        clone._skip = self._skip
+        clone._limit = self._limit
+        clone._refresh_view()
+        return clone
+
+    def rewind(self):
+        """Reset iteration to the beginning of the current cursor window."""
+        if self._closed:
+            raise InvalidOperation("Cannot rewind a closed cursor")
+        self.cursorpos = -1
+        return self
+
+    @property
+    def alive(self):
+        return not self._closed and self.cursorpos + 1 < len(self.cursordat)
+
+    def close(self):
+        """Close this local cursor and discard no collection data."""
+        self._closed = True
+
+    def to_list(self, length=None):
+        """Consume up to ``length`` remaining records into a list."""
+        if length is not None:
+            if isinstance(length, bool) or not isinstance(length, int):
+                raise TypeError("length must be an integer or None")
+            if length < 0:
+                raise ValueError("length must be non-negative")
+        if self._closed:
+            return []
+        start = self.cursorpos + 1
+        end = len(self.cursordat) if length is None else start + length
+        documents = [self._project(item) for item in self.cursordat[start:end]]
+        self.cursorpos += len(documents)
+        return documents
 
     def has_next(self):
         """
         Returns True if the cursor has a next position, False if not
         :return:
         """
-        cursor_pos = self.cursorpos + 1
-
-        return cursor_pos + 1 < len(self.cursordat)
+        return self.alive
 
     def hasNext(self):
         """
         Returns True if the cursor has a next position, False if not
         :return:
         """
+        if self._closed:
+            return False
         cursor_pos = self.cursorpos + 1
 
         try:
@@ -1833,8 +2376,10 @@ class TinyMongoCursor(object):
 
         :return:
         """
+        if not self.hasNext():
+            raise StopIteration
         self.cursorpos += 1
-        return self.cursordat[self.cursorpos]
+        return self._project(self.cursordat[self.cursorpos])
 
     def count(self, with_limit_and_skip=False):
         """
@@ -1845,7 +2390,8 @@ class TinyMongoCursor(object):
         return len(self.cursordat)
 
     def __iter__(self):
-        self.cursorpos = -1
+        if self._closed:
+            return iter(())
         return self
 
     def __next__(self):
@@ -1856,7 +2402,7 @@ class TinyMongoCursor(object):
         if not self.hasNext():
             raise StopIteration
         self.cursorpos += 1
-        return self.cursordat[self.cursorpos]
+        return self._project(self.cursordat[self.cursorpos])
 
 
 class TinyGridFS(object):


### PR DESCRIPTION
## Summary

This PR completes the remaining Milestone 1 compatibility prerequisites and
adds the shared API foundation needed for the Talk Python application work.

It:

- adds `tinymongo.patch()` as a nested-safe context manager and decorator that
  routes both synchronous and asynchronous PyMongo clients to TinyMongo;
- adds Mongo-style inclusion and exclusion projections to `find()` and
  `find_one()`, including `_id`, dotted paths, arrays, validation, and
  cross-backend contracts;
- replaces collection-handle indexes with durable catalogs and unique
  enforcement for memory, JSON, SQLite, DuckDB, Parquet, PostgreSQL, and
  MariaDB/MySQL;
- creates native indexes where SQLite and remote SQL can guarantee them, with
  restart, duplicate, drop, and concurrency coverage;
- adds practical duck-typed `IndexModel` batches, common
  client/database/collection/cursor APIs, and sync/async result parity;
- adds the first non-blocking async facade, keeping storage work and lock waits
  off the event loop;
- adds optional ObjectId and datetime encoding without making PyMongo a core
  dependency;
- implements the first Talk Python query slice and conditionally maps TinyMongo
  exceptions onto installed PyMongo exception classes;
- updates the README, migration guide, changelog, roadmap, and CI matrix.

## Why

The memory backend and initial contract framework are already merged. Patching,
projections, durable indexes, and the common API surface were the next blockers
to running a real PyMongo-shaped application against every TinyMongo backend.
Keeping these changes together lets the projection, index, BSON, sync, and
async paths share the same contracts instead of developing separate semantics.

## Compatibility and behavior notes

- The second positional argument to `find()` is now PyMongo's `projection`
  argument. Existing callers should pass sorting with `sort=` or cursor
  `.sort()`.
- `create_index()` now returns the effective index name, matching PyMongo.
- Direct `create_index()` remains strict: unsupported compound, descending,
  text, hashed, TTL, sparse, partial, collation, and wildcard declarations fail
  clearly.
- Plural `create_indexes()` may use an explicitly warned fallback for
  non-unique performance declarations where query correctness is preserved.
  Unsafe unique degradation fails before creating any batch entry. Text/TTL
  limitations are surfaced through `TinyMongoUnsupportedWarning`, not silently
  accepted.
- PyMongo remains optional; the `bson` and `pymongo` extras support PyMongo
  4.9 or newer.
- Full BSON-aware cross-type `_id` comparison remains tracked in #94.
- Native remote-SQL unique indexes reject array-valued keys until cross-process
  multikey uniqueness can be guaranteed.
- The async public facade is present, but #136 remains open until the complete
  Talk Python async acceptance contract is run and remaining gaps are recorded.
- The BSON, query/operator, version-adaptation, and application-contract issues
  listed below remain open for their broader follow-up scopes.

## Backend implementation

- JSON/TinyDB stores index definitions in a hidden durable catalog.
- Named memory namespaces retain index definitions for their process lifetime.
- SQLite uses native typed expression indexes and planner-compatible JSON paths.
- DuckDB and Parquet persist metadata and enforce unique constraints under
  complete write locks.
- PostgreSQL uses typed JSONB expression indexes.
- MariaDB/MySQL uses typed generated tokens and native indexes.
- Collection and index drops clean both metadata and physical indexes.

## Validation

Local release gates:

- `608 passed, 71 deselected`
- 100% statement and branch coverage: 4,174 statements and 1,482 branches, zero
  missed
- `black --check .`
- `ruff check .`
- `mypy --ignore-missing-imports tinymongo`
- `git diff --check`

External compatibility checks performed during implementation:

- real MongoDB 8 projection contracts;
- real PostgreSQL 16 typed uniqueness, persistence, native DDL, update/replace
  enforcement, cleanup, and concurrent duplicate races;
- real MariaDB 11.4 native generated indexes, scalar/nested values, persistence,
  and cleanup;
- repeated fresh-process DuckDB unique-index races.

CI now adds PostgreSQL/MariaDB integration services and a PyMongo 4.9
compatibility-floor job.

## Review guide

The highest-value review areas are:

1. process-global patch restoration and nested/task ownership in
   `tinymongo/patching.py`;
2. projection validation and nested-array behavior in
   `tinymongo/projection.py`;
3. index token semantics and batch planning in `tinymongo/indexes.py`;
4. native index DDL and transaction/lock boundaries in
   `tinymongo/table_backends.py`;
5. event-loop isolation and cursor lifecycle in `tinymongo/asyncio.py`;
6. backward-safe tagged BSON encoding in `tinymongo/bson_codec.py`.

Closes #70

Closes #73

Closes #74

Closes #76

Advances #72, #75, #77, #102, and #136.
