### PR TITLE
Restore stable Python 3.9 lint CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ mongoengine>=0.29,<1
 duckdb
 black>=25,<26
 ruff
-mypy
+mypy>=1.19,<2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ pymongo>=4.9
 mongoengine>=0.29,<1
 duckdb
 black>=25,<26
-ruff
+ruff>=0.15,<0.16
 mypy>=1.19,<2

--- a/tinymongo/patching.py
+++ b/tinymongo/patching.py
@@ -14,7 +14,7 @@ from .tinymongo import MongoClient
 
 _patch_state_lock = threading.RLock()
 _patch_owner = None
-_patch_entries = []
+_patch_entries: list[tuple] = []
 
 
 def _patch_context_owner():


### PR DESCRIPTION
## What changed

- constrain development mypy to the compatible 1.x line
- constrain Ruff to the compatible 0.15 line
- give the process-global patch entry stack an explicit type annotation

## Why

The post-merge CI run for #137 installed unbounded mypy 2.3. That release no longer accepts the project's Python 3.9 target and also rejected the unannotated module-level `_patch_entries` list. After that blocker was removed, Ruff 0.16 changed its default checks and reported 582 findings in previously accepted code. TinyMongo still advertises and tests Python 3.9, so raising the project minimum or mechanically rewriting unrelated code would be the wrong repair.

## Impact

This makes lint tooling reproducible again while preserving Python 3.9 support. It does not change runtime dependencies or behavior.

## Validation

- 608 tests passed
- 100% statement and branch coverage
- Ruff 0.15 passed
- Black passed
- mypy 1.19 passed across all 14 source files
- GitHub Actions passed on Python 3.9, 3.11, and 3.13
- real MongoDB contracts passed
- PyMongo 4.9 floor passed
- PostgreSQL and MariaDB integration passed
