### PR TITLE
Add sync and async compatibility baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,27 @@ jobs:
           pytest -o addopts='' -q -m contract tests/contracts
           --junitxml=contract-results.xml
 
-      - name: Upload compatibility results
+      - name: Generate compatibility reports
+        if: always()
+        run: |
+          if [ -f contract-results.xml ]; then
+            python scripts/generate_compatibility_report.py contract-results.xml \
+              --json-output compatibility-report.json \
+              --markdown-output compatibility-report.md
+          else
+            echo "::warning::Contract JUnit output was not created; reports cannot be generated"
+          fi
+
+      - name: Upload compatibility results and reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: mongodb-compatibility-results
-          path: contract-results.xml
+          path: |
+            contract-results.xml
+            compatibility-report.json
+            compatibility-report.md
+          if-no-files-found: warn
 
   remote-sql-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
             python scripts/generate_compatibility_report.py contract-results.xml \
               --json-output compatibility-report.json \
               --markdown-output compatibility-report.md
+            cat compatibility-report.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::warning::Contract JUnit output was not created; reports cannot be generated"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+contract-results.xml
+compatibility-report.json
+compatibility-report.md
 
 # Translations
 *.mo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   explicit same-process sharing through named `memory://NAME` namespaces.
 - The memory backend now participates in the shared MongoDB compatibility
   contract matrix.
+- Deterministic JSON and Markdown compatibility reports generated from contract
+  JUnit results, including per-backend outcomes, known gaps, and a documented
+  compatibility score.
 - `tinymongo.patch()` context-manager and decorator forms for temporarily
   routing sync and async PyMongo client construction to a configurable
   TinyMongo backend.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@
   explicit same-process sharing through named `memory://NAME` namespaces.
 - The memory backend now participates in the shared MongoDB compatibility
   contract matrix.
-- Deterministic JSON and Markdown compatibility reports generated from contract
-  JUnit results, including per-backend outcomes, known gaps, and a documented
-  compatibility score.
+- Deterministic JSON and Markdown compatibility reports generated from one or
+  more contract JUnit files, with sync/async, backend, and suite dimensions,
+  MongoDB-qualified scoring, and incomplete-matrix safeguards.
+- An external pytest acceptance runner that patches both PyMongo client classes
+  before application tests are imported and records report metadata.
 - `tinymongo.patch()` context-manager and decorator forms for temporarily
   routing sync and async PyMongo client construction to a configurable
   TinyMongo backend.
 - First-class non-blocking async client, database, collection, and lazy cursor
   APIs with awaited cleanup and off-thread storage work.
+- Shared MongoDB compatibility contracts now exercise both synchronous and
+  asynchronous APIs against every configured backend and reference target.
 - Mongo-style inclusion and exclusion projections for `find()` and `find_one()`,
   including nested dotted paths, array behavior, and compatible `_id` handling.
 - Durable single-field index metadata and unique constraints across JSON,

--- a/README.md
+++ b/README.md
@@ -477,6 +477,10 @@ See [Compatibility reports](docs/COMPATIBILITY_REPORTS.md) to generate them
 locally and understand how passes, expected gaps, skips, and the MongoDB
 reference affect the score.
 
+The shared Talk-Python-derived contracts run through both TinyMongo API modes.
+To exercise the actual application without rewriting its PyMongo call sites,
+follow the [Talk Python acceptance run](docs/TALKPYTHON_ACCEPTANCE.md).
+
 PyMongo remains optional. It is needed for these comparisons,
 `tinymongo.patch()`, and `ObjectId` support, but it is not required for normal
 TinyMongo clients or `datetime` storage. When it is installed, TinyMongo error

--- a/README.md
+++ b/README.md
@@ -471,6 +471,12 @@ pytest -o addopts='' -q -m 'contract and mongodb' tests/contracts
 Use `-m contract` instead of `-m 'contract and mongodb'` to run the complete
 embedded-plus-MongoDB matrix in one session.
 
+CI publishes the JUnit results together with deterministic JSON and Markdown
+reports containing per-backend outcomes and a documented compatibility score.
+See [Compatibility reports](docs/COMPATIBILITY_REPORTS.md) to generate them
+locally and understand how passes, expected gaps, skips, and the MongoDB
+reference affect the score.
+
 PyMongo remains optional. It is needed for these comparisons,
 `tinymongo.patch()`, and `ObjectId` support, but it is not required for normal
 TinyMongo clients or `datetime` storage. When it is installed, TinyMongo error

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,8 @@ Application-compatibility work:
 - [ ] [#136: Full non-blocking PyMongo async API parity](https://github.com/schapman1974/tinymongo/issues/136)
   - [x] Public async client/database/collection/cursor facade with lazy cursors,
     off-thread storage calls, async cleanup, and sync-result parity.
+  - [x] Run the application-derived compatibility contracts through both the
+    synchronous and asynchronous APIs.
   - [ ] Run the complete async application contract against Talk Python and
     record any remaining differences.
 - [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
@@ -45,6 +47,12 @@ Application-compatibility work:
   - [x] TinyMongo errors conditionally inherit matching PyMongo errors.
   - [ ] Add version-matrix CI plus broader signature and result adaptation.
 - [ ] [#72: Real MongoDB and application contract suite](https://github.com/schapman1974/tinymongo/issues/72)
+  - [x] Generate deterministic, dimensioned compatibility reports from the
+    sync/async backend and MongoDB contract matrix.
+  - [x] Provide an external pytest runner that patches both PyMongo client
+    classes before application tests are imported.
+  - [ ] Run the real Talk Python suite through the runner and publish its
+    reference, memory, and SQLite baseline.
 - [ ] [#87: Differential compatibility fuzzing](https://github.com/schapman1974/tinymongo/issues/87)
 
 Exit criteria:
@@ -220,6 +228,9 @@ Exit criteria:
    required by the first Talk Python contracts.
 4. [ ] Run Talk Python against TinyMongo's async client, turn every failure into a
    contract, and publish the baseline compatibility score.
+   - [x] Exercise the Talk-Python-derived contract slice through sync and async.
+   - [x] Add deterministic reporting and an external application test runner.
+   - [ ] Complete the real application run with Mike and record every difference.
 5. [ ] Build aggregation core after the real-application acceptance path works.
 6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
    compatibility gaps.

--- a/docs/COMPATIBILITY_REPORTS.md
+++ b/docs/COMPATIBILITY_REPORTS.md
@@ -1,0 +1,123 @@
+# Compatibility reports
+
+TinyMongo turns the shared contract suite's pytest JUnit XML into two
+deterministic reports:
+
+- `compatibility-report.json` is a versioned, machine-readable record with
+  per-test and per-target outcomes.
+- `compatibility-report.md` summarizes the score, per-target counts, known
+  gaps, failures, errors, and unexpected strict-xfail passes.
+
+The reports omit timestamps, durations, hostnames, and input paths. Common
+absolute paths captured in JUnit reason messages are replaced with
+`<ABSOLUTE_PATH>`, so otherwise-identical outcomes from different temporary
+directories produce byte-for-byte identical output.
+
+## Generate reports locally
+
+First write JUnit XML while running the complete embedded-plus-MongoDB contract
+matrix:
+
+```bash
+TINYMONGO_MONGODB_URI=mongodb://127.0.0.1:27017/?directConnection=true \
+TINYMONGO_REQUIRE_MONGODB=1 \
+pytest -o addopts='' -q -m contract tests/contracts \
+  --junitxml=contract-results.xml
+```
+
+Then generate both reports, even if pytest returned a nonzero status because a
+contract failed:
+
+```bash
+python scripts/generate_compatibility_report.py contract-results.xml \
+  --json-output compatibility-report.json \
+  --markdown-output compatibility-report.md
+```
+
+Without the output options, those same two report filenames are used in the
+current directory. Use `--targets` and `--reference-target` only for a custom
+contract matrix; the defaults match memory, JSON, SQLite, DuckDB, Parquet, and
+MongoDB. Target names may contain alphanumeric or underscore segments separated
+by single hyphens. The name `unattributed` is reserved for cases whose pytest
+parameter ID cannot be matched safely.
+
+## JSON structure
+
+The top-level `schema_version` changes only when the machine-readable shape
+changes incompatibly. Version 1 contains:
+
+- `scoring`: the formula, reference target, and aggregate numerator,
+  denominator, and percentage;
+- `totals`: counts for every outcome across the input JUnit file;
+- `targets`: ordered per-target roles, counts, scores, and individual test
+  outcomes;
+- `known_gaps`: expected failures with target, contract, test name, and reason;
+- `unexpected_passes`: strict expected failures whose behavior now passes.
+
+Percentages are rounded to two decimal places. A JSON `null` percentage means
+that target had no evaluated cases.
+
+## Scoring
+
+A **backend-contract cell** is one contract case executed for one TinyMongo
+backend. The overall score is:
+
+```text
+(passed + xpassed) /
+(passed + xpassed + xfailed + failed + error)
+```
+
+- A pass is compatible.
+- An expected failure (`xfail`) is an executed, known incompatibility. It stays
+  in the denominator and does not count as compatible.
+- A strict expected failure that unexpectedly passes (`xpass`) demonstrates
+  compatible behavior, so it counts as compatible. Pytest still fails the test
+  run until the stale known-gap marker is removed.
+- A failure or error is evaluated but incompatible.
+- An ordinary skip is reported but excluded because the behavior was not
+  executed. A target with only skips has no score rather than a misleading
+  zero.
+- The configured reference target is excluded from TinyMongo's aggregate score
+  while its outcomes remain visible. MongoDB is the default reference.
+- Cases that cannot be attributed to one configured target appear under
+  `unattributed` and are excluded from the aggregate rather than silently
+  changing it.
+
+The aggregate is weighted by backend-contract cells. This means a behavior gap
+on three backends contributes three incompatible cells. Per-target scores make
+that weighting visible.
+
+## JUnit interpretation
+
+Pytest writes expected failures as `<skipped type="pytest.xfail">` elements;
+the generator uses that type to distinguish them from ordinary skips. Strict
+unexpected passes are emitted as failures whose normalized message begins with
+the exact marker `[XPASS(strict)]`; only that marker or an exact xpass result
+type is classified as `xpassed`. The original pytest step remains failed.
+
+Target names are recovered from pytest's bracketed parameter ID, such as
+`test_name[sqlite]`, `test_name[value-sqlite]`, or
+`test_name[value-remote-sql]`. Matching uses full configured names at hyphen
+boundaries, so a target name may itself contain hyphens. A parameter ID
+containing no configured target, or matching more than one configured target,
+is reported as `unattributed`.
+
+Message normalization recognizes quoted or unquoted Unix paths beginning with
+`/`, Windows drive paths such as `C:\\...` or `C:/...`, and UNC paths beginning
+with `\\\\`. Quoted paths may contain spaces. An unquoted path ends at
+whitespace or common message punctuation; unusual unquoted paths containing
+those characters may therefore be only partly redacted. Relative paths and
+URLs are intentionally left intact because treating them as absolute paths
+would hide useful test details.
+
+## CI failure behavior
+
+The MongoDB contract step runs normally and retains its original success or
+failure status. Report generation and artifact upload use `if: always()`, so a
+JUnit file containing ordinary contract failures still produces JSON and
+Markdown diagnostics. Generating a report never converts a failed contract run
+into a successful job.
+
+If pytest stops before creating JUnit XML, CI emits a warning and uploads any
+files that do exist; there is no input from which a compatibility report can be
+generated.

--- a/docs/COMPATIBILITY_REPORTS.md
+++ b/docs/COMPATIBILITY_REPORTS.md
@@ -1,22 +1,21 @@
 # Compatibility reports
 
-TinyMongo turns the shared contract suite's pytest JUnit XML into two
-deterministic reports:
+TinyMongo turns pytest JUnit XML into deterministic JSON and Markdown
+compatibility reports. The reports show the API mode, backend, and suite for
+each contract cell and refuse to label an incomplete or unvalidated matrix as a
+publishable baseline.
 
-- `compatibility-report.json` is a versioned, machine-readable record with
-  per-test and per-target outcomes.
-- `compatibility-report.md` summarizes the score, per-target counts, known
-  gaps, failures, errors, and unexpected strict-xfail passes.
+- `compatibility-report.json` is a versioned, machine-readable record.
+- `compatibility-report.md` summarizes matrix integrity, scores, known gaps,
+  failures, and unexpected strict-xfail passes.
 
-The reports omit timestamps, durations, hostnames, and input paths. Common
-absolute paths captured in JUnit reason messages are replaced with
-`<ABSOLUTE_PATH>`, so otherwise-identical outcomes from different temporary
-directories produce byte-for-byte identical output.
+Timestamps, durations, hostnames, and input paths are omitted. Absolute paths in
+JUnit messages are replaced with `<ABSOLUTE_PATH>`, so identical results from
+different machines render byte-for-byte identically.
 
-## Generate reports locally
+## Generate the full report
 
-First write JUnit XML while running the complete embedded-plus-MongoDB contract
-matrix:
+Run the sync/async matrix against the five embedded backends and real MongoDB:
 
 ```bash
 TINYMONGO_MONGODB_URI=mongodb://127.0.0.1:27017/?directConnection=true \
@@ -25,8 +24,7 @@ pytest -o addopts='' -q -m contract tests/contracts \
   --junitxml=contract-results.xml
 ```
 
-Then generate both reports, even if pytest returned a nonzero status because a
-contract failed:
+Then generate both reports:
 
 ```bash
 python scripts/generate_compatibility_report.py contract-results.xml \
@@ -34,33 +32,63 @@ python scripts/generate_compatibility_report.py contract-results.xml \
   --markdown-output compatibility-report.md
 ```
 
-Without the output options, those same two report filenames are used in the
-current directory. Use `--targets` and `--reference-target` only for a custom
-contract matrix; the defaults match memory, JSON, SQLite, DuckDB, Parquet, and
-MongoDB. Target names may contain alphanumeric or underscore segments separated
-by single hyphens. The name `unattributed` is reserved for cases whose pytest
-parameter ID cannot be matched safely.
+The generator accepts multiple JUnit files. This is useful when an external
+application is run once against MongoDB and again against one or more TinyMongo
+backends:
 
-## JSON structure
+```bash
+python scripts/generate_compatibility_report.py \
+  app-async-mongodb.xml app-async-memory.xml app-async-sqlite.xml \
+  --apis async \
+  --backends memory,sqlite,mongodb
+```
 
-The top-level `schema_version` changes only when the machine-readable shape
-changes incompatibly. Version 1 contains:
+Without output options, the default filenames are
+`compatibility-report.json` and `compatibility-report.md`.
 
-- `scoring`: the formula, reference target, and aggregate numerator,
-  denominator, and percentage;
-- `totals`: counts for every outcome across the input JUnit file;
-- `targets`: ordered per-target roles, counts, scores, and individual test
-  outcomes;
-- `known_gaps`: expected failures with target, contract, test name, and reason;
-- `unexpected_passes`: strict expected failures whose behavior now passes.
+## JUnit dimensions
 
-Percentages are rounded to two decimal places. A JSON `null` percentage means
-that target had no evaluated cases.
+Contract tests attach these properties to every testcase:
 
-## Scoring
+```xml
+<property name="tinymongo.api" value="async" />
+<property name="tinymongo.backend" value="sqlite" />
+<property name="tinymongo.suite" value="talkpython" />
+```
 
-A **backend-contract cell** is one contract case executed for one TinyMongo
-backend. The overall score is:
+The generator prefers these explicit values. For older JUnit files it can infer
+API and backend values from pytest parameter IDs such as
+`test_name[async-sqlite]`, and it derives a conservative suite name from the
+test classname. Ambiguous values become `unattributed` and make the baseline
+incomplete.
+
+The defaults are:
+
+- APIs: `sync`, `async`
+- backends: `memory`, `json`, `sqlite`, `duckdb`, `parquet`, `mongodb`
+- reference backend: `mongodb`
+
+Use `--apis`, `--backends`, and `--reference-backend` only when the expected
+matrix is intentionally smaller or uses different labels. Names may contain
+alphanumeric or underscore segments separated by single hyphens. The name
+`unattributed` is reserved.
+
+## Publishability and scoring
+
+A baseline is publishable only when:
+
+- every discovered contract appears exactly once for every configured
+  API/backend target;
+- no expected cell is missing or skipped;
+- every case has an API, backend, and suite attribution; and
+- each same-API MongoDB reference contract passed.
+
+Incomplete inputs still produce diagnostic reports. Their baseline status and
+blockers make clear why the result must not be published as a compatibility
+claim.
+
+Only unique, evaluated non-MongoDB cells with a passing same-API MongoDB
+reference are scored:
 
 ```text
 (passed + xpassed) /
@@ -68,56 +96,43 @@ backend. The overall score is:
 ```
 
 - A pass is compatible.
-- An expected failure (`xfail`) is an executed, known incompatibility. It stays
-  in the denominator and does not count as compatible.
-- A strict expected failure that unexpectedly passes (`xpass`) demonstrates
-  compatible behavior, so it counts as compatible. Pytest still fails the test
-  run until the stale known-gap marker is removed.
-- A failure or error is evaluated but incompatible.
-- An ordinary skip is reported but excluded because the behavior was not
-  executed. A target with only skips has no score rather than a misleading
-  zero.
-- The configured reference target is excluded from TinyMongo's aggregate score
-  while its outcomes remain visible. MongoDB is the default reference.
-- Cases that cannot be attributed to one configured target appear under
-  `unattributed` and are excluded from the aggregate rather than silently
-  changing it.
+- An expected failure (`xfail`) is an evaluated, known incompatibility.
+- A strict expected failure that unexpectedly passes (`xpass`) is compatible,
+  but pytest still fails until the stale known-gap marker is removed.
+- A failure or error is evaluated and incompatible.
+- An ordinary skip makes the matrix incomplete.
+- MongoDB reference cells validate behavior but are not part of TinyMongo's
+  numerator or denominator.
+- Duplicate, unattributed, or reference-unqualified cells are excluded and
+  reported as blockers.
 
-The aggregate is weighted by backend-contract cells. This means a behavior gap
-on three backends contributes three incompatible cells. Per-target scores make
-that weighting visible.
+Scores are shown overall and by API, backend, and suite. Percentages are rounded
+to two decimal places; JSON `null` means there were no eligible evaluated cells.
 
-## JUnit interpretation
+## JSON schema
 
-Pytest writes expected failures as `<skipped type="pytest.xfail">` elements;
-the generator uses that type to distinguish them from ordinary skips. Strict
-unexpected passes are emitted as failures whose normalized message begins with
-the exact marker `[XPASS(strict)]`; only that marker or an exact xpass result
-type is classified as `xpassed`. The original pytest step remains failed.
+Schema version 2 contains:
 
-Target names are recovered from pytest's bracketed parameter ID, such as
-`test_name[sqlite]`, `test_name[value-sqlite]`, or
-`test_name[value-remote-sql]`. Matching uses full configured names at hyphen
-boundaries, so a target name may itself contain hyphens. A parameter ID
-containing no configured target, or matching more than one configured target,
-is reported as `unattributed`.
+- `baseline`: completeness, publishability, expected and observed targets,
+  missing/skipped/duplicate cells, attribution failures, and unqualified
+  references;
+- `scoring`: formula, reference backend, qualified score, and excluded cases;
+- `totals`: counts for every JUnit outcome;
+- `targets`: per API/backend counts, integrity, score, and test details;
+- `summaries`: API, backend, and suite rollups;
+- `known_gaps`: expected failures with dimensions and reasons; and
+- `unexpected_passes`: strict expected failures whose behavior now passes.
 
-Message normalization recognizes quoted or unquoted Unix paths beginning with
-`/`, Windows drive paths such as `C:\\...` or `C:/...`, and UNC paths beginning
-with `\\\\`. Quoted paths may contain spaces. An unquoted path ends at
-whitespace or common message punctuation; unusual unquoted paths containing
-those characters may therefore be only partly redacted. Relative paths and
-URLs are intentionally left intact because treating them as absolute paths
-would hide useful test details.
+The schema version changes only when the machine-readable shape changes
+incompatibly.
 
-## CI failure behavior
+## CI behavior
 
-The MongoDB contract step runs normally and retains its original success or
-failure status. Report generation and artifact upload use `if: always()`, so a
-JUnit file containing ordinary contract failures still produces JSON and
-Markdown diagnostics. Generating a report never converts a failed contract run
-into a successful job.
+The MongoDB contract step retains its original pass or failure status. Report
+generation and artifact upload use `if: always()`, so an ordinary contract
+failure still produces diagnostics. The Markdown report is also appended to the
+GitHub Actions job summary when generation succeeds.
 
 If pytest stops before creating JUnit XML, CI emits a warning and uploads any
-files that do exist; there is no input from which a compatibility report can be
-generated.
+files that do exist. Report generation never turns a failed contract run into a
+successful job.

--- a/docs/TALKPYTHON_ACCEPTANCE.md
+++ b/docs/TALKPYTHON_ACCEPTANCE.md
@@ -1,0 +1,110 @@
+# Talk Python acceptance run
+
+The goal of this work is to run the real Talk Python application and its tests
+against TinyMongo, not merely to approximate its query list. The repository now
+contains two layers that make that handoff practical:
+
+1. Talk-Python-derived contracts run through TinyMongo's synchronous and
+   asynchronous APIs against every supported embedded backend and real MongoDB.
+2. `scripts/run_pymongo_acceptance.py` starts an external pytest suite while
+   `pymongo.MongoClient` and `pymongo.AsyncMongoClient` are patched to use a
+   selected TinyMongo backend.
+
+The second layer still needs to be run in the Talk Python repository. Until that
+real application run happens, the roadmap's application-acceptance item remains
+open.
+
+## Prepare the application environment
+
+Use the Talk Python test environment so all of its application dependencies and
+configuration are available. Install the TinyMongo checkout and pytest into
+that environment:
+
+```bash
+python -m pip install -e "/path/to/tinymongo[all]" pytest
+```
+
+The runner activates the patch before pytest imports the application's test
+modules. Existing `from pymongo import AsyncMongoClient` imports and client
+construction therefore keep their normal call sites.
+
+## Establish the MongoDB reference
+
+First configure Talk Python exactly as it is normally configured for its test
+MongoDB, then run the selected application suite without patching:
+
+```bash
+python /path/to/tinymongo/scripts/run_pymongo_acceptance.py \
+  --api async \
+  --backend mongodb \
+  --suite talkpython-app \
+  --junitxml talkpython-async-mongodb.xml \
+  -- /path/to/talkpython/tests -q
+```
+
+`--backend mongodb` only adds report metadata; it deliberately leaves PyMongo
+untouched. The application's normal environment variable or configuration must
+point at the reference MongoDB.
+
+## Try the application with TinyMongo
+
+Run the identical tests through an isolated in-memory database:
+
+```bash
+python /path/to/tinymongo/scripts/run_pymongo_acceptance.py \
+  --api async \
+  --backend memory \
+  --suite talkpython-app \
+  --junitxml talkpython-async-memory.xml \
+  -- /path/to/talkpython/tests -q
+```
+
+Then repeat with SQLite to exercise a durable backend:
+
+```bash
+python /path/to/tinymongo/scripts/run_pymongo_acceptance.py \
+  --api async \
+  --backend sqlite \
+  --folder .talkpython-tinymongo \
+  --suite talkpython-app \
+  --junitxml talkpython-async-sqlite.xml \
+  -- /path/to/talkpython/tests -q
+```
+
+The patch affects process-global PyMongo client classes for the duration of the
+pytest session. Run these acceptance commands as separate processes rather than
+inside an already-running application server.
+
+## Generate the application report
+
+Combine the three JUnit files into one deterministic baseline:
+
+```bash
+python /path/to/tinymongo/scripts/generate_compatibility_report.py \
+  talkpython-async-mongodb.xml \
+  talkpython-async-memory.xml \
+  talkpython-async-sqlite.xml \
+  --apis async \
+  --backends memory,sqlite,mongodb \
+  --json-output talkpython-compatibility.json \
+  --markdown-output talkpython-compatibility.md
+```
+
+The report is publishable only when every expected target cell was executed,
+the matching MongoDB reference behavior passed, and no result is unattributed.
+A partial run is still rendered, but it is labeled incomplete.
+
+## Handling failures
+
+For each difference found in the real application:
+
+1. reduce the behavior to the smallest document, operation, and assertion;
+2. add it to `tests/contracts` for both sync and async APIs;
+3. compare the same case with real MongoDB;
+4. link the temporary expected difference to the relevant roadmap issue;
+5. fix TinyMongo or document the intentional difference; and
+6. rerun the same Talk Python test before updating the published baseline.
+
+The first application pass should prioritize whether Talk Python starts, creates
+its indexes, completes its service-layer tests, and shuts down cleanly. Broader
+backend coverage can follow after memory and SQLite have a trustworthy baseline.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ mongoengine>=0.29,<1
 duckdb
 black>=25,<26
 ruff
-mypy
+mypy>=1.19,<2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ pymongo>=4.9
 mongoengine>=0.29,<1
 duckdb
 black>=25,<26
-ruff
+ruff>=0.15,<0.16
 mypy>=1.19,<2

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance and reporting helpers."""

--- a/scripts/generate_compatibility_report.py
+++ b/scripts/generate_compatibility_report.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Generate deterministic compatibility reports from pytest JUnit XML."""
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+SCHEMA_VERSION = 1
+DEFAULT_TARGETS = ("memory", "json", "sqlite", "duckdb", "parquet", "mongodb")
+REFERENCE_TARGET = "mongodb"
+UNATTRIBUTED_TARGET = "unattributed"
+OUTCOMES = ("passed", "xpassed", "xfailed", "failed", "error", "skipped")
+COMPATIBLE_OUTCOMES = frozenset(("passed", "xpassed"))
+EVALUATED_OUTCOMES = frozenset(("passed", "xpassed", "xfailed", "failed", "error"))
+TARGET_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*$")
+STRICT_XPASS_TYPES = frozenset(("xpass", "pytest.xpass"))
+ABSOLUTE_PATH_TOKEN = "<ABSOLUTE_PATH>"
+QUOTED_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"""(?P<quote>["'])(?:[A-Za-z]:[\\/]|\\\\|/(?!/))[^"']*(?P=quote)"""
+)
+WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"""(?<![A-Za-z0-9_\\/])(?:[A-Za-z]:[\\/]|\\\\)[^\s"'<>()[\]{},;]+"""
+)
+UNIX_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"""(?<![A-Za-z0-9_:/\\])/(?!/)[^\s"'<>()[\]{},;]+"""
+)
+
+
+@dataclass(frozen=True)
+class ContractCase:
+    """One target-specific contract outcome read from JUnit."""
+
+    target: str
+    classname: str
+    name: str
+    contract: str
+    outcome: str
+    reason: Optional[str] = None
+
+    @property
+    def nodeid(self):
+        """Return a stable test identifier without filesystem-specific paths."""
+
+        if self.classname:
+            return "{0}::{1}".format(self.classname, self.name)
+        return self.name
+
+
+def _local_name(tag):
+    """Return an XML tag without an optional namespace."""
+
+    return tag.rsplit("}", 1)[-1]
+
+
+def _normalize_message(value):
+    if not value:
+        return None
+    message = " ".join(value.split())
+    message = QUOTED_ABSOLUTE_PATH_PATTERN.sub(
+        lambda match: "{0}{1}{0}".format(match.group("quote"), ABSOLUTE_PATH_TOKEN),
+        message,
+    )
+    message = WINDOWS_ABSOLUTE_PATH_PATTERN.sub(ABSOLUTE_PATH_TOKEN, message)
+    return UNIX_ABSOLUTE_PATH_PATTERN.sub(ABSOLUTE_PATH_TOKEN, message)
+
+
+def _result_child(testcase):
+    for child in testcase:
+        if _local_name(child.tag) in ("failure", "error", "skipped"):
+            return child
+    return None
+
+
+def _result_message(result):
+    if result is None:
+        return None
+    message = _normalize_message(result.get("message"))
+    if message:
+        return message
+    for line in (result.text or "").splitlines():
+        message = _normalize_message(line)
+        if message:
+            return message
+    return None
+
+
+def _classify(testcase):
+    result = _result_child(testcase)
+    if result is None:
+        return "passed", None
+
+    tag = _local_name(result.tag)
+    result_type = (result.get("type") or "").lower()
+    message = _result_message(result)
+
+    if tag == "skipped":
+        if "xfail" in result_type:
+            return "xfailed", message
+        return "skipped", message
+    if tag == "error":
+        return "error", message
+    if tag == "failure":
+        if result_type in STRICT_XPASS_TYPES or (
+            message and message.startswith("[XPASS(strict)]")
+        ):
+            return "xpassed", message
+        return "failed", message
+    raise AssertionError("unreachable JUnit result type")
+
+
+def _parameter_id(test_name):
+    match = re.search(r"\[([^][]*)\]$", test_name)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _target_from_name(test_name, targets):
+    parameter_id = _parameter_id(test_name)
+    if parameter_id is None:
+        return UNATTRIBUTED_TARGET
+
+    matches = [
+        target
+        for target in targets
+        if re.search(r"(?:^|-){0}(?:-|$)".format(re.escape(target)), parameter_id)
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    return UNATTRIBUTED_TARGET
+
+
+def validate_targets(targets):
+    """Return validated target names suitable for pytest parameter matching."""
+
+    targets = tuple(targets)
+    if not targets:
+        raise ValueError("at least one target is required")
+    if len(set(targets)) != len(targets):
+        raise ValueError("target names must be unique")
+    for target in targets:
+        if target == UNATTRIBUTED_TARGET:
+            raise ValueError("'unattributed' is reserved for unmatched test cases")
+        if not TARGET_NAME_PATTERN.fullmatch(target):
+            raise ValueError(
+                "target names must use alphanumeric or underscore segments "
+                "separated by single hyphens: {0!r}".format(target)
+            )
+    return targets
+
+
+def read_junit(path, targets=DEFAULT_TARGETS):
+    """Parse target-specific contract cases from a pytest JUnit XML file."""
+
+    targets = validate_targets(targets)
+    root = ET.parse(path).getroot()
+    cases = []
+    for testcase in root.iter():
+        if _local_name(testcase.tag) != "testcase":
+            continue
+        name = testcase.get("name") or "unnamed-testcase"
+        outcome, reason = _classify(testcase)
+        cases.append(
+            ContractCase(
+                target=_target_from_name(name, targets),
+                classname=testcase.get("classname") or "",
+                name=name,
+                contract=name.split("[", 1)[0],
+                outcome=outcome,
+                reason=reason,
+            )
+        )
+    return sorted(cases, key=lambda case: (case.target, case.nodeid, case.outcome))
+
+
+def _counts(cases):
+    observed = Counter(case.outcome for case in cases)
+    return {outcome: observed.get(outcome, 0) for outcome in OUTCOMES}
+
+
+def _score(cases):
+    compatible = sum(case.outcome in COMPATIBLE_OUTCOMES for case in cases)
+    evaluated = sum(case.outcome in EVALUATED_OUTCOMES for case in cases)
+    percentage = None
+    if evaluated:
+        percentage = round(compatible * 100.0 / evaluated, 2)
+    return {
+        "compatible": compatible,
+        "evaluated": evaluated,
+        "percentage": percentage,
+    }
+
+
+def _case_dict(case):
+    result = {
+        "contract": case.contract,
+        "name": case.nodeid,
+        "outcome": case.outcome,
+    }
+    if case.reason:
+        result["reason"] = case.reason
+    return result
+
+
+def build_report(cases, targets=DEFAULT_TARGETS, reference_target=REFERENCE_TARGET):
+    """Build the versioned, deterministic compatibility-report data model."""
+
+    targets = validate_targets(targets)
+    if reference_target not in targets:
+        raise ValueError("reference target must be one of the configured targets")
+    ordered_targets = list(targets)
+    if any(case.target == UNATTRIBUTED_TARGET for case in cases):
+        ordered_targets.append(UNATTRIBUTED_TARGET)
+
+    target_reports = []
+    for target in ordered_targets:
+        target_cases = sorted(
+            (case for case in cases if case.target == target),
+            key=lambda case: (case.nodeid, case.outcome),
+        )
+        role = "backend"
+        if target == reference_target:
+            role = "reference"
+        elif target == UNATTRIBUTED_TARGET:
+            role = "unattributed"
+        target_reports.append(
+            {
+                "name": target,
+                "role": role,
+                "counts": _counts(target_cases),
+                "score": _score(target_cases),
+                "tests": [_case_dict(case) for case in target_cases],
+            }
+        )
+
+    scored_cases = [
+        case
+        for case in cases
+        if case.target not in (reference_target, UNATTRIBUTED_TARGET)
+    ]
+    known_gaps = [
+        {
+            "contract": case.contract,
+            "name": case.nodeid,
+            "reason": case.reason or "Expected failure",
+            "target": case.target,
+        }
+        for case in cases
+        if case.outcome == "xfailed"
+    ]
+    unexpected_passes = [
+        {
+            "contract": case.contract,
+            "name": case.nodeid,
+            "reason": case.reason or "Strict expected failure passed",
+            "target": case.target,
+        }
+        for case in cases
+        if case.outcome == "xpassed"
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scoring": {
+            "description": (
+                "Passed and strict-xpass backend-contract cells divided by all "
+                "evaluated backend-contract cells; expected failures count as "
+                "known incompatibilities, ordinary skips are excluded, and the "
+                "{0} reference target is excluded."
+            ).format(reference_target),
+            "formula": (
+                "(passed + xpassed) / " "(passed + xpassed + xfailed + failed + error)"
+            ),
+            "reference_target": reference_target,
+            "overall": _score(scored_cases),
+        },
+        "totals": _counts(cases),
+        "targets": target_reports,
+        "known_gaps": sorted(known_gaps, key=lambda gap: (gap["target"], gap["name"])),
+        "unexpected_passes": sorted(
+            unexpected_passes,
+            key=lambda unexpected: (unexpected["target"], unexpected["name"]),
+        ),
+    }
+
+
+def render_json(report):
+    """Render canonical JSON suitable for diffs and downstream tools."""
+
+    return json.dumps(report, indent=2, sort_keys=True) + "\n"
+
+
+def _markdown_cell(value):
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _percentage(score):
+    value = score["percentage"]
+    if value is None:
+        return "not evaluated"
+    return "{0:.2f}%".format(value)
+
+
+def render_markdown(report):
+    """Render a concise human-readable report from the JSON data model."""
+
+    overall = report["scoring"]["overall"]
+    lines = [
+        "# TinyMongo compatibility report",
+        "",
+        "This deterministic report summarizes the target-specific pytest contract "
+        "results.",
+        "",
+        "## Compatibility score",
+        "",
+        "**{0}** ({1} compatible of {2} evaluated backend-contract cells)".format(
+            _percentage(overall), overall["compatible"], overall["evaluated"]
+        ),
+        "",
+        report["scoring"]["description"],
+        "",
+        "Formula: `{0}`".format(report["scoring"]["formula"]),
+        "",
+        "## Per-target outcomes",
+        "",
+        (
+            "| Target | Role | Score | Evaluated | Passed | XPASS | Known gaps "
+            "(xfail) | Failed | Errors | Skipped |"
+        ),
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for target in report["targets"]:
+        counts = target["counts"]
+        lines.append(
+            "| {name} | {role} | {score} | {evaluated} | {passed} | "
+            "{xpassed} | {xfailed} | {failed} | {error} | {skipped} |".format(
+                name=_markdown_cell(target["name"]),
+                role=target["role"],
+                score=_percentage(target["score"]),
+                evaluated=target["score"]["evaluated"],
+                **counts,
+            )
+        )
+
+    lines.extend(["", "## Known compatibility gaps", ""])
+    if report["known_gaps"]:
+        lines.extend(
+            [
+                "| Target | Contract | Reason |",
+                "| --- | --- | --- |",
+            ]
+        )
+        for gap in report["known_gaps"]:
+            lines.append(
+                "| {0} | `{1}` | {2} |".format(
+                    _markdown_cell(gap["target"]),
+                    _markdown_cell(gap["contract"]),
+                    _markdown_cell(gap["reason"]),
+                )
+            )
+    else:
+        lines.append("No expected compatibility gaps were reported.")
+
+    problems = []
+    for target in report["targets"]:
+        for case in target["tests"]:
+            if case["outcome"] in ("failed", "error"):
+                problems.append((target["name"], case))
+    lines.extend(["", "## Failures and errors", ""])
+    if problems:
+        lines.extend(
+            ["| Target | Test | Outcome | Reason |", "| --- | --- | --- | --- |"]
+        )
+        for target, case in problems:
+            lines.append(
+                "| {0} | `{1}` | {2} | {3} |".format(
+                    _markdown_cell(target),
+                    _markdown_cell(case["name"]),
+                    case["outcome"],
+                    _markdown_cell(case.get("reason", "No reason recorded")),
+                )
+            )
+    else:
+        lines.append("No failures or errors were reported.")
+
+    lines.extend(["", "## Unexpected strict-xfail passes", ""])
+    if report["unexpected_passes"]:
+        for unexpected in report["unexpected_passes"]:
+            lines.append(
+                "- `{0}` on **{1}**: {2}".format(
+                    _markdown_cell(unexpected["contract"]),
+                    _markdown_cell(unexpected["target"]),
+                    _markdown_cell(unexpected["reason"]),
+                )
+            )
+    else:
+        lines.append("No strict expected failures passed unexpectedly.")
+
+    return "\n".join(lines) + "\n"
+
+
+def _parse_targets(value):
+    targets = tuple(target.strip() for target in value.split(",") if target.strip())
+    try:
+        return validate_targets(targets)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def _argument_parser():
+    parser = argparse.ArgumentParser(
+        description="Generate JSON and Markdown compatibility reports from pytest JUnit"
+    )
+    parser.add_argument("junit", type=Path, help="pytest JUnit XML input")
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path("compatibility-report.json"),
+        help="JSON output path (default: compatibility-report.json)",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        default=Path("compatibility-report.md"),
+        help="Markdown output path (default: compatibility-report.md)",
+    )
+    parser.add_argument(
+        "--targets",
+        type=_parse_targets,
+        default=DEFAULT_TARGETS,
+        help="comma-separated pytest target IDs",
+    )
+    parser.add_argument(
+        "--reference-target",
+        default=REFERENCE_TARGET,
+        help="target excluded as the reference (default: mongodb)",
+    )
+    return parser
+
+
+def _write(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main(argv=None):
+    args = _argument_parser().parse_args(argv)
+    try:
+        cases = read_junit(args.junit, targets=args.targets)
+        report = build_report(
+            cases,
+            targets=args.targets,
+            reference_target=args.reference_target,
+        )
+        _write(args.json_output, render_json(report))
+        _write(args.markdown_output, render_markdown(report))
+    except (ET.ParseError, OSError, ValueError) as error:
+        print(
+            "Could not generate compatibility report: {0}".format(error),
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_compatibility_report.py
+++ b/scripts/generate_compatibility_report.py
@@ -6,20 +6,28 @@ import json
 import re
 import sys
 import xml.etree.ElementTree as ET
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass
+from itertools import product
 from pathlib import Path
 from typing import Optional
 
 
-SCHEMA_VERSION = 1
-DEFAULT_TARGETS = ("memory", "json", "sqlite", "duckdb", "parquet", "mongodb")
-REFERENCE_TARGET = "mongodb"
-UNATTRIBUTED_TARGET = "unattributed"
+SCHEMA_VERSION = 2
+DEFAULT_APIS = ("sync", "async")
+DEFAULT_BACKENDS = ("memory", "json", "sqlite", "duckdb", "parquet", "mongodb")
+DEFAULT_TARGETS = tuple(
+    "{0}-{1}".format(api, backend)
+    for api, backend in product(DEFAULT_APIS, DEFAULT_BACKENDS)
+)
+REFERENCE_BACKEND = "mongodb"
+REFERENCE_TARGET = REFERENCE_BACKEND
+UNATTRIBUTED = "unattributed"
+UNATTRIBUTED_TARGET = UNATTRIBUTED
 OUTCOMES = ("passed", "xpassed", "xfailed", "failed", "error", "skipped")
 COMPATIBLE_OUTCOMES = frozenset(("passed", "xpassed"))
 EVALUATED_OUTCOMES = frozenset(("passed", "xpassed", "xfailed", "failed", "error"))
-TARGET_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*$")
+NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*$")
 STRICT_XPASS_TYPES = frozenset(("xpass", "pytest.xpass"))
 ABSOLUTE_PATH_TOKEN = "<ABSOLUTE_PATH>"
 QUOTED_ABSOLUTE_PATH_PATTERN = re.compile(
@@ -35,14 +43,22 @@ UNIX_ABSOLUTE_PATH_PATTERN = re.compile(
 
 @dataclass(frozen=True)
 class ContractCase:
-    """One target-specific contract outcome read from JUnit."""
+    """One API/backend contract outcome read from JUnit."""
 
-    target: str
+    api: str
+    backend: str
+    suite: str
     classname: str
     name: str
     contract: str
     outcome: str
     reason: Optional[str] = None
+
+    @property
+    def target(self):
+        """Return the backend name retained for callers of schema version 1."""
+
+        return self.backend
 
     @property
     def nodeid(self):
@@ -51,6 +67,14 @@ class ContractCase:
         if self.classname:
             return "{0}::{1}".format(self.classname, self.name)
         return self.name
+
+    @property
+    def contract_id(self):
+        """Return the contract identity shared by all API/backend executions."""
+
+        if self.classname:
+            return "{0}::{1}".format(self.classname, self.contract)
+        return self.contract
 
 
 def _local_name(tag):
@@ -122,62 +146,206 @@ def _parameter_id(test_name):
     return None
 
 
-def _target_from_name(test_name, targets):
+def _value_from_name(test_name, values):
     parameter_id = _parameter_id(test_name)
     if parameter_id is None:
-        return UNATTRIBUTED_TARGET
+        return UNATTRIBUTED
 
     matches = [
-        target
-        for target in targets
-        if re.search(r"(?:^|-){0}(?:-|$)".format(re.escape(target)), parameter_id)
+        value
+        for value in values
+        if re.search(r"(?:^|-){0}(?:-|$)".format(re.escape(value)), parameter_id)
     ]
     if len(matches) == 1:
         return matches[0]
-    return UNATTRIBUTED_TARGET
+    return UNATTRIBUTED
+
+
+def _properties(testcase):
+    properties = defaultdict(list)
+    for element in testcase.iter():
+        if _local_name(element.tag) != "property":
+            continue
+        name = element.get("name")
+        if not name:
+            continue
+        value = element.get("value")
+        if value is None:
+            value = element.text or ""
+        properties[name].append(value.strip())
+    return properties
+
+
+def _property_value(properties, name, allowed=None):
+    if name not in properties:
+        return None
+    values = set(properties[name])
+    if len(values) != 1:
+        return UNATTRIBUTED
+    value = values.pop()
+    if not value or not NAME_PATTERN.fullmatch(value):
+        return UNATTRIBUTED
+    if allowed is not None and value not in allowed:
+        return UNATTRIBUTED
+    return value
+
+
+def _suite_from_name(classname, test_name):
+    parameter_id = _parameter_id(test_name) or ""
+    match = re.search(
+        r"(?:^|-)suite[_=]([A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*)", parameter_id
+    )
+    if match:
+        return match.group(1)
+
+    normalized = classname.replace("\\", "/")
+    leaf = normalized.rsplit("/", 1)[-1].rsplit(".", 1)[-1]
+    match = re.search(r"(?:^|\.?)test_([A-Za-z0-9_]+)_contract$", leaf)
+    if match and match.group(1) == "talkpython":
+        return "talkpython"
+    if "contracts" in normalized:
+        return "core"
+    if match:
+        return match.group(1)
+    return UNATTRIBUTED
+
+
+def _remove_subsequence(parts, subsequence):
+    if not subsequence:
+        return parts
+    for index in range(len(parts) - len(subsequence) + 1):
+        if parts[index : index + len(subsequence)] == subsequence:
+            return parts[:index] + parts[index + len(subsequence) :]
+    return parts
+
+
+def _contract_from_name(name, api, backend):
+    base = name.split("[", 1)[0]
+    parameter_id = _parameter_id(name)
+    if not parameter_id or UNATTRIBUTED in (api, backend):
+        return base
+
+    parts = parameter_id.split("-")
+    for sequence in (
+        [api] + backend.split("-"),
+        backend.split("-") + [api],
+        [api],
+        backend.split("-"),
+    ):
+        updated = _remove_subsequence(parts, sequence)
+        if updated != parts:
+            parts = updated
+            if len(sequence) > 1:
+                break
+    if parts:
+        return "{0}[{1}]".format(base, "-".join(parts))
+    return base
+
+
+def _validate_names(values, label):
+    values = tuple(values)
+    if not values:
+        raise ValueError("at least one {0} is required".format(label))
+    if len(set(values)) != len(values):
+        raise ValueError("{0} names must be unique".format(label))
+    for value in values:
+        if value == UNATTRIBUTED:
+            raise ValueError(
+                "'unattributed' is reserved for unmatched {0} values".format(label)
+            )
+        if not NAME_PATTERN.fullmatch(value):
+            raise ValueError(
+                "{0} names must use alphanumeric or underscore segments "
+                "separated by single hyphens: {1!r}".format(label, value)
+            )
+    return values
+
+
+def validate_apis(apis):
+    """Return validated API names suitable for pytest parameter matching."""
+
+    return _validate_names(apis, "API")
+
+
+def validate_backends(backends):
+    """Return validated backend names suitable for pytest parameter matching."""
+
+    return _validate_names(backends, "backend")
 
 
 def validate_targets(targets):
-    """Return validated target names suitable for pytest parameter matching."""
+    """Compatibility alias for validating schema-version-1 backend targets."""
 
-    targets = tuple(targets)
-    if not targets:
-        raise ValueError("at least one target is required")
-    if len(set(targets)) != len(targets):
-        raise ValueError("target names must be unique")
-    for target in targets:
-        if target == UNATTRIBUTED_TARGET:
-            raise ValueError("'unattributed' is reserved for unmatched test cases")
-        if not TARGET_NAME_PATTERN.fullmatch(target):
-            raise ValueError(
-                "target names must use alphanumeric or underscore segments "
-                "separated by single hyphens: {0!r}".format(target)
-            )
-    return targets
+    return validate_backends(targets)
 
 
-def read_junit(path, targets=DEFAULT_TARGETS):
-    """Parse target-specific contract cases from a pytest JUnit XML file."""
+def _input_paths(paths):
+    if isinstance(paths, (str, Path)):
+        return (Path(paths),)
+    paths = tuple(Path(path) for path in paths)
+    if not paths:
+        raise ValueError("at least one JUnit input is required")
+    return paths
 
-    targets = validate_targets(targets)
-    root = ET.parse(path).getroot()
+
+def read_junit(
+    paths,
+    apis=DEFAULT_APIS,
+    backends=DEFAULT_BACKENDS,
+    targets=None,
+):
+    """Parse contract cases from one or more pytest JUnit XML files."""
+
+    if targets is not None:
+        backends = targets
+    apis = validate_apis(apis)
+    backends = validate_backends(backends)
     cases = []
-    for testcase in root.iter():
-        if _local_name(testcase.tag) != "testcase":
-            continue
-        name = testcase.get("name") or "unnamed-testcase"
-        outcome, reason = _classify(testcase)
-        cases.append(
-            ContractCase(
-                target=_target_from_name(name, targets),
-                classname=testcase.get("classname") or "",
-                name=name,
-                contract=name.split("[", 1)[0],
-                outcome=outcome,
-                reason=reason,
+    for path in _input_paths(paths):
+        root = ET.parse(path).getroot()
+        for testcase in root.iter():
+            if _local_name(testcase.tag) != "testcase":
+                continue
+            name = testcase.get("name") or "unnamed-testcase"
+            classname = testcase.get("classname") or ""
+            properties = _properties(testcase)
+
+            api = _property_value(properties, "tinymongo.api", apis)
+            if api is None:
+                api = _value_from_name(name, apis)
+            backend = _property_value(properties, "tinymongo.backend", backends)
+            if backend is None:
+                backend = _value_from_name(name, backends)
+            suite = _property_value(properties, "tinymongo.suite")
+            if suite is None:
+                suite = _suite_from_name(classname, name)
+
+            outcome, reason = _classify(testcase)
+            cases.append(
+                ContractCase(
+                    api=api,
+                    backend=backend,
+                    suite=suite,
+                    classname=classname,
+                    name=name,
+                    contract=_contract_from_name(name, api, backend),
+                    outcome=outcome,
+                    reason=reason,
+                )
             )
-        )
-    return sorted(cases, key=lambda case: (case.target, case.nodeid, case.outcome))
+    return sorted(cases, key=_case_sort_key)
+
+
+def _case_sort_key(case):
+    return (
+        case.api,
+        case.backend,
+        case.suite,
+        case.contract_id,
+        case.nodeid,
+        case.outcome,
+        case.reason or "",
+    )
 
 
 def _counts(cases):
@@ -200,7 +368,11 @@ def _score(cases):
 
 def _case_dict(case):
     result = {
+        "api": case.api,
+        "backend": case.backend,
+        "suite": case.suite,
         "contract": case.contract,
+        "contract_id": case.contract_id,
         "name": case.nodeid,
         "outcome": case.outcome,
     }
@@ -209,84 +381,405 @@ def _case_dict(case):
     return result
 
 
-def build_report(cases, targets=DEFAULT_TARGETS, reference_target=REFERENCE_TARGET):
+def _cell_key(case):
+    return (case.api, case.backend, case.suite, case.classname, case.contract)
+
+
+def _reference_key(case):
+    return (case.api, case.suite, case.classname, case.contract)
+
+
+def _contract_key(case):
+    return (case.suite, case.classname, case.contract)
+
+
+def _cell_dict(key):
+    api, backend, suite, classname, contract = key
+    contract_id = contract
+    if classname:
+        contract_id = "{0}::{1}".format(classname, contract)
+    return {
+        "api": api,
+        "backend": backend,
+        "suite": suite,
+        "contract": contract,
+        "contract_id": contract_id,
+    }
+
+
+def _summary(
+    name,
+    cases,
+    scored_cases,
+    expected_keys,
+    observed_keys,
+    missing_keys,
+    skipped_keys,
+    duplicate_keys,
+):
+    return {
+        "name": name,
+        "counts": _counts(cases),
+        "score": _score(scored_cases),
+        "expected_cells": len(expected_keys),
+        "observed_cells": len(observed_keys),
+        "missing_cells": len(missing_keys),
+        "skipped_cells": len(skipped_keys),
+        "duplicate_cells": len(duplicate_keys),
+    }
+
+
+def _matches_dimension(key, dimension, value):
+    indexes = {"api": 0, "backend": 1, "suite": 2}
+    return key[indexes[dimension]] == value
+
+
+def _dimension_summaries(
+    dimension,
+    values,
+    cases,
+    scored_cases,
+    expected_keys,
+    observed_keys,
+    missing_keys,
+    skipped_keys,
+    duplicate_keys,
+):
+    summaries = []
+    for value in values:
+        summaries.append(
+            _summary(
+                value,
+                [case for case in cases if getattr(case, dimension) == value],
+                [case for case in scored_cases if getattr(case, dimension) == value],
+                [
+                    key
+                    for key in expected_keys
+                    if _matches_dimension(key, dimension, value)
+                ],
+                [
+                    key
+                    for key in observed_keys
+                    if _matches_dimension(key, dimension, value)
+                ],
+                [
+                    key
+                    for key in missing_keys
+                    if _matches_dimension(key, dimension, value)
+                ],
+                [
+                    key
+                    for key in skipped_keys
+                    if _matches_dimension(key, dimension, value)
+                ],
+                [
+                    key
+                    for key in duplicate_keys
+                    if _matches_dimension(key, dimension, value)
+                ],
+            )
+        )
+    return summaries
+
+
+def _blockers(
+    missing_targets,
+    missing_keys,
+    skipped_cases,
+    unattributed_cases,
+    duplicate_keys,
+    unqualified_references,
+    has_contracts,
+):
+    blockers = []
+    if not has_contracts:
+        blockers.append("no-contracts")
+    if missing_targets:
+        blockers.append("missing-targets")
+    if missing_keys:
+        blockers.append("missing-cells")
+    if skipped_cases:
+        blockers.append("skipped-cells")
+    if unattributed_cases:
+        blockers.append("unattributed-cases")
+    if duplicate_keys:
+        blockers.append("duplicate-cells")
+    if unqualified_references:
+        blockers.append("unqualified-mongodb-references")
+    return blockers
+
+
+def build_report(
+    cases,
+    apis=DEFAULT_APIS,
+    backends=DEFAULT_BACKENDS,
+    reference_backend=REFERENCE_BACKEND,
+    targets=None,
+    reference_target=None,
+):
     """Build the versioned, deterministic compatibility-report data model."""
 
-    targets = validate_targets(targets)
-    if reference_target not in targets:
-        raise ValueError("reference target must be one of the configured targets")
-    ordered_targets = list(targets)
-    if any(case.target == UNATTRIBUTED_TARGET for case in cases):
-        ordered_targets.append(UNATTRIBUTED_TARGET)
+    if targets is not None:
+        backends = targets
+    if reference_target is not None:
+        reference_backend = reference_target
+    apis = validate_apis(apis)
+    backends = validate_backends(backends)
+    if reference_backend not in backends:
+        raise ValueError("reference backend must be one of the configured backends")
+
+    cases = sorted(cases, key=_case_sort_key)
+    attributed_cases = [
+        case
+        for case in cases
+        if case.api in apis and case.backend in backends and case.suite != UNATTRIBUTED
+    ]
+    unattributed_cases = [case for case in cases if case not in attributed_cases]
+
+    cells = defaultdict(list)
+    for case in attributed_cases:
+        cells[_cell_key(case)].append(case)
+    observed_keys = set(cells)
+    duplicate_keys = {key for key, cell_cases in cells.items() if len(cell_cases) > 1}
+
+    contract_keys = sorted({_contract_key(case) for case in attributed_cases})
+    expected_keys = {
+        (api, backend, suite, classname, contract)
+        for api, backend in product(apis, backends)
+        for suite, classname, contract in contract_keys
+    }
+    missing_keys = expected_keys - observed_keys
+    skipped_cases = [case for case in attributed_cases if case.outcome == "skipped"]
+    skipped_keys = {_cell_key(case) for case in skipped_cases}
+
+    expected_targets = set(product(apis, backends))
+    observed_targets = {(case.api, case.backend) for case in attributed_cases}
+    missing_targets = sorted(expected_targets - observed_targets)
+
+    passed_references = set()
+    unqualified_references = []
+    for api in apis:
+        for suite, classname, contract in contract_keys:
+            key = (api, reference_backend, suite, classname, contract)
+            cell_cases = cells.get(key, ())
+            if len(cell_cases) == 1 and cell_cases[0].outcome == "passed":
+                passed_references.add((api, suite, classname, contract))
+                continue
+            reference = _cell_dict(key)
+            reference["outcomes"] = sorted(case.outcome for case in cell_cases)
+            unqualified_references.append(reference)
+
+    scored_cases = []
+    excluded_cases = []
+    for key in sorted(observed_keys):
+        cell_cases = cells[key]
+        case = cell_cases[0]
+        if case.backend == reference_backend or case.outcome not in EVALUATED_OUTCOMES:
+            continue
+        if key in duplicate_keys:
+            excluded = _case_dict(case)
+            excluded["reason"] = "duplicate-cell"
+            excluded_cases.append(excluded)
+        elif _reference_key(case) not in passed_references:
+            excluded = _case_dict(case)
+            excluded["reason"] = "mongodb-reference-not-passed"
+            excluded_cases.append(excluded)
+        else:
+            scored_cases.append(case)
+
+    complete = bool(contract_keys) and not any(
+        (
+            missing_targets,
+            missing_keys,
+            skipped_cases,
+            unattributed_cases,
+            duplicate_keys,
+        )
+    )
+    publishable = complete and not unqualified_references
+    blockers = _blockers(
+        missing_targets,
+        missing_keys,
+        skipped_cases,
+        unattributed_cases,
+        duplicate_keys,
+        unqualified_references,
+        bool(contract_keys),
+    )
 
     target_reports = []
-    for target in ordered_targets:
-        target_cases = sorted(
-            (case for case in cases if case.target == target),
-            key=lambda case: (case.nodeid, case.outcome),
+    for api, backend in product(apis, backends):
+        target_cases = [
+            case
+            for case in attributed_cases
+            if case.api == api and case.backend == backend
+        ]
+        target_scored = [
+            case for case in scored_cases if case.api == api and case.backend == backend
+        ]
+        target_expected = {
+            key for key in expected_keys if key[0] == api and key[1] == backend
+        }
+        target_observed = {
+            key for key in observed_keys if key[0] == api and key[1] == backend
+        }
+        target_report = _summary(
+            "{0}-{1}".format(api, backend),
+            target_cases,
+            target_scored,
+            target_expected,
+            target_observed,
+            target_expected - target_observed,
+            {key for key in skipped_keys if key in target_expected},
+            {key for key in duplicate_keys if key in target_expected},
         )
-        role = "backend"
-        if target == reference_target:
-            role = "reference"
-        elif target == UNATTRIBUTED_TARGET:
-            role = "unattributed"
-        target_reports.append(
+        target_report.update(
             {
-                "name": target,
-                "role": role,
-                "counts": _counts(target_cases),
-                "score": _score(target_cases),
+                "api": api,
+                "backend": backend,
+                "role": "reference" if backend == reference_backend else "backend",
                 "tests": [_case_dict(case) for case in target_cases],
             }
         )
+        target_reports.append(target_report)
 
-    scored_cases = [
-        case
-        for case in cases
-        if case.target not in (reference_target, UNATTRIBUTED_TARGET)
-    ]
-    known_gaps = [
-        {
-            "contract": case.contract,
-            "name": case.nodeid,
-            "reason": case.reason or "Expected failure",
-            "target": case.target,
-        }
-        for case in cases
-        if case.outcome == "xfailed"
-    ]
+    suites = sorted({case.suite for case in attributed_cases})
+    summaries = {
+        "apis": _dimension_summaries(
+            "api",
+            apis,
+            attributed_cases,
+            scored_cases,
+            expected_keys,
+            observed_keys,
+            missing_keys,
+            skipped_keys,
+            duplicate_keys,
+        ),
+        "backends": _dimension_summaries(
+            "backend",
+            backends,
+            attributed_cases,
+            scored_cases,
+            expected_keys,
+            observed_keys,
+            missing_keys,
+            skipped_keys,
+            duplicate_keys,
+        ),
+        "suites": _dimension_summaries(
+            "suite",
+            suites,
+            attributed_cases,
+            scored_cases,
+            expected_keys,
+            observed_keys,
+            missing_keys,
+            skipped_keys,
+            duplicate_keys,
+        ),
+    }
+
+    known_gaps = [_case_dict(case) for case in cases if case.outcome == "xfailed"]
     unexpected_passes = [
-        {
-            "contract": case.contract,
-            "name": case.nodeid,
-            "reason": case.reason or "Strict expected failure passed",
-            "target": case.target,
-        }
-        for case in cases
-        if case.outcome == "xpassed"
+        _case_dict(case) for case in cases if case.outcome == "xpassed"
     ]
 
     return {
         "schema_version": SCHEMA_VERSION,
+        "baseline": {
+            "status": (
+                "publishable"
+                if publishable
+                else "complete-unpublishable" if complete else "incomplete"
+            ),
+            "complete": complete,
+            "publishable": publishable,
+            "blockers": blockers,
+            "expected_targets": (
+                list(DEFAULT_TARGETS)
+                if apis == DEFAULT_APIS and backends == DEFAULT_BACKENDS
+                else [
+                    "{0}-{1}".format(api, backend)
+                    for api, backend in product(apis, backends)
+                ]
+            ),
+            "observed_targets": [
+                "{0}-{1}".format(api, backend)
+                for api, backend in sorted(observed_targets)
+            ],
+            "missing_targets": [
+                {"api": api, "backend": backend} for api, backend in missing_targets
+            ],
+            "expected_cells": len(expected_keys),
+            "observed_cells": len(observed_keys),
+            "missing_cells": [_cell_dict(key) for key in sorted(missing_keys)],
+            "skipped_cells": [
+                _case_dict(case) for case in sorted(skipped_cases, key=_case_sort_key)
+            ],
+            "unattributed_cases": [
+                _case_dict(case)
+                for case in sorted(unattributed_cases, key=_case_sort_key)
+            ],
+            "duplicate_cells": [
+                dict(
+                    _cell_dict(key),
+                    count=len(cells[key]),
+                    outcomes=sorted(case.outcome for case in cells[key]),
+                    tests=sorted(case.nodeid for case in cells[key]),
+                )
+                for key in sorted(duplicate_keys)
+            ],
+            "unqualified_references": sorted(
+                unqualified_references,
+                key=lambda reference: (
+                    reference["api"],
+                    reference["suite"],
+                    reference["contract_id"],
+                ),
+            ),
+        },
         "scoring": {
             "description": (
-                "Passed and strict-xpass backend-contract cells divided by all "
-                "evaluated backend-contract cells; expected failures count as "
-                "known incompatibilities, ordinary skips are excluded, and the "
-                "{0} reference target is excluded."
-            ).format(reference_target),
-            "formula": (
-                "(passed + xpassed) / " "(passed + xpassed + xfailed + failed + error)"
+                "Only unique, evaluated non-MongoDB cells whose matching same-API "
+                "MongoDB reference contract passed are scored. Expected failures "
+                "are evaluated incompatibilities; ordinary skips are excluded."
             ),
-            "reference_target": reference_target,
+            "formula": (
+                "(passed + xpassed) / (passed + xpassed + xfailed + failed + error)"
+            ),
+            "reference_backend": reference_backend,
             "overall": _score(scored_cases),
+            "excluded": sorted(
+                excluded_cases,
+                key=lambda case: (
+                    case["api"],
+                    case["backend"],
+                    case["suite"],
+                    case["contract_id"],
+                ),
+            ),
         },
         "totals": _counts(cases),
         "targets": target_reports,
-        "known_gaps": sorted(known_gaps, key=lambda gap: (gap["target"], gap["name"])),
+        "summaries": summaries,
+        "known_gaps": sorted(
+            known_gaps,
+            key=lambda gap: (
+                gap["api"],
+                gap["backend"],
+                gap["suite"],
+                gap["name"],
+            ),
+        ),
         "unexpected_passes": sorted(
             unexpected_passes,
-            key=lambda unexpected: (unexpected["target"], unexpected["name"]),
+            key=lambda unexpected: (
+                unexpected["api"],
+                unexpected["backend"],
+                unexpected["suite"],
+                unexpected["name"],
+            ),
         ),
     }
 
@@ -308,61 +801,109 @@ def _percentage(score):
     return "{0:.2f}%".format(value)
 
 
+def _summary_table(lines, heading, label, summaries):
+    lines.extend(
+        [
+            "",
+            "## {0}".format(heading),
+            "",
+            (
+                "| {0} | Score | Evaluated | Expected | Observed | Missing | "
+                "Skipped | Duplicates |"
+            ).format(label),
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for summary in summaries:
+        lines.append(
+            "| {name} | {score} | {evaluated} | {expected} | {observed} | "
+            "{missing} | {skipped} | {duplicates} |".format(
+                name=_markdown_cell(summary["name"]),
+                score=_percentage(summary["score"]),
+                evaluated=summary["score"]["evaluated"],
+                expected=summary["expected_cells"],
+                observed=summary["observed_cells"],
+                missing=summary["missing_cells"],
+                skipped=summary["skipped_cells"],
+                duplicates=summary["duplicate_cells"],
+            )
+        )
+
+
 def render_markdown(report):
     """Render a concise human-readable report from the JSON data model."""
 
+    baseline = report["baseline"]
     overall = report["scoring"]["overall"]
+    blockers = ", ".join(baseline["blockers"]) or "none"
     lines = [
         "# TinyMongo compatibility report",
         "",
-        "This deterministic report summarizes the target-specific pytest contract "
-        "results.",
+        "Baseline status: **{0}**".format(baseline["status"]),
+        "",
+        "- Complete matrix: **{0}**".format("yes" if baseline["complete"] else "no"),
+        "- Publishable baseline: **{0}**".format(
+            "yes" if baseline["publishable"] else "no"
+        ),
+        "- Blockers: {0}".format(_markdown_cell(blockers)),
         "",
         "## Compatibility score",
         "",
-        "**{0}** ({1} compatible of {2} evaluated backend-contract cells)".format(
+        "**{0}** ({1} compatible of {2} reference-qualified cells)".format(
             _percentage(overall), overall["compatible"], overall["evaluated"]
         ),
         "",
         report["scoring"]["description"],
         "",
         "Formula: `{0}`".format(report["scoring"]["formula"]),
-        "",
-        "## Per-target outcomes",
-        "",
-        (
-            "| Target | Role | Score | Evaluated | Passed | XPASS | Known gaps "
-            "(xfail) | Failed | Errors | Skipped |"
-        ),
-        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
-    for target in report["targets"]:
-        counts = target["counts"]
-        lines.append(
-            "| {name} | {role} | {score} | {evaluated} | {passed} | "
-            "{xpassed} | {xfailed} | {failed} | {error} | {skipped} |".format(
-                name=_markdown_cell(target["name"]),
-                role=target["role"],
-                score=_percentage(target["score"]),
-                evaluated=target["score"]["evaluated"],
-                **counts,
-            )
+
+    _summary_table(lines, "Per-API summary", "API", report["summaries"]["apis"])
+    _summary_table(
+        lines,
+        "Per-backend summary",
+        "Backend",
+        report["summaries"]["backends"],
+    )
+    _summary_table(
+        lines,
+        "Per-suite summary",
+        "Suite",
+        report["summaries"]["suites"],
+    )
+
+    lines.extend(["", "## Matrix integrity", ""])
+    lines.append(
+        "{0} of {1} expected cells were observed.".format(
+            baseline["observed_cells"], baseline["expected_cells"]
         )
+    )
+    flag_groups = (
+        ("Missing cells", baseline["missing_cells"]),
+        ("Skipped cells", baseline["skipped_cells"]),
+        ("Unattributed cases", baseline["unattributed_cases"]),
+        ("Duplicate cells", baseline["duplicate_cells"]),
+        ("Unqualified MongoDB references", baseline["unqualified_references"]),
+    )
+    for label, values in flag_groups:
+        lines.append("- {0}: **{1}**".format(label, len(values)))
 
     lines.extend(["", "## Known compatibility gaps", ""])
     if report["known_gaps"]:
         lines.extend(
             [
-                "| Target | Contract | Reason |",
-                "| --- | --- | --- |",
+                "| API | Backend | Suite | Contract | Reason |",
+                "| --- | --- | --- | --- | --- |",
             ]
         )
         for gap in report["known_gaps"]:
             lines.append(
-                "| {0} | `{1}` | {2} |".format(
-                    _markdown_cell(gap["target"]),
-                    _markdown_cell(gap["contract"]),
-                    _markdown_cell(gap["reason"]),
+                "| {api} | {backend} | {suite} | `{contract}` | {reason} |".format(
+                    api=_markdown_cell(gap["api"]),
+                    backend=_markdown_cell(gap["backend"]),
+                    suite=_markdown_cell(gap["suite"]),
+                    contract=_markdown_cell(gap["contract"]),
+                    reason=_markdown_cell(gap.get("reason", "Expected failure")),
                 )
             )
     else:
@@ -372,19 +913,38 @@ def render_markdown(report):
     for target in report["targets"]:
         for case in target["tests"]:
             if case["outcome"] in ("failed", "error"):
-                problems.append((target["name"], case))
+                problems.append(case)
+    problems.extend(
+        case
+        for case in baseline["unattributed_cases"]
+        if case["outcome"] in ("failed", "error")
+    )
     lines.extend(["", "## Failures and errors", ""])
     if problems:
         lines.extend(
-            ["| Target | Test | Outcome | Reason |", "| --- | --- | --- | --- |"]
+            [
+                "| API | Backend | Suite | Test | Outcome | Reason |",
+                "| --- | --- | --- | --- | --- | --- |",
+            ]
         )
-        for target, case in problems:
+        for case in sorted(
+            problems,
+            key=lambda item: (
+                item["api"],
+                item["backend"],
+                item["suite"],
+                item["name"],
+            ),
+        ):
             lines.append(
-                "| {0} | `{1}` | {2} | {3} |".format(
-                    _markdown_cell(target),
-                    _markdown_cell(case["name"]),
-                    case["outcome"],
-                    _markdown_cell(case.get("reason", "No reason recorded")),
+                "| {api} | {backend} | {suite} | `{name}` | {outcome} | "
+                "{reason} |".format(
+                    api=_markdown_cell(case["api"]),
+                    backend=_markdown_cell(case["backend"]),
+                    suite=_markdown_cell(case["suite"]),
+                    name=_markdown_cell(case["name"]),
+                    outcome=case["outcome"],
+                    reason=_markdown_cell(case.get("reason", "No reason recorded")),
                 )
             )
     else:
@@ -394,10 +954,14 @@ def render_markdown(report):
     if report["unexpected_passes"]:
         for unexpected in report["unexpected_passes"]:
             lines.append(
-                "- `{0}` on **{1}**: {2}".format(
+                "- `{0}` on **{1}-{2}** ({3}): {4}".format(
                     _markdown_cell(unexpected["contract"]),
-                    _markdown_cell(unexpected["target"]),
-                    _markdown_cell(unexpected["reason"]),
+                    _markdown_cell(unexpected["api"]),
+                    _markdown_cell(unexpected["backend"]),
+                    _markdown_cell(unexpected["suite"]),
+                    _markdown_cell(
+                        unexpected.get("reason", "Strict expected failure passed")
+                    ),
                 )
             )
     else:
@@ -406,19 +970,34 @@ def render_markdown(report):
     return "\n".join(lines) + "\n"
 
 
-def _parse_targets(value):
-    targets = tuple(target.strip() for target in value.split(",") if target.strip())
+def _parse_names(value, label):
+    names = tuple(name.strip() for name in value.split(",") if name.strip())
     try:
-        return validate_targets(targets)
+        return _validate_names(names, label)
     except ValueError as error:
         raise argparse.ArgumentTypeError(str(error)) from error
 
 
+def _parse_apis(value):
+    return _parse_names(value, "API")
+
+
+def _parse_backends(value):
+    return _parse_names(value, "backend")
+
+
 def _argument_parser():
     parser = argparse.ArgumentParser(
-        description="Generate JSON and Markdown compatibility reports from pytest JUnit"
+        description=(
+            "Generate JSON and Markdown compatibility reports from pytest JUnit"
+        )
     )
-    parser.add_argument("junit", type=Path, help="pytest JUnit XML input")
+    parser.add_argument(
+        "junit",
+        nargs="+",
+        type=Path,
+        help="one or more pytest JUnit XML inputs",
+    )
     parser.add_argument(
         "--json-output",
         type=Path,
@@ -432,15 +1011,25 @@ def _argument_parser():
         help="Markdown output path (default: compatibility-report.md)",
     )
     parser.add_argument(
-        "--targets",
-        type=_parse_targets,
-        default=DEFAULT_TARGETS,
-        help="comma-separated pytest target IDs",
+        "--apis",
+        type=_parse_apis,
+        default=DEFAULT_APIS,
+        help="comma-separated API IDs (default: sync,async)",
     )
     parser.add_argument(
+        "--backends",
+        "--targets",
+        dest="backends",
+        type=_parse_backends,
+        default=DEFAULT_BACKENDS,
+        help="comma-separated backend IDs",
+    )
+    parser.add_argument(
+        "--reference-backend",
         "--reference-target",
-        default=REFERENCE_TARGET,
-        help="target excluded as the reference (default: mongodb)",
+        dest="reference_backend",
+        default=REFERENCE_BACKEND,
+        help="reference backend used to qualify scoring (default: mongodb)",
     )
     return parser
 
@@ -453,11 +1042,16 @@ def _write(path, content):
 def main(argv=None):
     args = _argument_parser().parse_args(argv)
     try:
-        cases = read_junit(args.junit, targets=args.targets)
+        cases = read_junit(
+            args.junit,
+            apis=args.apis,
+            backends=args.backends,
+        )
         report = build_report(
             cases,
-            targets=args.targets,
-            reference_target=args.reference_target,
+            apis=args.apis,
+            backends=args.backends,
+            reference_backend=args.reference_backend,
         )
         _write(args.json_output, render_json(report))
         _write(args.markdown_output, render_markdown(report))

--- a/scripts/run_pymongo_acceptance.py
+++ b/scripts/run_pymongo_acceptance.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Run an application's pytest suite against PyMongo or patched TinyMongo."""
+
+import argparse
+import importlib
+from contextlib import nullcontext
+from pathlib import Path
+
+
+BACKENDS = ("memory", "json", "sqlite", "duckdb", "parquet", "mongodb")
+APIS = ("sync", "async")
+
+
+class AcceptanceMetadataPlugin:
+    """Attach report dimensions to every application test result."""
+
+    def __init__(self, api, backend, suite):
+        self.api = api
+        self.backend = backend
+        self.suite = suite
+
+    def pytest_collection_modifyitems(self, session, config, items):
+        properties = (
+            ("tinymongo.api", self.api),
+            ("tinymongo.backend", self.backend),
+            ("tinymongo.suite", self.suite),
+        )
+        for item in items:
+            existing = {name for name, _ in item.user_properties}
+            item.user_properties.extend(
+                (name, value) for name, value in properties if name not in existing
+            )
+
+
+def _argument_parser():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run application tests with PyMongo client construction routed to "
+            "TinyMongo, while recording compatibility-report metadata."
+        )
+    )
+    parser.add_argument("--api", choices=APIS, required=True)
+    parser.add_argument("--backend", choices=BACKENDS, required=True)
+    parser.add_argument(
+        "--folder",
+        type=Path,
+        help="TinyMongo data folder; defaults to isolated memory or ./tinydb",
+    )
+    parser.add_argument(
+        "--suite",
+        default="talkpython-app",
+        help="report suite label (default: talkpython-app)",
+    )
+    parser.add_argument(
+        "--junitxml",
+        type=Path,
+        help="JUnit output path (default: acceptance-API-BACKEND.xml)",
+    )
+    parser.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="pytest paths and options after --",
+    )
+    return parser
+
+
+def _pytest_arguments(args):
+    pytest_args = list(args.pytest_args)
+    if pytest_args[:1] == ["--"]:
+        pytest_args.pop(0)
+    if not pytest_args:
+        pytest_args.append(".")
+    if not any(value.startswith("--junitxml") for value in pytest_args):
+        output = args.junitxml or Path(
+            "acceptance-{0}-{1}.xml".format(args.api, args.backend)
+        )
+        pytest_args.append("--junitxml={0}".format(output))
+    return pytest_args
+
+
+def _patch_context(args):
+    if args.backend == "mongodb":
+        return nullcontext()
+
+    tinymongo = importlib.import_module("tinymongo")
+    folder = str(args.folder) if args.folder is not None else None
+    return tinymongo.patch(folder=folder, backend=args.backend)
+
+
+def main(argv=None):
+    args = _argument_parser().parse_args(argv)
+    try:
+        pytest = importlib.import_module("pytest")
+    except ImportError as error:
+        raise ImportError(
+            "The acceptance runner requires pytest. Install it with: "
+            "pip install pytest"
+        ) from error
+
+    plugin = AcceptanceMetadataPlugin(args.api, args.backend, args.suite)
+    with _patch_context(args):
+        return int(pytest.main(_pytest_arguments(args), plugins=[plugin]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -1,9 +1,10 @@
 # Compatibility contracts
 
 These tests describe the application-facing behavior TinyMongo intends to share
-with PyMongo and a real MongoDB server. Each contract runs against memory, JSON,
-SQLite, DuckDB, and Parquet during the normal unit suite. The same test item is
-marked `mongodb` for the real server target.
+with PyMongo and a real MongoDB server. Each contract runs through both the
+synchronous and asynchronous APIs against memory, JSON, SQLite, DuckDB, and
+Parquet during the normal unit suite. The same test item is marked `mongodb`
+for the real server reference.
 
 Run the embedded backend matrix:
 
@@ -18,9 +19,10 @@ TINYMONGO_MONGODB_URI=mongodb://localhost:27017 \
 pytest -o addopts='' -q -m mongodb tests/contracts
 ```
 
-Run the complete embedded-plus-MongoDB matrix in one session with `-m contract`
-and `-o addopts=''`. CI uses that form and publishes its JUnit result file plus
-deterministic JSON and Markdown compatibility reports as a workflow artifact.
+Run the complete sync/async, embedded-plus-MongoDB matrix in one session with
+`-m contract` and `-o addopts=''`. CI uses that form and publishes its JUnit
+result file plus deterministic JSON and Markdown compatibility reports as a
+workflow artifact and job summary.
 
 To generate those reports locally, add
 `--junitxml=contract-results.xml` to the pytest command and run:

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -19,8 +19,18 @@ pytest -o addopts='' -q -m mongodb tests/contracts
 ```
 
 Run the complete embedded-plus-MongoDB matrix in one session with `-m contract`
-and `-o addopts=''`. CI uses that form and publishes its JUnit result file as a
-workflow artifact.
+and `-o addopts=''`. CI uses that form and publishes its JUnit result file plus
+deterministic JSON and Markdown compatibility reports as a workflow artifact.
+
+To generate those reports locally, add
+`--junitxml=contract-results.xml` to the pytest command and run:
+
+```bash
+python scripts/generate_compatibility_report.py contract-results.xml
+```
+
+The scoring rules, complete command, report schema, and CI failure behavior are
+documented in [Compatibility reports](../../docs/COMPATIBILITY_REPORTS.md).
 
 CI also sets `TINYMONGO_REQUIRE_MONGODB=1`, which turns a missing or unreachable
 server into a failure instead of a skip.

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -1,27 +1,96 @@
 """Factories that run one contract against every supported target."""
 
+import asyncio
+import inspect
 import os
 import time
 from uuid import uuid4
 
 import pytest
 import tinymongo
+from tinymongo.asyncio import AsyncTinyMongoClient
 
 from .support import ContractTarget
 
 
+APIS = ("sync", "async")
+BACKENDS = ("memory", "json", "sqlite", "duckdb", "parquet", "mongodb")
 TARGETS = [
-    pytest.param("memory", id="memory"),
-    pytest.param("json", id="json"),
-    pytest.param("sqlite", id="sqlite"),
-    pytest.param("duckdb", id="duckdb"),
-    pytest.param("parquet", id="parquet"),
     pytest.param(
-        "mongodb",
-        id="mongodb",
-        marks=(pytest.mark.integration, pytest.mark.mongodb),
-    ),
+        (api, backend),
+        id="{0}-{1}".format(api, backend),
+        marks=(
+            (pytest.mark.integration, pytest.mark.mongodb)
+            if backend == "mongodb"
+            else ()
+        ),
+    )
+    for api in APIS
+    for backend in BACKENDS
 ]
+
+
+class _AsyncRunner:
+    """Run one async target on a stable event loop from synchronous contracts."""
+
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+
+    def run(self, awaitable):
+        return self.loop.run_until_complete(awaitable)
+
+    def close(self):
+        self.loop.close()
+
+
+class _AsyncCursorAdapter:
+    """Expose async cursor behavior to the transport-neutral contract body."""
+
+    def __init__(self, cursor, runner):
+        self._cursor = cursor
+        self._runner = runner
+
+    def sort(self, *args, **kwargs):
+        self._cursor.sort(*args, **kwargs)
+        return self
+
+    def skip(self, *args, **kwargs):
+        self._cursor.skip(*args, **kwargs)
+        return self
+
+    def limit(self, *args, **kwargs):
+        self._cursor.limit(*args, **kwargs)
+        return self
+
+    def to_list(self, length=None):
+        return self._runner.run(self._cursor.to_list(length=length))
+
+    def __iter__(self):
+        return iter(self.to_list())
+
+
+class _AsyncCollectionAdapter:
+    """Await collection calls while preserving immediate cursor construction."""
+
+    def __init__(self, collection, runner):
+        self._collection = collection
+        self._runner = runner
+
+    def find(self, *args, **kwargs):
+        return _AsyncCursorAdapter(self._collection.find(*args, **kwargs), self._runner)
+
+    def __getattr__(self, name):
+        attribute = getattr(self._collection, name)
+        if not callable(attribute):
+            return attribute
+
+        def call(*args, **kwargs):
+            result = attribute(*args, **kwargs)
+            if inspect.isawaitable(result):
+                return self._runner.run(result)
+            return result
+
+        return call
 
 
 def _mongo_client(uri):
@@ -44,12 +113,45 @@ def _mongo_client(uri):
     raise RuntimeError("MongoDB did not become ready: {0}".format(last_error))
 
 
+def _async_mongo_client(uri, runner):
+    try:
+        from pymongo import AsyncMongoClient
+    except ImportError:  # pragma: no cover - guarded by dev requirements
+        pytest.fail("Real MongoDB contracts require PyMongo; run `pip install pymongo`")
+
+    client = AsyncMongoClient(uri, serverSelectionTimeoutMS=1000)
+    deadline = time.monotonic() + 15
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            runner.run(client.admin.command("ping"))
+            return client
+        except Exception as error:  # noqa: BLE001 - retry server startup
+            last_error = error
+            time.sleep(0.25)
+    runner.run(client.close())
+    raise RuntimeError("MongoDB did not become ready: {0}".format(last_error))
+
+
+def _contract_suite(request):
+    if "test_talkpython_contract.py" in request.node.nodeid:
+        return "talkpython"
+    return "core"
+
+
 @pytest.fixture(params=TARGETS)
 def contract_target(request, tmp_path, monkeypatch):
     """Yield an isolated collection for a TinyMongo backend or real MongoDB."""
 
-    target_name = request.param
+    api, target_name = request.param
     database_name = "tinymongo_contract_{0}".format(uuid4().hex)
+    request.node.user_properties.extend(
+        [
+            ("tinymongo.api", api),
+            ("tinymongo.backend", target_name),
+            ("tinymongo.suite", _contract_suite(request)),
+        ]
+    )
 
     if target_name == "mongodb":
         uri = os.environ.get("TINYMONGO_MONGODB_URI")
@@ -59,24 +161,40 @@ def contract_target(request, tmp_path, monkeypatch):
             if required:
                 pytest.fail(message)
             pytest.skip(message)
+        runner = None
         try:
-            client = _mongo_client(uri)
+            if api == "async":
+                runner = _AsyncRunner()
+                client = _async_mongo_client(uri, runner)
+            else:
+                client = _mongo_client(uri)
         except RuntimeError as error:
+            if runner is not None:
+                runner.close()
             if required:
                 pytest.fail(str(error))
             pytest.skip(str(error))
         database = client[database_name]
+        collection = database["items"]
+        if runner is not None:
+            collection = _AsyncCollectionAdapter(collection, runner)
         target = ContractTarget(
             name=target_name,
+            api=api,
             client=client,
             database=database,
-            collection=database["items"],
+            collection=collection,
         )
         try:
             yield target
         finally:
-            client.drop_database(database_name)
-            client.close()
+            if runner is None:
+                client.drop_database(database_name)
+                client.close()
+            else:
+                runner.run(client.drop_database(database_name))
+                runner.run(client.close())
+                runner.close()
         return
 
     backend = "tinydb" if target_name == "json" else target_name
@@ -89,19 +207,32 @@ def contract_target(request, tmp_path, monkeypatch):
         working_directory = tmp_path / "memory-cwd"
         working_directory.mkdir()
         monkeypatch.chdir(working_directory)
-        client = tinymongo.TinyMongoClient(backend=backend)
+        arguments = ()
+        options = {"backend": backend}
     else:
-        client = tinymongo.TinyMongoClient(
-            str(tmp_path / target_name),
-            backend=backend,
-        )
+        arguments = (str(tmp_path / target_name),)
+        options = {"backend": backend}
+    runner = None
+    if api == "async":
+        runner = _AsyncRunner()
+        client = AsyncTinyMongoClient(*arguments, **options)
+    else:
+        client = tinymongo.TinyMongoClient(*arguments, **options)
     database = client[database_name]
+    collection = database["items"]
+    if runner is not None:
+        collection = _AsyncCollectionAdapter(collection, runner)
     try:
         yield ContractTarget(
             name=target_name,
+            api=api,
             client=client,
             database=database,
-            collection=database["items"],
+            collection=collection,
         )
     finally:
-        client.close()
+        if runner is None:
+            client.close()
+        else:
+            runner.run(client.close())
+            runner.close()

--- a/tests/contracts/support.py
+++ b/tests/contracts/support.py
@@ -27,6 +27,7 @@ class ContractTarget:
     """Objects and metadata exposed to each shared contract."""
 
     name: str
+    api: str
     client: Any
     database: Any
     collection: Any

--- a/tests/test_acceptance_runner.py
+++ b/tests/test_acceptance_runner.py
@@ -1,0 +1,138 @@
+"""Tests for the external PyMongo application acceptance runner."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import run_pymongo_acceptance
+
+
+class _Item:
+    def __init__(self, properties=()):
+        self.user_properties = list(properties)
+
+
+def test_metadata_plugin_adds_dimensions_without_replacing_existing_values():
+    plugin = run_pymongo_acceptance.AcceptanceMetadataPlugin(
+        "async", "sqlite", "talkpython-app"
+    )
+    first = _Item()
+    second = _Item((("tinymongo.api", "custom"),))
+
+    plugin.pytest_collection_modifyitems(None, None, [first, second])
+
+    assert first.user_properties == [
+        ("tinymongo.api", "async"),
+        ("tinymongo.backend", "sqlite"),
+        ("tinymongo.suite", "talkpython-app"),
+    ]
+    assert second.user_properties == [
+        ("tinymongo.api", "custom"),
+        ("tinymongo.backend", "sqlite"),
+        ("tinymongo.suite", "talkpython-app"),
+    ]
+
+
+def test_main_patches_embedded_backend_and_adds_default_junit(monkeypatch, tmp_path):
+    events = []
+    calls = []
+
+    @contextmanager
+    def fake_patch(**kwargs):
+        events.append(("enter", kwargs))
+        yield
+        events.append(("exit", kwargs))
+
+    fake_pytest = SimpleNamespace(
+        main=lambda args, plugins: calls.append((args, plugins)) or 0
+    )
+
+    def fake_import(name):
+        if name == "pytest":
+            return fake_pytest
+        if name == "tinymongo":
+            return SimpleNamespace(patch=fake_patch)
+        raise AssertionError(name)
+
+    monkeypatch.setattr(run_pymongo_acceptance.importlib, "import_module", fake_import)
+
+    result = run_pymongo_acceptance.main(
+        [
+            "--api",
+            "async",
+            "--backend",
+            "sqlite",
+            "--folder",
+            str(tmp_path),
+            "--",
+            "app_tests",
+            "-q",
+        ]
+    )
+
+    assert result == 0
+    assert events == [
+        ("enter", {"folder": str(tmp_path), "backend": "sqlite"}),
+        ("exit", {"folder": str(tmp_path), "backend": "sqlite"}),
+    ]
+    assert calls[0][0] == [
+        "app_tests",
+        "-q",
+        "--junitxml=acceptance-async-sqlite.xml",
+    ]
+    plugin = calls[0][1][0]
+    assert (plugin.api, plugin.backend, plugin.suite) == (
+        "async",
+        "sqlite",
+        "talkpython-app",
+    )
+
+
+def test_main_leaves_real_mongodb_unpatched_and_keeps_explicit_junit(monkeypatch):
+    calls = []
+    fake_pytest = SimpleNamespace(
+        main=lambda args, plugins: calls.append((args, plugins)) or 5
+    )
+
+    def fake_import(name):
+        if name == "pytest":
+            return fake_pytest
+        raise AssertionError("MongoDB reference run must not import {0}".format(name))
+
+    monkeypatch.setattr(run_pymongo_acceptance.importlib, "import_module", fake_import)
+
+    result = run_pymongo_acceptance.main(
+        [
+            "--api",
+            "sync",
+            "--backend",
+            "mongodb",
+            "--suite",
+            "external-app",
+            "--junitxml",
+            "reference.xml",
+        ]
+    )
+
+    assert result == 5
+    assert calls[0][0] == [".", "--junitxml=reference.xml"]
+    plugin = calls[0][1][0]
+    assert (plugin.api, plugin.backend, plugin.suite) == (
+        "sync",
+        "mongodb",
+        "external-app",
+    )
+
+
+def test_main_reports_missing_pytest(monkeypatch):
+    def missing_pytest(name):
+        assert name == "pytest"
+        raise ImportError("missing")
+
+    monkeypatch.setattr(
+        run_pymongo_acceptance.importlib, "import_module", missing_pytest
+    )
+
+    with pytest.raises(ImportError, match="pip install pytest"):
+        run_pymongo_acceptance.main(["--api", "async", "--backend", "memory"])

--- a/tests/test_compatibility_report.py
+++ b/tests/test_compatibility_report.py
@@ -16,298 +16,476 @@ sys.modules[SPEC.name] = compatibility_report
 SPEC.loader.exec_module(compatibility_report)
 
 DEFAULT_TARGETS = compatibility_report.DEFAULT_TARGETS
-UNATTRIBUTED_TARGET = compatibility_report.UNATTRIBUTED_TARGET
+UNATTRIBUTED = compatibility_report.UNATTRIBUTED
 build_report = compatibility_report.build_report
 main = compatibility_report.main
 read_junit = compatibility_report.read_junit
 render_json = compatibility_report.render_json
 render_markdown = compatibility_report.render_markdown
-validate_targets = compatibility_report.validate_targets
+validate_apis = compatibility_report.validate_apis
+validate_backends = compatibility_report.validate_backends
 
 
-JUNIT_CASES = """
-<testsuites xmlns="urn:junit">
-  <testsuite name="contracts" tests="8" failures="3" errors="1" skipped="2">
-    <testcase classname="tests.contracts.test_api" name="test_pass[memory]" />
-    <testcase classname="tests.contracts.test_api" name="test_skip[json]">
-      <skipped type="pytest.skip" message="optional driver missing" />
-    </testcase>
-    <testcase classname="tests.contracts.test_api" name="test_gap[sqlite]">
-      <skipped type="pytest.xfail" message="#77: known | array gap" />
-    </testcase>
-    <testcase classname="tests.contracts.test_api" name="test_fail[duckdb]">
-      <failure type="AssertionError" message="documents differ" />
-    </testcase>
-    <testcase classname="tests.contracts.test_api" name="test_error[parquet]">
-      <error type="RuntimeError">setup failed\nwith details</error>
-    </testcase>
-    <testcase classname="tests.contracts.test_api" name="test_fixed[memory]">
-      <failure type="builtins.Failed" message="[XPASS(strict)] #73 fixed" />
-    </testcase>
-    <testcase classname="tests.contracts.test_api" name="test_reference[mongodb]" />
-    <testcase classname="tests.contracts.test_api" name="collection_error">
-      <failure message="not target-specific" />
-    </testcase>
-  </testsuite>
-</testsuites>
-""".strip()
+def _testcase(
+    name,
+    api=None,
+    backend=None,
+    suite=None,
+    classname="tests.contracts.test_api_contract",
+    result="",
+):
+    properties = []
+    for key, value in (
+        ("tinymongo.api", api),
+        ("tinymongo.backend", backend),
+        ("tinymongo.suite", suite),
+    ):
+        if value is not None:
+            properties.append('<property name="{0}" value="{1}" />'.format(key, value))
+    properties_xml = ""
+    if properties:
+        properties_xml = "<properties>{0}</properties>".format("".join(properties))
+    return '<testcase classname="{0}" name="{1}">{2}{3}</testcase>'.format(
+        classname, name, properties_xml, result
+    )
 
 
-def _write_junit(tmp_path, content=JUNIT_CASES, name="results.xml"):
+def _junit(*cases):
+    return "<testsuite>{0}</testsuite>".format("".join(cases))
+
+
+def _write_junit(tmp_path, content, name="results.xml"):
     path = tmp_path / name
     path.write_text(content, encoding="utf-8")
     return path
 
 
-def _target(report, name):
-    return next(target for target in report["targets"] if target["name"] == name)
+def _complete_matrix_xml(contract="test_contract", outcome_overrides=None):
+    outcome_overrides = outcome_overrides or {}
+    cases = []
+    for api in ("sync", "async"):
+        for backend in ("memory", "mongodb"):
+            cases.append(
+                _testcase(
+                    "{0}[{1}-{2}]".format(contract, api, backend),
+                    api=api,
+                    backend=backend,
+                    suite="talkpython",
+                    result=outcome_overrides.get((api, backend), ""),
+                )
+            )
+    return _junit(*cases)
 
 
-def test_read_junit_classifies_pytest_outcomes_and_targets(tmp_path):
-    cases = read_junit(_write_junit(tmp_path))
-    outcomes = {(case.target, case.contract): case.outcome for case in cases}
+def _summary(report, dimension, name):
+    return next(
+        summary for summary in report["summaries"][dimension] if summary["name"] == name
+    )
 
-    assert outcomes[("memory", "test_pass")] == "passed"
-    assert outcomes[("json", "test_skip")] == "skipped"
-    assert outcomes[("sqlite", "test_gap")] == "xfailed"
-    assert outcomes[("duckdb", "test_fail")] == "failed"
-    assert outcomes[("parquet", "test_error")] == "error"
-    assert outcomes[("memory", "test_fixed")] == "xpassed"
-    assert outcomes[("mongodb", "test_reference")] == "passed"
-    assert outcomes[(UNATTRIBUTED_TARGET, "collection_error")] == "failed"
+
+def test_default_targets_cover_sync_and_async_for_every_backend():
+    assert DEFAULT_TARGETS == (
+        "sync-memory",
+        "sync-json",
+        "sync-sqlite",
+        "sync-duckdb",
+        "sync-parquet",
+        "sync-mongodb",
+        "async-memory",
+        "async-json",
+        "async-sqlite",
+        "async-duckdb",
+        "async-parquet",
+        "async-mongodb",
+    )
+
+
+def test_junit_properties_are_preferred_over_parameter_name_fallback(tmp_path):
+    xml = _junit(
+        _testcase(
+            "test_case[async-json]",
+            api="sync",
+            backend="memory",
+            suite="talkpython",
+        )
+    )
+
+    case = read_junit(_write_junit(tmp_path, xml))[0]
+
+    assert (case.api, case.backend, case.suite) == (
+        "sync",
+        "memory",
+        "talkpython",
+    )
+    assert case.contract == "test_case[async-json]"
+
+
+def test_name_and_classname_fallback_attribute_legacy_junit(tmp_path):
+    xml = _junit(
+        _testcase(
+            "test_case[value-async-remote-sql]",
+            classname="tests.contracts.test_talkpython_contract",
+        )
+    )
+
+    case = read_junit(
+        _write_junit(tmp_path, xml),
+        backends=("memory", "remote-sql"),
+    )[0]
+
+    assert (case.api, case.backend, case.suite) == (
+        "async",
+        "remote-sql",
+        "talkpython",
+    )
+    assert case.contract == "test_case[value]"
+
+
+def test_conflicting_or_unknown_properties_are_unattributed(tmp_path):
+    xml = """
+    <testsuite>
+      <testcase classname="tests.contracts.test_api_contract"
+                name="test_case[sync-memory]">
+        <properties>
+          <property name="tinymongo.api" value="sync" />
+          <property name="tinymongo.api" value="async" />
+          <property name="tinymongo.backend" value="unknown" />
+          <property name="tinymongo.suite" value="bad suite" />
+        </properties>
+      </testcase>
+    </testsuite>
+    """
+
+    case = read_junit(_write_junit(tmp_path, xml))[0]
+    report = build_report([case])
+
+    assert (case.api, case.backend, case.suite) == (
+        UNATTRIBUTED,
+        UNATTRIBUTED,
+        UNATTRIBUTED,
+    )
+    assert report["baseline"]["unattributed_cases"][0]["name"].endswith(
+        "test_case[sync-memory]"
+    )
+
+
+def test_read_junit_classifies_all_pytest_outcomes(tmp_path):
+    xml = _junit(
+        _testcase("test_pass[sync-memory]", "sync", "memory", "core"),
+        _testcase(
+            "test_skip[sync-memory]",
+            "sync",
+            "memory",
+            "core",
+            result='<skipped type="pytest.skip" message="driver missing" />',
+        ),
+        _testcase(
+            "test_gap[sync-memory]",
+            "sync",
+            "memory",
+            "core",
+            result='<skipped type="pytest.xfail" message="#77: known gap" />',
+        ),
+        _testcase(
+            "test_fail[sync-memory]",
+            "sync",
+            "memory",
+            "core",
+            result='<failure type="AssertionError" message="different" />',
+        ),
+        _testcase(
+            "test_error[sync-memory]",
+            "sync",
+            "memory",
+            "core",
+            result='<error type="RuntimeError">setup failed\nmore</error>',
+        ),
+        _testcase(
+            "test_fixed[sync-memory]",
+            "sync",
+            "memory",
+            "core",
+            result=(
+                '<failure type="builtins.Failed" message="[XPASS(strict)] fixed" />'
+            ),
+        ),
+    )
+
+    cases = read_junit(_write_junit(tmp_path, xml))
+
+    assert {case.contract: case.outcome for case in cases} == {
+        "test_error": "error",
+        "test_fail": "failed",
+        "test_fixed": "xpassed",
+        "test_gap": "xfailed",
+        "test_pass": "passed",
+        "test_skip": "skipped",
+    }
     assert next(case for case in cases if case.contract == "test_error").reason == (
         "setup failed"
     )
 
 
-def test_target_detection_supports_additional_pytest_parameters(tmp_path):
-    xml = """
-    <testsuite>
-      <testcase classname="contracts" name="test_case[value-json-fast]" />
-      <testcase classname="contracts" name="test_ambiguous[json-mongodb]" />
-    </testsuite>
-    """
-
-    cases = read_junit(_write_junit(tmp_path, xml))
-
-    assert cases[0].target == "json"
-    assert cases[1].target == UNATTRIBUTED_TARGET
-
-
-def test_target_detection_supports_full_hyphenated_names(tmp_path):
-    xml = """
-    <testsuite>
-      <testcase classname="contracts" name="test_exact[remote-sql]" />
-      <testcase classname="contracts" name="test_nested[value-remote-sql-fast]" />
-      <testcase classname="contracts" name="test_boundary[notremote-sqlish]" />
-    </testsuite>
-    """
-
-    cases = read_junit(_write_junit(tmp_path, xml), targets=("remote-sql", "memory"))
-    outcomes = {case.contract: case.target for case in cases}
-
-    assert outcomes["test_exact"] == "remote-sql"
-    assert outcomes["test_nested"] == "remote-sql"
-    assert outcomes["test_boundary"] == UNATTRIBUTED_TARGET
-
-
-def test_target_detection_reports_overlapping_names_as_ambiguous(tmp_path):
-    xml = """
-    <testsuite>
-      <testcase classname="contracts" name="test_case[remote-sql]" />
-    </testsuite>
-    """
-
-    cases = read_junit(_write_junit(tmp_path, xml), targets=("sql", "remote-sql"))
-
-    assert cases[0].target == UNATTRIBUTED_TARGET
-
-
-@pytest.mark.parametrize(
-    "targets",
-    [
-        (),
-        ("json", "json"),
-        ("unattributed",),
-        ("bad target",),
-        ("-leading",),
-        ("trailing-",),
-        ("two--hyphens",),
-    ],
-)
-def test_invalid_or_reserved_target_names_are_rejected(targets):
-    with pytest.raises(ValueError):
-        validate_targets(targets)
-
-
-def test_xpass_text_in_normal_failures_does_not_change_the_outcome(tmp_path):
-    xml = """
-    <testsuite>
-      <testcase classname="contracts" name="test_message[memory]">
-        <failure message="AssertionError: xpass was unexpected" />
-      </testcase>
-      <testcase classname="contracts" name="test_type[memory]">
-        <failure type="CustomXpassAssertion" message="ordinary failure" />
-      </testcase>
-      <testcase classname="contracts" name="test_trace[memory]">
-        <failure message="AssertionError: ordinary failure">
-          traceback mentioned [XPASS(strict)] later
-        </failure>
-      </testcase>
-      <testcase classname="contracts" name="test_not_prefix[memory]">
-        <failure message="AssertionError: [XPASS(strict)] is data" />
-      </testcase>
-    </testsuite>
-    """
-
-    cases = read_junit(_write_junit(tmp_path, xml))
-
-    assert {case.outcome for case in cases} == {"failed"}
-
-
-def test_exact_xpass_result_type_is_supported(tmp_path):
-    xml = """
-    <testsuite>
-      <testcase classname="contracts" name="test_type[memory]">
-        <failure type="pytest.xpass" message="known gap fixed" />
-      </testcase>
-    </testsuite>
-    """
-
-    cases = read_junit(_write_junit(tmp_path, xml))
-
-    assert cases[0].outcome == "xpassed"
-
-
-def test_absolute_temp_paths_do_not_change_rendered_reports(tmp_path):
-    template = """
-    <testsuite>
-      <testcase classname="contracts" name="test_missing[memory]">
-        <failure message="FileNotFoundError: missing '{path}'" />
-      </testcase>
-    </testsuite>
-    """
-    first_cases = read_junit(
-        _write_junit(
-            tmp_path,
-            template.format(path="/private/tmp/run-one/missing.json"),
-            "first-path.xml",
-        )
-    )
-    second_cases = read_junit(
-        _write_junit(
-            tmp_path,
-            template.format(path="/var/folders/run-two/missing.json"),
-            "second-path.xml",
-        )
+def test_complete_reference_backed_matrix_is_publishable(tmp_path):
+    cases = read_junit(
+        _write_junit(tmp_path, _complete_matrix_xml()),
+        backends=("memory", "mongodb"),
     )
 
-    first = build_report(first_cases)
-    second = build_report(second_cases)
+    report = build_report(cases, backends=("memory", "mongodb"))
 
-    assert first_cases[0].reason == ("FileNotFoundError: missing '<ABSOLUTE_PATH>'")
-    assert render_json(first) == render_json(second)
-    assert render_markdown(first) == render_markdown(second)
-
-
-def test_windows_drive_and_unc_paths_are_redacted(tmp_path):
-    xml = r"""
-    <testsuite>
-      <testcase classname="contracts" name="test_windows[memory]">
-        <failure message="Missing 'C:\Users\Ada Lovelace\Temp\file.json' and \\server\share\file.json" />
-      </testcase>
-    </testsuite>
-    """
-
-    cases = read_junit(_write_junit(tmp_path, xml))
-
-    assert cases[0].reason == ("Missing '<ABSOLUTE_PATH>' and <ABSOLUTE_PATH>")
-
-
-def test_report_scores_only_evaluated_non_reference_backend_cells(tmp_path):
-    report = build_report(read_junit(_write_junit(tmp_path)))
-
-    assert report["schema_version"] == 1
+    assert report["schema_version"] == 2
+    assert report["baseline"]["status"] == "publishable"
+    assert report["baseline"]["complete"] is True
+    assert report["baseline"]["publishable"] is True
+    assert report["baseline"]["blockers"] == []
+    assert report["baseline"]["expected_cells"] == 4
+    assert report["baseline"]["observed_cells"] == 4
     assert report["scoring"]["overall"] == {
-        "compatible": 2,
-        "evaluated": 5,
-        "percentage": 40.0,
-    }
-    assert _target(report, "memory")["score"] == {
         "compatible": 2,
         "evaluated": 2,
         "percentage": 100.0,
     }
-    assert _target(report, "json")["score"] == {
-        "compatible": 0,
-        "evaluated": 0,
-        "percentage": None,
-    }
-    assert _target(report, "mongodb")["role"] == "reference"
-    assert _target(report, UNATTRIBUTED_TARGET)["role"] == "unattributed"
-    assert report["totals"] == {
-        "passed": 2,
-        "xpassed": 1,
-        "xfailed": 1,
-        "failed": 2,
-        "error": 1,
-        "skipped": 1,
-    }
 
 
-def test_report_exposes_known_gaps_and_strict_xpasses(tmp_path):
-    report = build_report(read_junit(_write_junit(tmp_path)))
-
-    assert report["known_gaps"] == [
-        {
-            "contract": "test_gap",
-            "name": "tests.contracts.test_api::test_gap[sqlite]",
-            "reason": "#77: known | array gap",
-            "target": "sqlite",
+def test_only_cells_with_same_api_passing_mongodb_reference_are_scored(tmp_path):
+    xml = _complete_matrix_xml(
+        outcome_overrides={
+            ("async", "mongodb"): (
+                '<failure type="AssertionError" message="reference failed" />'
+            )
         }
-    ]
-    assert report["unexpected_passes"] == [
-        {
-            "contract": "test_fixed",
-            "name": "tests.contracts.test_api::test_fixed[memory]",
-            "reason": "[XPASS(strict)] #73 fixed",
-            "target": "memory",
-        }
-    ]
-
-
-def test_json_and_markdown_render_deterministically(tmp_path):
-    first_cases = read_junit(_write_junit(tmp_path, name="first.xml"))
-    reordered = JUNIT_CASES.replace(
-        '<testcase classname="tests.contracts.test_api" name="test_pass[memory]" />',
-        "",
-    ).replace(
-        "</testsuite>",
-        '<testcase classname="tests.contracts.test_api" '
-        'name="test_pass[memory]" />\n</testsuite>',
     )
-    second_cases = read_junit(_write_junit(tmp_path, reordered, "second.xml"))
+    cases = read_junit(
+        _write_junit(tmp_path, xml),
+        backends=("memory", "mongodb"),
+    )
 
-    first = build_report(first_cases)
-    second = build_report(second_cases)
+    report = build_report(cases, backends=("memory", "mongodb"))
 
-    assert render_json(first) == render_json(second)
-    assert render_json(first).endswith("\n")
-    assert json.loads(render_json(first)) == first
-    markdown = render_markdown(first)
-    assert "**40.00%** (2 compatible of 5 evaluated" in markdown
-    assert "#77: known \\| array gap" in markdown
-    assert "| mongodb | reference | 100.00%" in markdown
+    assert report["baseline"]["complete"] is True
+    assert report["baseline"]["publishable"] is False
+    assert report["baseline"]["status"] == "complete-unpublishable"
+    assert report["scoring"]["overall"] == {
+        "compatible": 1,
+        "evaluated": 1,
+        "percentage": 100.0,
+    }
+    assert report["scoring"]["excluded"][0]["api"] == "async"
+    assert report["scoring"]["excluded"][0]["reason"] == "mongodb-reference-not-passed"
+    assert _summary(report, "apis", "async")["score"]["evaluated"] == 0
+    assert _summary(report, "backends", "mongodb")["score"]["evaluated"] == 0
+    assert _summary(report, "suites", "talkpython")["score"]["evaluated"] == 1
 
 
-def test_cli_writes_both_reports_even_when_junit_contains_failures(tmp_path):
-    junit = _write_junit(tmp_path)
+def test_matrix_flags_missing_skipped_unattributed_and_duplicates(tmp_path):
+    first = _junit(
+        _testcase(
+            "test_contract[sync-memory]",
+            "sync",
+            "memory",
+            "core",
+            result='<skipped type="pytest.skip" message="optional dependency" />',
+        ),
+        _testcase(
+            "test_contract[sync-mongodb]",
+            "sync",
+            "mongodb",
+            "core",
+        ),
+        _testcase("not_a_contract", classname="collection"),
+    )
+    second = _junit(
+        _testcase(
+            "test_contract[sync-mongodb]",
+            "sync",
+            "mongodb",
+            "core",
+        )
+    )
+    cases = read_junit(
+        (
+            _write_junit(tmp_path, first, "first.xml"),
+            _write_junit(tmp_path, second, "second.xml"),
+        ),
+        backends=("memory", "mongodb"),
+    )
+
+    report = build_report(cases, backends=("memory", "mongodb"))
+    baseline = report["baseline"]
+
+    assert baseline["complete"] is False
+    assert baseline["publishable"] is False
+    assert set(baseline["blockers"]) == {
+        "missing-targets",
+        "missing-cells",
+        "skipped-cells",
+        "unattributed-cases",
+        "duplicate-cells",
+        "unqualified-mongodb-references",
+    }
+    assert baseline["missing_targets"] == [
+        {"api": "async", "backend": "memory"},
+        {"api": "async", "backend": "mongodb"},
+    ]
+    assert len(baseline["missing_cells"]) == 2
+    assert len(baseline["skipped_cells"]) == 1
+    assert len(baseline["unattributed_cases"]) == 1
+    assert baseline["duplicate_cells"][0]["count"] == 2
+
+
+def test_reports_have_api_backend_and_suite_summaries(tmp_path):
+    cases = read_junit(
+        _write_junit(tmp_path, _complete_matrix_xml()),
+        backends=("memory", "mongodb"),
+    )
+    report = build_report(cases, backends=("memory", "mongodb"))
+
+    assert [item["name"] for item in report["summaries"]["apis"]] == [
+        "sync",
+        "async",
+    ]
+    assert [item["name"] for item in report["summaries"]["backends"]] == [
+        "memory",
+        "mongodb",
+    ]
+    assert [item["name"] for item in report["summaries"]["suites"]] == ["talkpython"]
+    assert _summary(report, "apis", "sync")["expected_cells"] == 2
+    assert _summary(report, "backends", "memory")["observed_cells"] == 2
+    assert _summary(report, "suites", "talkpython")["missing_cells"] == 0
+
+
+def test_known_gaps_and_xpasses_include_all_dimensions(tmp_path):
+    xml = _complete_matrix_xml(
+        outcome_overrides={
+            ("sync", "memory"): (
+                '<skipped type="pytest.xfail" message="#77: array | gap" />'
+            ),
+            ("async", "memory"): ('<failure type="pytest.xpass" message="fixed" />'),
+        }
+    )
+    cases = read_junit(
+        _write_junit(tmp_path, xml),
+        backends=("memory", "mongodb"),
+    )
+
+    report = build_report(cases, backends=("memory", "mongodb"))
+
+    assert report["known_gaps"][0]["api"] == "sync"
+    assert report["known_gaps"][0]["backend"] == "memory"
+    assert report["known_gaps"][0]["suite"] == "talkpython"
+    assert report["unexpected_passes"][0]["api"] == "async"
+    assert "#77: array \\| gap" in render_markdown(report)
+
+
+def test_absolute_paths_are_redacted_but_urls_are_preserved(tmp_path):
+    template = """
+    <testsuite>
+      <testcase classname="tests.contracts.test_api_contract"
+                name="test_missing[sync-memory]">
+        <properties>
+          <property name="tinymongo.api" value="sync" />
+          <property name="tinymongo.backend" value="memory" />
+          <property name="tinymongo.suite" value="core" />
+        </properties>
+        <failure message="Missing '{path}' at https://example.test/a/b" />
+      </testcase>
+    </testsuite>
+    """
+    first = read_junit(
+        _write_junit(
+            tmp_path,
+            template.format(path="/private/tmp/run-one/file.json"),
+            "first.xml",
+        )
+    )
+    second = read_junit(
+        _write_junit(
+            tmp_path,
+            template.format(path="/var/folders/run-two/file.json"),
+            "second.xml",
+        )
+    )
+
+    assert first[0].reason == ("Missing '<ABSOLUTE_PATH>' at https://example.test/a/b")
+    assert render_json(build_report(first)) == render_json(build_report(second))
+
+
+def test_windows_drive_and_unc_paths_are_redacted(tmp_path):
+    xml = _junit(
+        _testcase(
+            "test_windows[sync-memory]",
+            "sync",
+            "memory",
+            "core",
+            result=(
+                r'<failure message="Missing '
+                r"'C:\Users\Ada Lovelace\Temp\file.json' and "
+                r'\\server\share\file.json" />'
+            ),
+        )
+    )
+
+    case = read_junit(_write_junit(tmp_path, xml))[0]
+
+    assert case.reason == "Missing '<ABSOLUTE_PATH>' and <ABSOLUTE_PATH>"
+
+
+def test_json_and_markdown_are_deterministic_across_input_order(tmp_path):
+    sync = _junit(
+        _testcase("test_contract[sync-memory]", "sync", "memory", "core"),
+        _testcase("test_contract[sync-mongodb]", "sync", "mongodb", "core"),
+    )
+    async_xml = _junit(
+        _testcase("test_contract[async-memory]", "async", "memory", "core"),
+        _testcase("test_contract[async-mongodb]", "async", "mongodb", "core"),
+    )
+    first = _write_junit(tmp_path, sync, "sync.xml")
+    second = _write_junit(tmp_path, async_xml, "async.xml")
+
+    report_one = build_report(
+        read_junit((first, second), backends=("memory", "mongodb")),
+        backends=("memory", "mongodb"),
+    )
+    report_two = build_report(
+        read_junit((second, first), backends=("memory", "mongodb")),
+        backends=("memory", "mongodb"),
+    )
+
+    assert render_json(report_one) == render_json(report_two)
+    assert render_json(report_one).endswith("\n")
+    assert json.loads(render_json(report_one)) == report_one
+    assert render_markdown(report_one) == render_markdown(report_two)
+    assert "Baseline status: **publishable**" in render_markdown(report_one)
+
+
+def test_cli_accepts_multiple_inputs_and_emits_incomplete_reports(tmp_path):
+    first = _write_junit(
+        tmp_path,
+        _junit(_testcase("test_contract[sync-memory]", "sync", "memory", "core")),
+        "first.xml",
+    )
+    second = _write_junit(
+        tmp_path,
+        _junit(
+            _testcase(
+                "test_contract[sync-mongodb]",
+                "sync",
+                "mongodb",
+                "core",
+            )
+        ),
+        "second.xml",
+    )
     json_output = tmp_path / "reports" / "compatibility.json"
     markdown_output = tmp_path / "reports" / "compatibility.md"
 
     result = main(
         [
-            str(junit),
+            str(first),
+            str(second),
+            "--backends",
+            "memory,mongodb",
             "--json-output",
             str(json_output),
             "--markdown-output",
@@ -316,44 +494,50 @@ def test_cli_writes_both_reports_even_when_junit_contains_failures(tmp_path):
     )
 
     assert result == 0
-    assert json.loads(json_output.read_text(encoding="utf-8"))["totals"]["failed"] == 2
+    report = json.loads(json_output.read_text(encoding="utf-8"))
+    assert report["baseline"]["complete"] is False
+    assert report["baseline"]["status"] == "incomplete"
     assert markdown_output.read_text(encoding="utf-8").startswith(
         "# TinyMongo compatibility report\n"
     )
 
 
-def test_cli_reports_invalid_or_missing_xml(tmp_path, capsys):
+def test_cli_errors_only_for_malformed_config_or_input(tmp_path, capsys):
     invalid = _write_junit(tmp_path, "<testsuite>")
 
     assert main([str(invalid)]) == 2
     assert "Could not generate compatibility report" in capsys.readouterr().err
     assert main([str(tmp_path / "missing.xml")]) == 2
+    with pytest.raises(SystemExit):
+        main([str(invalid), "--apis", "bad api"])
 
 
-def test_custom_target_list_and_reference_are_supported(tmp_path):
-    xml = """
-    <testsuite>
-      <testcase classname="contracts" name="test_one[alpha]" />
-      <testcase classname="contracts" name="test_one[server]" />
-    </testsuite>
-    """
-    cases = read_junit(_write_junit(tmp_path, xml), targets=("alpha", "server"))
-    report = build_report(
-        cases,
-        targets=("alpha", "server"),
-        reference_target="server",
+@pytest.mark.parametrize(
+    "validator,values",
+    [
+        (validate_apis, ()),
+        (validate_backends, ("json", "json")),
+        (validate_apis, ("unattributed",)),
+        (validate_backends, ("bad target",)),
+        (validate_backends, ("-leading",)),
+        (validate_backends, ("trailing-",)),
+        (validate_backends, ("two--hyphens",)),
+    ],
+)
+def test_invalid_or_reserved_dimension_names_are_rejected(validator, values):
+    with pytest.raises(ValueError):
+        validator(values)
+
+
+def test_reference_backend_must_be_configured(tmp_path):
+    cases = read_junit(
+        _write_junit(tmp_path, _complete_matrix_xml()),
+        backends=("memory", "mongodb"),
     )
 
-    assert [target["name"] for target in report["targets"]] == ["alpha", "server"]
-    assert report["scoring"]["overall"]["percentage"] == 100.0
-    assert report["scoring"]["reference_target"] == "server"
-    assert "server reference target is excluded" in report["scoring"]["description"]
-    assert "MongoDB" not in report["scoring"]["description"]
-    assert DEFAULT_TARGETS[-1] == "mongodb"
-
-
-def test_reference_target_must_be_configured(tmp_path):
-    cases = read_junit(_write_junit(tmp_path), targets=DEFAULT_TARGETS)
-
-    with pytest.raises(ValueError, match="reference target"):
-        build_report(cases, targets=DEFAULT_TARGETS, reference_target="server")
+    with pytest.raises(ValueError, match="reference backend"):
+        build_report(
+            cases,
+            backends=("memory", "mongodb"),
+            reference_backend="server",
+        )

--- a/tests/test_compatibility_report.py
+++ b/tests/test_compatibility_report.py
@@ -1,0 +1,359 @@
+"""Tests for deterministic JUnit compatibility reporting."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "generate_compatibility_report.py"
+SPEC = importlib.util.spec_from_file_location("compatibility_report", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+compatibility_report = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = compatibility_report
+SPEC.loader.exec_module(compatibility_report)
+
+DEFAULT_TARGETS = compatibility_report.DEFAULT_TARGETS
+UNATTRIBUTED_TARGET = compatibility_report.UNATTRIBUTED_TARGET
+build_report = compatibility_report.build_report
+main = compatibility_report.main
+read_junit = compatibility_report.read_junit
+render_json = compatibility_report.render_json
+render_markdown = compatibility_report.render_markdown
+validate_targets = compatibility_report.validate_targets
+
+
+JUNIT_CASES = """
+<testsuites xmlns="urn:junit">
+  <testsuite name="contracts" tests="8" failures="3" errors="1" skipped="2">
+    <testcase classname="tests.contracts.test_api" name="test_pass[memory]" />
+    <testcase classname="tests.contracts.test_api" name="test_skip[json]">
+      <skipped type="pytest.skip" message="optional driver missing" />
+    </testcase>
+    <testcase classname="tests.contracts.test_api" name="test_gap[sqlite]">
+      <skipped type="pytest.xfail" message="#77: known | array gap" />
+    </testcase>
+    <testcase classname="tests.contracts.test_api" name="test_fail[duckdb]">
+      <failure type="AssertionError" message="documents differ" />
+    </testcase>
+    <testcase classname="tests.contracts.test_api" name="test_error[parquet]">
+      <error type="RuntimeError">setup failed\nwith details</error>
+    </testcase>
+    <testcase classname="tests.contracts.test_api" name="test_fixed[memory]">
+      <failure type="builtins.Failed" message="[XPASS(strict)] #73 fixed" />
+    </testcase>
+    <testcase classname="tests.contracts.test_api" name="test_reference[mongodb]" />
+    <testcase classname="tests.contracts.test_api" name="collection_error">
+      <failure message="not target-specific" />
+    </testcase>
+  </testsuite>
+</testsuites>
+""".strip()
+
+
+def _write_junit(tmp_path, content=JUNIT_CASES, name="results.xml"):
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _target(report, name):
+    return next(target for target in report["targets"] if target["name"] == name)
+
+
+def test_read_junit_classifies_pytest_outcomes_and_targets(tmp_path):
+    cases = read_junit(_write_junit(tmp_path))
+    outcomes = {(case.target, case.contract): case.outcome for case in cases}
+
+    assert outcomes[("memory", "test_pass")] == "passed"
+    assert outcomes[("json", "test_skip")] == "skipped"
+    assert outcomes[("sqlite", "test_gap")] == "xfailed"
+    assert outcomes[("duckdb", "test_fail")] == "failed"
+    assert outcomes[("parquet", "test_error")] == "error"
+    assert outcomes[("memory", "test_fixed")] == "xpassed"
+    assert outcomes[("mongodb", "test_reference")] == "passed"
+    assert outcomes[(UNATTRIBUTED_TARGET, "collection_error")] == "failed"
+    assert next(case for case in cases if case.contract == "test_error").reason == (
+        "setup failed"
+    )
+
+
+def test_target_detection_supports_additional_pytest_parameters(tmp_path):
+    xml = """
+    <testsuite>
+      <testcase classname="contracts" name="test_case[value-json-fast]" />
+      <testcase classname="contracts" name="test_ambiguous[json-mongodb]" />
+    </testsuite>
+    """
+
+    cases = read_junit(_write_junit(tmp_path, xml))
+
+    assert cases[0].target == "json"
+    assert cases[1].target == UNATTRIBUTED_TARGET
+
+
+def test_target_detection_supports_full_hyphenated_names(tmp_path):
+    xml = """
+    <testsuite>
+      <testcase classname="contracts" name="test_exact[remote-sql]" />
+      <testcase classname="contracts" name="test_nested[value-remote-sql-fast]" />
+      <testcase classname="contracts" name="test_boundary[notremote-sqlish]" />
+    </testsuite>
+    """
+
+    cases = read_junit(_write_junit(tmp_path, xml), targets=("remote-sql", "memory"))
+    outcomes = {case.contract: case.target for case in cases}
+
+    assert outcomes["test_exact"] == "remote-sql"
+    assert outcomes["test_nested"] == "remote-sql"
+    assert outcomes["test_boundary"] == UNATTRIBUTED_TARGET
+
+
+def test_target_detection_reports_overlapping_names_as_ambiguous(tmp_path):
+    xml = """
+    <testsuite>
+      <testcase classname="contracts" name="test_case[remote-sql]" />
+    </testsuite>
+    """
+
+    cases = read_junit(_write_junit(tmp_path, xml), targets=("sql", "remote-sql"))
+
+    assert cases[0].target == UNATTRIBUTED_TARGET
+
+
+@pytest.mark.parametrize(
+    "targets",
+    [
+        (),
+        ("json", "json"),
+        ("unattributed",),
+        ("bad target",),
+        ("-leading",),
+        ("trailing-",),
+        ("two--hyphens",),
+    ],
+)
+def test_invalid_or_reserved_target_names_are_rejected(targets):
+    with pytest.raises(ValueError):
+        validate_targets(targets)
+
+
+def test_xpass_text_in_normal_failures_does_not_change_the_outcome(tmp_path):
+    xml = """
+    <testsuite>
+      <testcase classname="contracts" name="test_message[memory]">
+        <failure message="AssertionError: xpass was unexpected" />
+      </testcase>
+      <testcase classname="contracts" name="test_type[memory]">
+        <failure type="CustomXpassAssertion" message="ordinary failure" />
+      </testcase>
+      <testcase classname="contracts" name="test_trace[memory]">
+        <failure message="AssertionError: ordinary failure">
+          traceback mentioned [XPASS(strict)] later
+        </failure>
+      </testcase>
+      <testcase classname="contracts" name="test_not_prefix[memory]">
+        <failure message="AssertionError: [XPASS(strict)] is data" />
+      </testcase>
+    </testsuite>
+    """
+
+    cases = read_junit(_write_junit(tmp_path, xml))
+
+    assert {case.outcome for case in cases} == {"failed"}
+
+
+def test_exact_xpass_result_type_is_supported(tmp_path):
+    xml = """
+    <testsuite>
+      <testcase classname="contracts" name="test_type[memory]">
+        <failure type="pytest.xpass" message="known gap fixed" />
+      </testcase>
+    </testsuite>
+    """
+
+    cases = read_junit(_write_junit(tmp_path, xml))
+
+    assert cases[0].outcome == "xpassed"
+
+
+def test_absolute_temp_paths_do_not_change_rendered_reports(tmp_path):
+    template = """
+    <testsuite>
+      <testcase classname="contracts" name="test_missing[memory]">
+        <failure message="FileNotFoundError: missing '{path}'" />
+      </testcase>
+    </testsuite>
+    """
+    first_cases = read_junit(
+        _write_junit(
+            tmp_path,
+            template.format(path="/private/tmp/run-one/missing.json"),
+            "first-path.xml",
+        )
+    )
+    second_cases = read_junit(
+        _write_junit(
+            tmp_path,
+            template.format(path="/var/folders/run-two/missing.json"),
+            "second-path.xml",
+        )
+    )
+
+    first = build_report(first_cases)
+    second = build_report(second_cases)
+
+    assert first_cases[0].reason == ("FileNotFoundError: missing '<ABSOLUTE_PATH>'")
+    assert render_json(first) == render_json(second)
+    assert render_markdown(first) == render_markdown(second)
+
+
+def test_windows_drive_and_unc_paths_are_redacted(tmp_path):
+    xml = r"""
+    <testsuite>
+      <testcase classname="contracts" name="test_windows[memory]">
+        <failure message="Missing 'C:\Users\Ada Lovelace\Temp\file.json' and \\server\share\file.json" />
+      </testcase>
+    </testsuite>
+    """
+
+    cases = read_junit(_write_junit(tmp_path, xml))
+
+    assert cases[0].reason == ("Missing '<ABSOLUTE_PATH>' and <ABSOLUTE_PATH>")
+
+
+def test_report_scores_only_evaluated_non_reference_backend_cells(tmp_path):
+    report = build_report(read_junit(_write_junit(tmp_path)))
+
+    assert report["schema_version"] == 1
+    assert report["scoring"]["overall"] == {
+        "compatible": 2,
+        "evaluated": 5,
+        "percentage": 40.0,
+    }
+    assert _target(report, "memory")["score"] == {
+        "compatible": 2,
+        "evaluated": 2,
+        "percentage": 100.0,
+    }
+    assert _target(report, "json")["score"] == {
+        "compatible": 0,
+        "evaluated": 0,
+        "percentage": None,
+    }
+    assert _target(report, "mongodb")["role"] == "reference"
+    assert _target(report, UNATTRIBUTED_TARGET)["role"] == "unattributed"
+    assert report["totals"] == {
+        "passed": 2,
+        "xpassed": 1,
+        "xfailed": 1,
+        "failed": 2,
+        "error": 1,
+        "skipped": 1,
+    }
+
+
+def test_report_exposes_known_gaps_and_strict_xpasses(tmp_path):
+    report = build_report(read_junit(_write_junit(tmp_path)))
+
+    assert report["known_gaps"] == [
+        {
+            "contract": "test_gap",
+            "name": "tests.contracts.test_api::test_gap[sqlite]",
+            "reason": "#77: known | array gap",
+            "target": "sqlite",
+        }
+    ]
+    assert report["unexpected_passes"] == [
+        {
+            "contract": "test_fixed",
+            "name": "tests.contracts.test_api::test_fixed[memory]",
+            "reason": "[XPASS(strict)] #73 fixed",
+            "target": "memory",
+        }
+    ]
+
+
+def test_json_and_markdown_render_deterministically(tmp_path):
+    first_cases = read_junit(_write_junit(tmp_path, name="first.xml"))
+    reordered = JUNIT_CASES.replace(
+        '<testcase classname="tests.contracts.test_api" name="test_pass[memory]" />',
+        "",
+    ).replace(
+        "</testsuite>",
+        '<testcase classname="tests.contracts.test_api" '
+        'name="test_pass[memory]" />\n</testsuite>',
+    )
+    second_cases = read_junit(_write_junit(tmp_path, reordered, "second.xml"))
+
+    first = build_report(first_cases)
+    second = build_report(second_cases)
+
+    assert render_json(first) == render_json(second)
+    assert render_json(first).endswith("\n")
+    assert json.loads(render_json(first)) == first
+    markdown = render_markdown(first)
+    assert "**40.00%** (2 compatible of 5 evaluated" in markdown
+    assert "#77: known \\| array gap" in markdown
+    assert "| mongodb | reference | 100.00%" in markdown
+
+
+def test_cli_writes_both_reports_even_when_junit_contains_failures(tmp_path):
+    junit = _write_junit(tmp_path)
+    json_output = tmp_path / "reports" / "compatibility.json"
+    markdown_output = tmp_path / "reports" / "compatibility.md"
+
+    result = main(
+        [
+            str(junit),
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    assert result == 0
+    assert json.loads(json_output.read_text(encoding="utf-8"))["totals"]["failed"] == 2
+    assert markdown_output.read_text(encoding="utf-8").startswith(
+        "# TinyMongo compatibility report\n"
+    )
+
+
+def test_cli_reports_invalid_or_missing_xml(tmp_path, capsys):
+    invalid = _write_junit(tmp_path, "<testsuite>")
+
+    assert main([str(invalid)]) == 2
+    assert "Could not generate compatibility report" in capsys.readouterr().err
+    assert main([str(tmp_path / "missing.xml")]) == 2
+
+
+def test_custom_target_list_and_reference_are_supported(tmp_path):
+    xml = """
+    <testsuite>
+      <testcase classname="contracts" name="test_one[alpha]" />
+      <testcase classname="contracts" name="test_one[server]" />
+    </testsuite>
+    """
+    cases = read_junit(_write_junit(tmp_path, xml), targets=("alpha", "server"))
+    report = build_report(
+        cases,
+        targets=("alpha", "server"),
+        reference_target="server",
+    )
+
+    assert [target["name"] for target in report["targets"]] == ["alpha", "server"]
+    assert report["scoring"]["overall"]["percentage"] == 100.0
+    assert report["scoring"]["reference_target"] == "server"
+    assert "server reference target is excluded" in report["scoring"]["description"]
+    assert "MongoDB" not in report["scoring"]["description"]
+    assert DEFAULT_TARGETS[-1] == "mongodb"
+
+
+def test_reference_target_must_be_configured(tmp_path):
+    cases = read_junit(_write_junit(tmp_path), targets=DEFAULT_TARGETS)
+
+    with pytest.raises(ValueError, match="reference target"):
+        build_report(cases, targets=DEFAULT_TARGETS, reference_target="server")

--- a/tinymongo/patching.py
+++ b/tinymongo/patching.py
@@ -14,7 +14,7 @@ from .tinymongo import MongoClient
 
 _patch_state_lock = threading.RLock()
 _patch_owner = None
-_patch_entries = []
+_patch_entries: list[tuple] = []
 
 
 def _patch_context_owner():


### PR DESCRIPTION
## Summary

This turns the existing application-focused contract suite into a measured sync/async compatibility baseline and prepares the real Talk Python application handoff.

The same 28 behaviors now run through both API modes against memory, JSON, SQLite, DuckDB, Parquet, and real MongoDB. The Talk-Python-derived slice is included in that matrix instead of being covered only by synchronous contracts.

## What changed

- run every shared contract through TinyMongo's sync and async APIs
- use PyMongo's real `MongoClient` and `AsyncMongoClient` as same-API reference targets
- attach explicit API, backend, and suite metadata to JUnit cases
- generate deterministic schema-v2 JSON and Markdown reports from one or more JUnit files
- report overall, per-API, per-backend, and per-suite scores
- require a complete expected matrix before a baseline is publishable
- exclude cells whose matching MongoDB reference did not pass
- diagnose missing, skipped, unattributed, duplicate, and unqualified-reference cells
- append the Markdown report to the GitHub Actions job summary and retain all report artifacts
- add an external pytest runner that activates `tinymongo.patch()` before application tests are imported
- document the exact MongoDB, memory, and SQLite Talk Python acceptance commands
- update ROADMAP.md with completed infrastructure while keeping the real application run unchecked

## Why

PR #137 delivered the async facade, but the existing shared contracts and abandoned report prototype were still sync-only. That could produce an attractive score without proving async parity or even proving that every expected target ran.

The new report only scores a TinyMongo behavior when its same-API MongoDB reference passed. A partial local run still produces diagnostics, but it is explicitly marked incomplete and unpublishable.

## Real application boundary

This PR does **not** claim that the Talk Python application itself has run successfully. The repository does not contain that application or its fixtures. It provides the tested runner and runbook needed for Mike to execute the real suite without rewriting PyMongo call sites; every resulting difference should become a shared contract before the roadmap item is completed.

## Validation

- 775 local tests passed
- 100% statement and branch coverage across `tinymongo/*`
- Ruff passed
- Black passed
- mypy passed across all 14 source files
- 280 embedded contract cells passed across sync/async × five TinyMongo backends
- 336 complete contract cells passed with MongoDB 8 and PyMongo's real sync/async clients
- generated baseline: complete and publishable
- generated score: 280/280 MongoDB-qualified non-reference cells (100%)
- incomplete embedded-only input correctly produced no score and reported missing MongoDB reference cells
- external runner smoke test passed and emitted API/backend/suite JUnit properties

## Dependency

This branch currently includes the two small lint-tooling commits from #138 so its checks are reproducible. Once #138 merges, those files disappear from this PR's effective diff against `master`.

Advances #72 and #136. Related application-driven gaps remain tracked in #75, #77, and #102.
