### PR TITLE
Complete Talk Python BSON and insert_many compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,35 @@ on:
     branches: [ main, master ]
 
 jobs:
+  core-only:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: pip
+
+      - name: Install only core dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest .
+
+      - name: Verify optional BSON dependencies are absent
+        run: >-
+          python -c "import importlib.util;
+          assert importlib.util.find_spec('pymongo') is None;
+          assert importlib.util.find_spec('bson') is None"
+
+      - name: Run dependency-free BSON and CLI tests
+        run: >-
+          pytest -o addopts='' -q
+          tests/test_bson_registry_hardening.py tests/test_cli.py
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -146,7 +175,7 @@ jobs:
       - name: Install remote SQL test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest ".[remote-sql]"
+          pip install pytest ".[remote-sql,bson]"
 
       - name: Run PostgreSQL and MariaDB integration tests
         run: pytest -o addopts='' -q -m integration tests/integration/test_remote_sql.py
@@ -173,3 +202,5 @@ jobs:
         run: >-
           pytest -o addopts='' -q
           tests/test_patching.py tests/test_bson_codec.py
+          tests/test_insert_many_semantics.py tests/test_talkpython_regressions.py
+          -k 'not duckdb and not parquet'

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,15 +6,40 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch origin master
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "::error::Release tags must point to a commit on origin/master"
+            exit 1
+          fi
+          successful_runs="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${GITHUB_SHA}&status=success&per_page=1" \
+              --jq '.total_count'
+          )"
+          if [ "$successful_runs" -lt 1 ]; then
+            echo "::error::The tagged commit does not have a successful CI workflow run"
+            exit 1
+          fi
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           check-latest: true
@@ -26,6 +51,56 @@ jobs:
 
       - name: Build package
         run: python -m build
+
+      - name: Verify release artifacts
+        env:
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          from datetime import date
+          import tomllib
+          from pathlib import Path
+
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          ref_type = os.environ["RELEASE_REF_TYPE"]
+          release_tag = os.environ["RELEASE_TAG"]
+          if ref_type != "tag":
+              raise SystemExit(
+                  "PyPI publishing must run from a release tag, including manual runs"
+              )
+          if release_tag != f"v{version}":
+              raise SystemExit(
+                  f"release tag {release_tag!r} does not match package version v{version}"
+              )
+
+          changelog = Path("CHANGELOG.md").read_text()
+          prefix = f"## [{version}] - "
+          headings = [line for line in changelog.splitlines() if line.startswith(prefix)]
+          if len(headings) != 1 or headings[0].endswith("Unreleased"):
+              raise SystemExit(
+                  f"CHANGELOG.md must have one dated release heading for {version}"
+              )
+          try:
+              date.fromisoformat(headings[0][len(prefix):].strip())
+          except ValueError as exc:
+              raise SystemExit(
+                  f"CHANGELOG.md release heading for {version} needs an ISO date"
+              ) from exc
+
+          readme = Path("README.md").read_text()
+          stale_release_phrases = (
+              f"forthcoming {version}",
+              f"Until {version} is published",
+              "after that release is published",
+          )
+          if any(phrase in readme for phrase in stale_release_phrases):
+              raise SystemExit(
+                  f"README.md still describes {version} as unpublished"
+              )
+          PY
+          python -m twine check --strict dist/*
 
       - name: Publish package to PyPI
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [1.2.1] - Unreleased
 
 ### Added
 - Process-local `memory` backend for isolated tests and temporary data, with
@@ -31,6 +31,9 @@
   pagination, cloning, closing, and `to_list()`.
 - Tagged `datetime` and optional `ObjectId` round trips across all storage
   backends, with `bson` and `pymongo` optional dependency groups.
+- Tagged `Binary`, `bytes`, and `bytearray` persistence across all storage
+  backends, preserving nonzero BSON subtypes and supporting binary queries.
+- A shared BSON scalar registry used by persistence and cursor sorting.
 
 ### Changed
 - The second positional argument to `find()` is now the PyMongo-compatible
@@ -45,10 +48,19 @@
 - PostgreSQL and MariaDB/MySQL unique indexes reject array-valued keys because
   their native scalar constraints cannot safely guarantee multikey uniqueness
   across processes.
+- `insert_many()` now honors ordered and unordered partial-failure behavior and
+  accepts document iterables while raising a PyMongo-shaped `BulkWriteError`
+  for duplicate writes.
+- SQL, DuckDB, and Parquet backends now use BSON-aware typed physical `_id`
+  keys for new rows while retaining read, replace, and delete compatibility
+  with legacy stringified keys.
+- Collection attributes and subscriptions now select dotted child collections,
+  with private attribute access guarded like PyMongo in both APIs.
 
 ### Fixed
-- `bypass_document_validation=True` no longer bypasses the built-in unique
-  `_id` constraint.
+- `bypass_document_validation` remains a compatibility no-op: TinyMongo has no
+  user-configurable validator layer, and the flag cannot bypass built-in `_id`
+  or declared unique-index constraints.
 - Durable index catalogs now use unambiguous collection/index identities, and
   local write locks cover the complete uniqueness preflight and write.
 - File-backed deletes and find-and-modify operations now hold their collection
@@ -67,6 +79,36 @@
   process-global client replacement.
 - TinyMongo exceptions inherit matching PyMongo exception classes when PyMongo
   is installed, while retaining dependency-free fallbacks.
+- Datetime, ObjectId, and BinData cursor sorts now follow MongoDB ordering;
+  numeric `NaN` values have deterministic MongoDB ordering, and unsupported
+  sort values emit a bounded diagnostic instead of failing silently.
+- Generic subtype-0 `Binary`, `bytes`, and `bytearray` now share MongoDB
+  equality semantics in direct queries, the `$in`, `$nin`, and `$all` query
+  operators, and `_id` duplicate detection, while nonzero binary subtypes
+  remain distinct.
+- Non-finite floats use strict JSON-safe persistence tags. Remote SQL retains
+  its normal, indexable JSON/JSONB `data` object and adds a nullable
+  `data_ordered` text copy to preserve embedded-document field order. Older
+  rows remain readable and gain the ordered copy when rewritten; automatic
+  schema upgrades leave existing native JSON indexes in place.
+- Explicit null `_id` values are preserved, and exact recursive `_id` identity
+  prevents scalar/container aliases and codec-normalized tuple/list duplicates.
+- Remote SQL duplicate races are reread and replanned so ordered and unordered
+  batches retain their documented partial-write behavior; database commit
+  failures now propagate instead of being reported as successful writes.
+- Top-level `$unset` now persists the exact TinyDB post-image instead of
+  allowing removed keys to merge back into the document.
+- CLI export/import now round-trips supported BSON values without reordering
+  embedded-document fields, and API and CLI collection listings, inspection,
+  and migration hide TinyDB's internal `_default` table. Replace imports and
+  migrations preflight the complete destination write and restore prior
+  documents if a destructive delete or final insertion fails.
+- CLI database discovery and migration summaries now honor object-storage URIs
+  and remote SQL DSNs supplied only through environment variables.
+- Clients reject unknown backend names during construction, report every
+  accepted alias, and consistently reject metadata/listing operations after
+  close. Remote SQL and object-storage clients no longer create an unused
+  local placeholder directory.
 
 ## [1.2.0] - 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ Python 3.9, 3.11, and 3.13.
 # Installation
 
 The latest stable release can be installed via `pip install tinymongo`.
+This checkout is the forthcoming 1.2.1 release line. Until 1.2.1 is published
+on PyPI, install the Git branch directly to use the APIs documented below:
 
-The library is currently under rapid development and a more recent version
-may be desired.
+```bash
+pip install "tinymongo @ git+https://github.com/schapman1974/tinymongo.git@master"
+```
 
-In this case, simply clone this repository, navigate
-to the root project directory, and `pip install -e .`
-
-or use `pip install -e git+https://github.com/schapman1974/tinymongo.git#egg=tinymongo`
+For development, clone this repository and run `pip install -e .` from its
+root. Use the `v1.2.0` tag when you need documentation that matches the current
+stable package exactly; use the `v1.2.1` tag after that release is published.
 
 The default JSON backend has a small dependency set. Optional database backends
 may install native binary wheels supplied by DuckDB, PyArrow, or SQL drivers.
@@ -34,7 +36,9 @@ may install native binary wheels supplied by DuckDB, PyArrow, or SQL drivers.
 - **Roadmap:** See the [TinyMongo roadmap](https://github.com/schapman1974/tinymongo/blob/master/ROADMAP.md) for planned compatibility, GridFS, Compass, wire-server, and browser work.
 - **Default storage:** TinyMongo uses TinyDB-compatible JSON storage unless another backend is selected.
 - **Table-native backends:** SQLite, DuckDB, and Parquet backends store one real table/file per collection instead of one serialized database blob.
-- **Concurrency:** writes use atomic temp-file replace and optional advisory locks (`portalocker`) to reduce corruption risk under concurrent writers.
+- **Concurrency:** local JSON writes use atomic replace, `fsync`, and advisory
+  locks. Table-native and remote backends use their own transactional or
+  file-replacement mechanisms; see the backend-specific documentation.
 - **Async API:** async clients keep storage and lock waits off the event loop
   while sharing the synchronous implementation's behavior.
 - **Tests & CI:** a GitHub Actions workflow is included at `.github/workflows/ci.yml` to run unit tests and linters across Python versions. See `requirements-dev.txt` for dev dependencies.
@@ -182,16 +186,23 @@ You can select another backend with the `backend` argument:
 
 Parquet can also store collection files in object storage by passing
 `storage_uri` or setting `TINYMONGO_STORAGE_URI`. Object-storage Parquet is
-experimental in `1.2.0` and currently uses one Parquet file per collection, so
+experimental and currently uses one Parquet file per collection, so
 updates/deletes rewrite that file:
 
 ```python
     s3_connection = TinyMongoClient(
-        "/local/fallback-folder",
+        "/unused-local-path",
         backend="parquet",
         storage_uri="s3://my-bucket/tinymongo",
     )
 ```
+
+When `storage_uri` is set, it fully determines the Parquet data location. The
+API folder argument is optional and ignored; the CLI path argument remains a
+required placeholder. Neither creates a local cache or fallback directory.
+Remote SQL treats its path argument the same way. Environment-only
+`TINYMONGO_STORAGE_URI` and remote DSN settings also work for CLI database
+discovery and migration summaries.
 
 Available backends:
 
@@ -216,11 +227,11 @@ pip install "tinymongo[serialization]"
 ```
 
 If an optional driver is missing, selecting that backend raises an `ImportError`
-with the corresponding installation command. PyMongo itself is not a runtime
-dependency; it is used by the optional patch helper and development compatibility
-tests only when those features are selected. Install `tinymongo[bson]` for
-`ObjectId` values or `tinymongo[pymongo]` for patching and
-installed-version compatibility.
+with the corresponding installation command. PyMongo is not a core runtime
+dependency. It is selected at runtime for `ObjectId`, non-generic `Binary`
+subtypes, patching, and conditional PyMongo exception inheritance, and is also
+used by development compatibility tests. Install `tinymongo[bson]` for BSON
+values or `tinymongo[pymongo]` for patching and installed-version compatibility.
 
 | Backend | Dependency | Best fit | Notes |
 | --- | --- | --- | --- |
@@ -305,10 +316,19 @@ Use `--backend` with `inspect`, `list-dbs`, `list-collections`, `export`, and
 ```bash
 tinymongo inspect ./sqlite-db --backend sqlite
 tinymongo export ./parquet-db app users --backend parquet -o users.json
-tinymongo inspect ./local-cache --backend parquet --storage-uri s3://my-bucket/tinymongo
-tinymongo migrate ./tinydb ./local-cache --to-backend parquet --target-uri s3://my-bucket/tinymongo
+tinymongo inspect ./unused --backend parquet --storage-uri s3://my-bucket/tinymongo
+tinymongo migrate ./tinydb ./unused --to-backend parquet --target-uri s3://my-bucket/tinymongo
 tinymongo migrate ./tinydb ./unused --to-backend postgres --target-dsn "$TINYMONGO_POSTGRES_DSN"
 ```
+
+Export and import use the same tagged JSON codec as storage, so supported
+datetime, ObjectId, bytes, and Binary values round-trip. `bytearray` is accepted
+and imports back as `bytes`. Inspection, collection listing, and migration omit
+TinyDB's internal `_default` table. Export preserves embedded-document field
+order, including document-valued `_id` values. Replace-mode imports and
+migrations preflight the complete write with the destination's indexes before
+deleting existing documents, and restore those documents if deletion or the
+final insertion fails.
 
 
 # Integration and stress testing
@@ -418,14 +438,24 @@ supported for unique indexes yet. Remote SQL uses native constraints for scalar
 races. It rejects array values under unique indexes because its native indexes
 cannot yet guarantee cross-process multikey uniqueness.
 
-Use one consistent scalar type for `_id` values. Full BSON-aware `_id`
-comparison is tracked in [#94](https://github.com/schapman1974/tinymongo/issues/94);
-cross-type comparison and sort order remain outside the current BSON slice.
+SQL, DuckDB, and Parquet storage uses typed physical `_id` keys for new rows.
+Existing databases with older stringified keys remain readable and mutable.
+BSON-equivalent IDs share one key (`1` and `1.0`, or native bytes and Binary
+subtype 0), while BSON-distinct values such as `True` and `1` or identical
+binary data with different subtypes remain separate.
 
-## ObjectId and datetime values
+Cursor sorting follows MongoDB's comparison order for the currently supported
+scalar families, including BinData, `ObjectId`, booleans, and datetimes.
+Broader BSON comparison across ranges, indexes, and future aggregation remains
+tracked in
+[#94](https://github.com/schapman1974/tinymongo/issues/94).
 
-`datetime` values round-trip through every backend. Install the optional BSON
-extra to use `bson.ObjectId` without making PyMongo a core dependency:
+## ObjectId, datetime, and binary values
+
+`datetime` and `bytes` values round-trip through every backend. `bytearray` is
+accepted and reads back as `bytes`. Install the optional BSON extra to use
+`bson.ObjectId` or non-generic `bson.Binary` subtypes without making PyMongo a
+core dependency:
 
 ```bash
 pip install "tinymongo[bson]"
@@ -433,19 +463,57 @@ pip install "tinymongo[bson]"
 
 ```python
 from datetime import datetime
-from bson import ObjectId
+from bson import Binary, ObjectId
 
 episode_id = ObjectId()
 episodes.insert_one(
-    {"_id": episode_id, "created_date": datetime.now(), "title": "Async Python"}
+    {
+        "_id": episode_id,
+        "created_date": datetime.now(),
+        "image": b"\x89PNG\r\n\x1a\n",
+        "asset_id": Binary(bytes(range(16)), subtype=4),
+        "title": "Async Python",
+    }
 )
 episode = episodes.find_one({"_id": episode_id})
 ```
 
 JSON-backed storage uses an explicit tagged representation and restores native
 values on read. Existing plain JSON files and string or integer IDs remain
-compatible. UUID, Decimal128, Binary, and regular-expression round trips remain
+compatible. Binary payloads are base64-encoded, which increases their stored
+size by roughly one third. Generic subtype `0` reads back as `bytes`; other
+subtypes preserve `bson.Binary.subtype`. The exact two-key mapping shape using
+`__tinymongo_type_v1__` and `value` is reserved for TinyMongo's persistence
+codec; new user mappings with that shape are escaped automatically. If an
+older database already contains that valid tag shape as ordinary data, whether
+written through an earlier API or edited manually, rename one of those keys
+before upgrading so it is not interpreted as the tagged value. UUID,
+Decimal128, and regular-expression round trips remain
 tracked in [#75](https://github.com/schapman1974/tinymongo/issues/75).
+Non-finite floats (`NaN`, positive infinity, and negative infinity) also use
+strict JSON-safe tags. Remote SQL keeps the encoded document as a normal,
+indexable object in its existing JSON/JSONB `data` column and stores a second
+copy in the nullable text `data_ordered` column to preserve embedded-document
+field order. Older rows without that copy remain readable through `data`;
+rewriting one populates its ordered copy.
+
+Sorts normalize naive datetimes as UTC and convert aware datetimes to UTC.
+BinData sorts by length, subtype, and then unsigned bytes, matching MongoDB.
+Numeric `NaN` sorts below every other numeric value, matching MongoDB.
+TinyMongo retains Python microseconds, so it can distinguish two datetimes that
+MongoDB would store in the same millisecond.
+When a sort encounters a genuinely unsupported value type, TinyMongo emits one
+`TinyMongoUnsupportedWarning` per field and type instead of silently returning
+insertion order.
+
+`insert_many()` accepts any iterable of document dictionaries and honors
+PyMongo's `ordered` option, which defaults to `True`. An ordered batch keeps the
+successful prefix and stops at the first duplicate-key error; an unordered
+batch inserts every valid document and reports all duplicate failures in a
+PyMongo-shaped `BulkWriteError`. Values are encoded before storage changes, so
+a client-side serialization failure leaves the entire TinyMongo input
+unwritten. This is a stronger whole-list guarantee than PyMongo provides for
+very large inputs, which it may split across multiple wire batches.
 
 TinyMongo includes PyMongo-shaped contract tests that run application code with
 `import pymongo` redirected to TinyMongo:
@@ -473,19 +541,22 @@ embedded-plus-MongoDB matrix in one session.
 
 CI publishes the JUnit results together with deterministic JSON and Markdown
 reports containing per-backend outcomes and a documented compatibility score.
-See [Compatibility reports](docs/COMPATIBILITY_REPORTS.md) to generate them
-locally and understand how passes, expected gaps, skips, and the MongoDB
-reference affect the score.
+See
+[Compatibility reports](https://github.com/schapman1974/tinymongo/blob/master/docs/COMPATIBILITY_REPORTS.md)
+to generate them locally and understand how passes, expected gaps, skips, and
+the MongoDB reference affect the score.
 
 The shared Talk-Python-derived contracts run through both TinyMongo API modes.
 To exercise the actual application without rewriting its PyMongo call sites,
-follow the [Talk Python acceptance run](docs/TALKPYTHON_ACCEPTANCE.md).
+follow the
+[Talk Python acceptance run](https://github.com/schapman1974/tinymongo/blob/master/docs/TALKPYTHON_ACCEPTANCE.md).
 
 PyMongo remains optional. It is needed for these comparisons,
-`tinymongo.patch()`, and `ObjectId` support, but it is not required for normal
-TinyMongo clients or `datetime` storage. When it is installed, TinyMongo error
-classes also inherit the matching `pymongo.errors` classes, so existing
-`PyMongoError` handlers continue to work.
+`tinymongo.patch()`, `ObjectId` support, and non-generic `Binary` subtypes, but
+it is not required for normal TinyMongo clients, `datetime` storage, or native
+subtype-0 byte values. When it is installed, TinyMongo error classes also
+inherit the matching `pymongo.errors` classes, so existing `PyMongoError`
+handlers continue to work.
 
 PyMongo's full upstream driver test suite targets a real MongoDB server and
 driver internals, so it is not expected to pass against TinyMongo. The contract
@@ -512,6 +583,10 @@ Operations whose semantics TinyMongo cannot honor raise
 streams, aggregation pipelines, bulk writes, database commands, non-default
 read/write concerns, and unsupported index specifications. Connection options
 that only describe an ignored network target remain harmless for drop-in use.
+`bypass_document_validation` is accepted as a compatibility no-op and never
+disables `_id` or unique-index enforcement. Where a compatibility method
+accepts a `session` keyword, `session=None` is allowed; non-`None` sessions and
+`start_session()` remain unsupported.
 
 ## MongoEngine
 
@@ -626,10 +701,10 @@ First install it with `pip install "tinymongo[serialization]"`.
 
 ## Custom serialized types
 
-`datetime` and optional `ObjectId` values are handled directly by TinyMongo;
-they do not need a custom serializer. For application-specific classes, subclass
-`TinyMongoClient` and provide a `tinydb-serialization` middleware as described
-in the TinyDB extension documentation. The legacy
+`datetime`, binary values, and optional `ObjectId` values are handled directly
+by TinyMongo; they do not need a custom serializer. For application-specific
+classes, subclass `TinyMongoClient` and provide a `tinydb-serialization`
+middleware as described in the TinyDB extension documentation. The legacy
 `tinymongo.serializers.DateTimeSerializer` remains available for existing
 custom-storage integrations, but new TinyMongo storage does not require it.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,88 @@ Prerequisite backend work:
 - [x] [#74: Field projections](https://github.com/schapman1974/tinymongo/issues/74)
 - [x] [#76: Durable indexes and unique constraints](https://github.com/schapman1974/tinymongo/issues/76)
 
+### Mike Kennedy's Talk Python and agent-guide follow-up
+
+This checklist combines Mike Kennedy's
+[Talk Python acceptance blockers](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5112320332)
+with the follow-up audit of his
+[TinyMongo agent reference](https://github.com/mikeckennedy/python-package-guides-for-agents/blob/main/package-guides/tinymongo_reference.md):
+
+- [x] Redirect the real Talk Python data layer through TinyMongo's asynchronous
+  client on SQLite, initialize all 16 collections, and reduce the observed
+  failures to backend-independent reproductions.
+- [x] Complete the Talk Python slice of
+  [#94: MongoDB BSON comparison and sort order](https://github.com/schapman1974/tinymongo/issues/94)
+  for `datetime`, `ObjectId`, and BinData values in both directions, including
+  mixed naive/aware datetimes and compound sorts.
+- [x] Preserve binary payloads from `Binary`, `bytes`, and `bytearray` through
+  storage and queries, including the BSON subtype and nested or large values;
+  normalize `bytearray` to `bytes` on read as part of
+  [#75](https://github.com/schapman1974/tinymongo/issues/75).
+- [x] Apply BSON-aware equality to direct queries, the `$in`, `$nin`, and `$all`
+  query operators, and `_id` identity: native bytes equal generic Binary
+  subtype 0, nonzero subtypes remain distinct, booleans remain distinct from
+  numbers, and equivalent numeric representations share one key.
+- [x] Use typed physical `_id` keys on SQL, DuckDB, and Parquet backends without
+  breaking reads, replacements, or deletes for existing stringified keys.
+- [x] Preserve embedded-document field order and strict-JSON non-finite floats
+  in remote SQL rows while continuing to read legacy rows without an ordered
+  copy.
+- [x] Emit one useful diagnostic per unsupported sort type and field instead of
+  silently returning insertion order.
+- [x] Capture the batch rejection Mike observed when unsupported Binary made
+  one document unserializable, and verify the real PyMongo reference behavior.
+- [x] [#140: Match `insert_many()` ordered and partial-failure semantics](https://github.com/schapman1974/tinymongo/issues/140):
+  accept document iterables; ordered inserts preserve the successful prefix
+  and stop at the first error; unordered inserts continue valid documents and
+  report every duplicate-key write failure in a `BulkWriteError`. TinyMongo
+  deliberately preflights its complete local batch, so client-side encoding
+  failures remain all-or-nothing even though PyMongo may split very large
+  inputs across wire batches.
+- [x] Preserve exact TinyDB update post-images so top-level `$unset` really
+  removes a field while nested and missing-field cases retain their expected
+  behavior.
+- [x] Make CLI export/import BSON-aware, safely preflight complete
+  replace/migration writes, and keep TinyDB's internal `_default` table out of
+  API and CLI collection listings, inspection, and migration.
+- [x] Match PyMongo's dotted child-collection behavior and private-attribute
+  guard for synchronous and asynchronous handles.
+- [x] Apply the agent-guide audit to runtime configuration: honor
+  environment-only object-storage/remote SQL settings in CLI discovery and
+  migration reports, avoid unused nonlocal-storage directories, reject invalid
+  backends eagerly with the complete alias list, and guard client metadata and
+  listing methods after close.
+- [ ] After this work merges, update Mike's agent guide against the merge SHA
+  or the `v1.2.1` tag. Until 1.2.1 is published, label it as the forthcoming
+  1.2.1 release, use the Git install command, and do not describe the expanded
+  API as available from PyPI.
+  Correct its list-only `insert_many()` signature
+  and defaults, `BulkWriteError` details, blanket session-rejection claim,
+  conditional `AsyncMongoClient` patch/import caveat, numeric-equivalence
+  versus boolean identity rules, explicit null `_id` handling, `_default`
+  collection filtering, current error/result shapes, and `bytearray`
+  normalization. Also distinguish PyMongo from a core dependency: it is an
+  optional runtime dependency for ObjectId and nonzero Binary values, patching,
+  and conditional exception inheritance. Correct the remaining constructor,
+  sync-laziness, validation, sort, locking, environment-variable,
+  capabilities-detection, portable-error-catching, index-migration wording,
+  and the contradictory async `db.name` collection example identified by the
+  guide audit.
+- [ ] Under [#77](https://github.com/schapman1974/tinymongo/issues/77), reject
+  unsupported query operators with `TinyMongoNotSupportedError` instead of
+  silently returning no matches; then implement the application-prioritized
+  `$size`, `$elemMatch`, `$type`, and `$mod` slices.
+- [ ] Under [#94](https://github.com/schapman1974/tinymongo/issues/94), replace
+  raw Python range comparisons with BSON-aware comparison contracts and reuse
+  BSON identity rules in `$pull`, `$addToSet`, and `distinct()`.
+- [ ] Extend unique-index tokens to supported BSON values through
+  [#75](https://github.com/schapman1974/tinymongo/issues/75) and
+  [#76](https://github.com/schapman1974/tinymongo/issues/76).
+- [ ] Rerun Mike's two focused reproductions, resume the real Talk Python
+  acceptance run, and publish the MongoDB, memory, and SQLite baseline through
+  [#72](https://github.com/schapman1974/tinymongo/issues/72) and
+  [#136](https://github.com/schapman1974/tinymongo/issues/136).
+
 Application-compatibility work:
 
 - [ ] [#136: Full non-blocking PyMongo async API parity](https://github.com/schapman1974/tinymongo/issues/136)
@@ -36,8 +118,8 @@ Application-compatibility work:
     record any remaining differences.
 - [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
 - [ ] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
-  - [x] Milestone 1 ObjectId and datetime storage/query support.
-  - [ ] Add UUID, Decimal128, Binary, and regular-expression round trips.
+  - [x] Milestone 1 ObjectId, datetime, and Binary storage/query support.
+  - [ ] Add UUID, Decimal128, and regular-expression round trips.
 - [ ] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
   - [x] Talk Python query slice: scalar-to-array equality, combined `$nin`,
     `$not`, `$regex`, case-insensitive `$options`, and missing fields.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,6 +1,7 @@
 # Migration Guide
 
-This guide helps you migrate from earlier `tinymongo` versions to `1.0.0`.
+This guide helps you migrate from earlier `tinymongo` versions to the 1.2.1
+release line.
 
 ## Key changes
 
@@ -9,8 +10,21 @@ This guide helps you migrate from earlier `tinymongo` versions to `1.0.0`.
 - Parquet v2, SQLite, and DuckDB are available as table-native backends.
 - A `tinymongo` CLI is available for inspecting, exporting, importing, and migrating data.
 - Common update operators and durable single-field indexes are supported.
-- Concurrent writes are safer due to atomic file replace and optional file locks.
-- Optional `uv` extras are available for dependency-managed ASGI usage.
+- Local JSON writes use advisory locks, atomic replacement, and file/directory
+  `fsync`; local table backends use scoped locking plus database/file
+  mechanisms, remote SQL relies on database transactions, and object-storage
+  Parquet remains single-writer.
+- Synchronous and asynchronous operations share data semantics, but async
+  database handles and cursors defer storage work while synchronous database
+  selection may open storage immediately.
+- Datetime, ObjectId, and binary values use TinyMongo's tagged persistence
+  codec, and table-native backends use BSON-aware physical `_id` keys.
+- An explicitly supplied `_id: None` is preserved and participates in duplicate
+  detection instead of being replaced with a generated ID.
+- `insert_many()` defaults to `ordered=True`: successful documents before a
+  duplicate remain written, then the operation stops and raises
+  `BulkWriteError`. Set `ordered=False` to continue other valid documents and
+  collect all duplicate-key write errors.
 
 ## Installation
 
@@ -19,10 +33,11 @@ python3 -m pip install -U pip
 pip install .
 ```
 
-Or with the optional uv support:
+Install only the optional integrations you need, or install all of them:
 
 ```bash
-pip install .[uv]
+pip install ".[bson,parquet]"
+pip install ".[all]"
 ```
 
 ## Notes
@@ -33,9 +48,34 @@ pip install .[uv]
 - Select optional storage backends with `TinyMongoClient(path, backend="parquet")`, `backend="sqlite"`, or `backend="duckdb"`.
 - Older blob-format SQLite and DuckDB files are migrated to collection tables when opened.
 - Use `tinymongo migrate SOURCE TARGET --to-backend sqlite` to copy existing TinyDB JSON data into another backend.
-- Indexes created by earlier releases were collection-handle scoped and cannot
-  be migrated automatically. Recreate them once with `collection.create_index()`;
-  new index metadata persists with the backend, and unique indexes are enforced
-  for later writes. Memory-backend metadata lasts for the named namespace's
-  process lifetime.
+- Existing plain JSON and legacy stringified table-backend `_id` keys remain
+  readable and mutable after upgrading.
+- Before a bulk rewrite or migration, check legacy data for `_id` pairs that
+  are BSON-equivalent, such as `1` and `1.0` or native bytes and generic
+  subtype-0 `Binary`. Version 1.2.1 rejects new equivalent duplicates while
+  keeping booleans distinct from numbers and preserving mapping field order.
+- Remote SQL keeps the existing `data` column as a normal, indexable JSON/JSONB
+  object. Version 1.2.1 adds a nullable `data_ordered` text column containing
+  an encoded copy that preserves embedded-document field order. Existing rows
+  with no ordered copy remain readable from `data`, and rewriting one fills
+  `data_ordered`. The column is added automatically on first access, so the
+  database account needs `ALTER TABLE` permission during the upgrade. Existing
+  native indexes continue to target the unchanged `data` object. PostgreSQL
+  JSONB may already have normalized field order in legacy rows. TinyMongo can
+  recover a literal container `_id` from its legacy physical row key; other
+  normalized embedded documents retain the order returned by PostgreSQL.
+- Remote SQL and object-storage Parquet no longer create the unused local path
+  passed for API/CLI compatibility. Environment-only object-storage URIs and
+  remote DSNs participate in CLI database discovery and migration summaries.
+- The exact two-key mapping shape containing `__tinymongo_type_v1__` and
+  `value` is reserved for the persistence codec. If an older database contains
+  a valid tag shape as ordinary user data, whether written through an earlier
+  API or edited manually, rename one of those keys before upgrading so
+  TinyMongo does not decode it as a tagged value.
+- The CLI migrates documents, not source index metadata. It preserves and
+  preflights any indexes that already exist on the target collection. On a
+  fresh target, recreate the indexes with `collection.create_index()` after
+  migration; new index metadata persists with the backend, and unique indexes
+  are enforced for later writes. Memory-backend metadata lasts for the named
+  namespace's process lifetime.
 - For local development, install `requirements-dev.txt` and run `pytest -q`.

--- a/docs/OBJECT_STORAGE.md
+++ b/docs/OBJECT_STORAGE.md
@@ -1,6 +1,6 @@
 # Parquet Object Storage
 
-This feature is experimental in `1.1.2`.
+This feature remains experimental in `1.2.1`.
 
 TinyMongo's `parquet` and `parquetv2` backends can place collection Parquet
 files under an object-storage URI. DuckDB performs the remote file reads and
@@ -24,12 +24,16 @@ multi-writer update/delete semantics.
 from tinymongo import TinyMongoClient
 
 client = TinyMongoClient(
-    "/tmp/tinymongo-cache",
+    "/unused-local-path",
     backend="parquet",
     storage_uri="s3://my-bucket/tinymongo",
 )
 client.app.users.insert_one({"_id": "ada", "name": "Ada"})
 ```
+
+With `storage_uri` configured, the API folder argument is optional and ignored;
+the CLI path argument remains a required placeholder. It is not a cache or
+fallback location, and TinyMongo does not create it.
 
 The same value can be provided with an environment variable:
 
@@ -48,21 +52,23 @@ s3://my-bucket/tinymongo/app.parquet/events.parquet
 ## CLI Usage
 
 ```bash
-tinymongo inspect ./local-cache \
+tinymongo inspect ./unused \
   --backend parquet \
   --storage-uri s3://my-bucket/tinymongo
 
-tinymongo export ./local-cache app users \
+tinymongo export ./unused app users \
   --backend parquet \
   --storage-uri s3://my-bucket/tinymongo \
   -o users.json
 
-tinymongo migrate ./tinydb ./local-cache \
+tinymongo migrate ./tinydb ./unused \
   --to-backend parquet \
   --target-uri s3://my-bucket/tinymongo
 ```
 
-For remote-to-remote migrations, use `--source-uri` and `--target-uri`.
+For remote-to-remote migrations, use `--source-uri` and `--target-uri`. CLI
+commands also honor `TINYMONGO_STORAGE_URI`; an explicit URI flag takes
+precedence.
 
 ## Supported URI Families
 

--- a/docs/REMOTE_SQL.md
+++ b/docs/REMOTE_SQL.md
@@ -91,7 +91,8 @@ tinymongo migrate ./tinydb ./unused \
 ```
 
 The `path` argument is ignored for remote SQL backends, but it is still present
-to keep CLI commands consistent across all backends.
+to keep CLI commands consistent across all backends. When the DSN flags are
+omitted, CLI commands use the environment-variable precedence documented above.
 
 ## Storage Layout
 
@@ -110,11 +111,27 @@ app__events
 
 Each table has:
 
-- `_id`: string primary key
+- `_id`: opaque BSON-aware primary key for new rows, with legacy stringified
+  keys still readable and mutable
 - `data`: JSON/JSONB document payload
+- `data_ordered`: nullable `TEXT` on PostgreSQL or `LONGTEXT` on
+  MariaDB/MySQL, holding an encoded copy that preserves embedded-document field
+  order and strict-JSON non-finite values
 
 TinyMongo also creates `__tinymongo_collections` to track database and
-collection names.
+collection names and `__tinymongo_indexes` to persist index definitions.
+Supported indexes are backed by native SQL indexes over the unchanged `data`
+JSON object.
+
+When TinyMongo first opens a table created before 1.2.1, it adds
+`data_ordered` automatically. The database account therefore needs
+`ALTER TABLE` permission during the upgrade. Existing rows remain readable
+with a null ordered copy, and existing native JSON indexes remain valid because
+the `data` column keeps its original object representation. PostgreSQL JSONB
+may already have normalized field order in legacy rows. TinyMongo can recover a
+literal container `_id` from its legacy physical row key; other legacy mappings
+retain the order PostgreSQL returns, not necessarily the document's original
+application order.
 
 ## Query Behavior
 

--- a/docs/TALKPYTHON_ACCEPTANCE.md
+++ b/docs/TALKPYTHON_ACCEPTANCE.md
@@ -94,6 +94,52 @@ The report is publishable only when every expected target cell was executed,
 the matching MongoDB reference behavior passed, and no result is unattributed.
 A partial run is still rendered, but it is labeled incomplete.
 
+## First application findings and rerun gate
+
+Mike Kennedy's first real Talk Python pass reached the asynchronous application
+initializer on SQLite, opened all four database handles, and accepted the index
+declarations for all 16 collections. It reduced the first blocking differences
+to reusable contracts:
+
+- datetimes and ObjectIds must sort instead of silently retaining insertion
+  order;
+- BinData must sort by length, subtype, and bytes;
+- `Binary`, `bytes`, and `bytearray` must cross the JSON persistence boundary;
+  generic subtype-0 values must compare like native bytes while other subtypes
+  remain distinct;
+- `insert_many()` must distinguish duplicate-key partial failures from
+  client-side encoding failures; and
+- synchronous and asynchronous code must preserve the same behavior across
+  memory, JSON, SQLite, DuckDB, and Parquet.
+
+The Mongo-compatible portions of these behaviors now run through the shared
+synchronous/asynchronous matrix and real MongoDB contracts. TinyMongo's
+stronger whole-input serialization preflight is covered locally because
+PyMongo may split a very large input across wire batches. Before publishing
+the Talk Python baseline, rerun the two reduced reproductions and the
+application suite, and record the exact Talk Python commit, Python and PyMongo
+versions, selected test inventory, and configuration. The runner's `--api`
+value labels results; the application configuration must actually exercise
+the corresponding client path.
+
+Mike's separate TinyMongo agent reference currently describes unreleased
+`master` behavior as version 1.2.0. After the compatibility branch merges,
+update that guide against the merge SHA or the `v1.2.1` tag, including the
+Binary codec, BSON-aware `_id` identity, `insert_many()` partial failures,
+bounded sort diagnostics, exact `$unset`, BSON-aware CLI, and dotted child
+collections. Also correct the stale list-only `insert_many()` signature and
+defaults, `BulkWriteError` details, blanket session claim, conditional
+`AsyncMongoClient` patch/import caveat, numeric-versus-bool identity wording,
+explicit null `_id` handling, `_default` collection filtering, current
+error/result shapes, and `bytearray` normalization. It should call PyMongo an
+optional runtime dependency—not a core dependency—for ObjectId and nonzero
+Binary values, patching, and conditional exception inheritance.
+The same guide update should correct constructor and sync-laziness wording,
+document validation as a no-op, empty-array and sort-error details,
+backend-specific locking and durability, the full object-storage environment
+table, portable capability and duplicate-error examples, and the fact that CLI
+migration does not copy source index metadata.
+
 ## Handling failures
 
 For each difference found in the real application:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinymongo"
-version = "1.2.0"
+version = "1.2.1"
 description = "Embedded MongoDB-compatible database with sync, async, and multi-backend storage"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/contracts/test_crud_contract.py
+++ b/tests/contracts/test_crud_contract.py
@@ -63,6 +63,28 @@ def test_update_and_result_metadata(contract_target):
     ]
 
 
+def test_unset_removes_top_level_and_nested_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "unset",
+            "remove_me": True,
+            "nested": {"keep": 1, "remove_me": 2},
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "unset"},
+        {"$unset": {"remove_me": "", "nested.remove_me": ""}},
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "unset"}) == {
+        "_id": "unset",
+        "nested": {"keep": 1},
+    }
+
+
 def test_replace_upsert_and_delete_metadata(contract_target):
     collection = contract_target.collection
     collection.insert_one({"_id": 1, "name": "Ada", "active": False})
@@ -94,6 +116,21 @@ def test_duplicate_id_has_a_shared_error_category(contract_target):
 
     assert outcome.error == "duplicate_key"
     assert collection.count_documents({"_id": 1}) == 1
+
+
+def test_explicit_null_id_is_preserved_and_unique(contract_target):
+    collection = contract_target.collection
+    document = {"_id": None, "name": "explicit null"}
+
+    result = collection.insert_one(document)
+    duplicate = observe(
+        lambda: collection.insert_one({"_id": None, "name": "duplicate"})
+    )
+
+    assert result.inserted_id is None
+    assert document["_id"] is None
+    assert duplicate.error == "duplicate_key"
+    assert collection.find_one({"_id": None})["name"] == "explicit null"
 
 
 def test_sort_skip_and_limit_contract(contract_target):

--- a/tests/contracts/test_talkpython_contract.py
+++ b/tests/contracts/test_talkpython_contract.py
@@ -1,6 +1,6 @@
 """High-signal compatibility contracts derived from the Talk Python application."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -333,6 +333,215 @@ def test_object_id_and_datetime_round_trip_and_range_query(contract_target):
     assert document["created_date"] == created_date
     assert isinstance(document["created_date"], datetime)
     assert _ids(in_range) == [episode_id]
+
+
+def test_binary_round_trip_query_and_mongodb_sort_order(contract_target):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    uuid_binary = bson.Binary(bytes(range(16)), subtype=4)
+    sort_values = [
+        ("short-custom", bson.Binary(b"\xff", subtype=128)),
+        ("two-generic", b"\xff\xff"),
+        ("two-custom-low", bson.Binary(b"\x00\x00", subtype=128)),
+        ("two-custom-high", bson.Binary(b"\xff\x00", subtype=128)),
+        ("three-generic", b"\x00\x00\x00"),
+    ]
+    collection.insert_many(
+        [
+            {
+                "_id": label,
+                "label": label,
+                "value": value,
+                "nested": {"token": uuid_binary},
+            }
+            for label, value in reversed(sort_values)
+        ]
+    )
+
+    by_binary = list(collection.find({}).sort("value", 1))
+    matched = collection.find_one({"nested.token": uuid_binary})
+
+    assert [document["label"] for document in by_binary] == [
+        label for label, _value in sort_values
+    ]
+    assert matched is not None
+    assert isinstance(matched["value"], (bytes, bson.Binary))
+    assert isinstance(matched["nested"]["token"], bson.Binary)
+    assert matched["nested"]["token"].subtype == 4
+    assert bytes(matched["nested"]["token"]) == bytes(uuid_binary)
+
+
+def test_generic_binary_equality_matches_native_bytes_and_query_operators(
+    contract_target,
+):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    generic = bson.Binary(b"talk-python", subtype=0)
+    collection.insert_many(
+        [
+            {
+                "_id": "binary-object",
+                "value": generic,
+                "values": [generic, "other"],
+            },
+            {
+                "_id": "native-bytes",
+                "value": b"python-bytes",
+                "values": [b"python-bytes"],
+            },
+        ]
+    )
+
+    assert collection.find_one({"value": b"talk-python"})["_id"] == "binary-object"
+    assert collection.find_one({"value": generic})["_id"] == "binary-object"
+    if contract_target.name != "mongodb":
+        # TinyMongo accepts bytearray as a convenience and canonicalizes it to
+        # BSON's generic binary subtype. PyMongo rejects bytearray at encoding.
+        assert (
+            collection.find_one({"value": bytearray(b"talk-python")})["_id"]
+            == "binary-object"
+        )
+    assert (
+        collection.find_one({"value": bson.Binary(b"python-bytes", subtype=0)})["_id"]
+        == "native-bytes"
+    )
+    assert collection.find_one({"values": generic})["_id"] == "binary-object"
+    assert collection.find_one({"values": {"$in": [generic]}})["_id"] == "binary-object"
+    assert (
+        collection.find_one({"values": {"$all": [b"talk-python"]}})["_id"]
+        == "binary-object"
+    )
+    assert sorted(_ids(collection.find({"value": {"$nin": [b"talk-python"]}}))) == [
+        "native-bytes"
+    ]
+
+
+def test_binary_ids_use_bson_equality_without_losing_subtype(contract_target):
+    bson = pytest.importorskip("bson")
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    raw = bytes(range(16))
+    generic_id = bson.Binary(raw, subtype=0)
+    uuid_id = bson.Binary(raw, subtype=4)
+
+    collection.insert_one({"_id": generic_id, "kind": "generic"})
+
+    assert collection.find_one({"_id": raw})["kind"] == "generic"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": raw, "kind": "duplicate"})
+
+    collection.insert_one({"_id": uuid_id, "kind": "uuid"})
+    assert collection.find_one({"_id": uuid_id})["kind"] == "uuid"
+    assert sorted(document["kind"] for document in collection.find({})) == [
+        "generic",
+        "uuid",
+    ]
+    collection.update_one({"_id": uuid_id}, {"$set": {"updated": True}})
+    assert collection.find_one({"_id": raw}).get("updated") is None
+    assert collection.find_one({"_id": uuid_id})["updated"] is True
+    collection.delete_one({"_id": raw})
+    assert collection.find_one({"_id": raw}) is None
+    assert collection.find_one({"_id": uuid_id}) is not None
+
+
+def test_boolean_and_numeric_ids_are_bson_distinct(contract_target):
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "kind": "number"},
+            {"_id": True, "kind": "boolean"},
+        ]
+    )
+
+    assert collection.find_one({"_id": 1})["kind"] == "number"
+    assert collection.find_one({"_id": True})["kind"] == "boolean"
+    assert collection.find_one({"_id": 1.0})["kind"] == "number"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": 1.0, "kind": "duplicate-number"})
+    collection.update_one({"_id": True}, {"$set": {"updated": True}})
+    assert collection.find_one({"_id": 1}).get("updated") is None
+    assert collection.find_one({"_id": True})["updated"] is True
+    collection.delete_one({"_id": 1.0})
+    assert collection.find_one({"_id": 1}) is None
+    assert collection.find_one({"_id": True}) is not None
+
+
+def test_mixed_timezone_datetimes_sort_by_utc_instant(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "late",
+                "published": datetime(2026, 1, 1, 3, tzinfo=timezone.utc),
+            },
+            {
+                "_id": "early",
+                "published": datetime(
+                    2025,
+                    12,
+                    31,
+                    21,
+                    tzinfo=timezone(timedelta(hours=-3)),
+                ),
+            },
+            {"_id": "middle", "published": datetime(2026, 1, 1, 1)},
+        ]
+    )
+
+    assert _ids(collection.find({}).sort("published", 1)) == [
+        "early",
+        "middle",
+        "late",
+    ]
+    assert _ids(collection.find({}).sort("published", -1)) == [
+        "late",
+        "middle",
+        "early",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("ordered", "expected_ids", "expected_inserted"),
+    [
+        (True, [1], 1),
+        (False, [1, 2], 2),
+    ],
+)
+def test_insert_many_reports_compatible_partial_failures(
+    contract_target,
+    ordered,
+    expected_ids,
+    expected_inserted,
+):
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    documents = [
+        {"_id": 1, "label": "first"},
+        {"_id": 1, "label": "duplicate"},
+        {"_id": 2, "label": "last"},
+    ]
+
+    with pytest.raises(pymongo_errors.BulkWriteError) as caught:
+        collection.insert_many(documents, ordered=ordered)
+
+    details = caught.value.details
+    assert _ids(collection.find({}).sort("_id", 1)) == expected_ids
+    assert details["nInserted"] == expected_inserted
+    assert details["writeConcernErrors"] == []
+    assert [(error["index"], error["code"]) for error in details["writeErrors"]] == [
+        (1, 11000)
+    ]
+
+
+def test_insert_many_accepts_a_document_generator(contract_target):
+    collection = contract_target.collection
+    documents = ({"_id": number, "label": str(number)} for number in range(3))
+
+    result = collection.insert_many(documents)
+
+    assert result.inserted_ids == [0, 1, 2]
+    assert _ids(collection.find({}).sort("_id", 1)) == [0, 1, 2]
 
 
 def test_duplicate_errors_are_catchable_as_pymongo_errors(contract_target):

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -1,10 +1,17 @@
+from collections import UserDict
 import os
+import math
 from uuid import uuid4
 
 import pytest
 
 import tinymongo as tm
-from tinymongo.errors import DuplicateKeyError, TinyMongoNotSupportedError
+from tinymongo.errors import (
+    BulkWriteError,
+    DuplicateKeyError,
+    TinyMongoNotSupportedError,
+)
+from tinymongo.table_backends import _json_dumps
 
 
 pytestmark = pytest.mark.integration
@@ -25,6 +32,41 @@ def _remote_target(backend, env_name):
     return dsn, database, prefix
 
 
+def _create_legacy_remote_table(engine, collection):
+    conn = engine._connect()
+    try:
+        cursor = engine._execute(
+            conn,
+            "CREATE TABLE {0} (_id VARCHAR(255) PRIMARY KEY, "
+            "data {1} NOT NULL)".format(
+                engine._quote(engine._table_name(collection)),
+                engine.json_type,
+            ),
+        )
+        engine._close_cursor(cursor)
+        engine._commit(conn)
+    finally:
+        conn.close()
+
+
+def _insert_legacy_remote_row(engine, collection, row_id, document):
+    conn = engine._connect()
+    try:
+        cursor = engine._execute(
+            conn,
+            "INSERT INTO {0} (_id, data) VALUES ({1}, {2})".format(
+                engine._quote(engine._table_name(collection)),
+                engine.placeholder,
+                engine._data_placeholder(),
+            ),
+            (row_id, _json_dumps(document)),
+        )
+        engine._close_cursor(cursor)
+        engine._commit(conn)
+    finally:
+        conn.close()
+
+
 @pytest.mark.parametrize(
     ("backend", "env_name"),
     REMOTE_BACKENDS,
@@ -34,19 +76,207 @@ def test_remote_sql_backend_round_trip(backend, env_name):
     collection = prefix + "_round_trip"
     client = tm.TinyMongoClient(backend=backend, dsn=dsn)
     docs = client[database][collection]
+    large_payload = bytes(range(256)) * 400
     try:
         docs.insert_many(
             [
-                {"_id": "one", "kind": backend, "score": 1},
+                {
+                    "_id": "one",
+                    "kind": backend,
+                    "score": 1,
+                    "payload": large_payload,
+                },
                 {"_id": "two", "kind": backend, "score": 2},
             ]
         )
         docs.update_one({"_id": "one"}, {"$inc": {"score": 10}})
 
         assert docs.find_one({"_id": "one"})["score"] == 11
+        assert docs.find_one({"payload": large_payload})["_id"] == "one"
         assert docs.find({"kind": backend}).count() == 2
         assert collection in client[database].collection_names()
         assert database in client.list_database_names()
+    finally:
+        docs.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_insert_many_partial_failures(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_insert_many"
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][collection]
+    batch = [{"_id": 1}, {"_id": 1}, {"_id": 2}]
+    try:
+        with pytest.raises(BulkWriteError) as ordered:
+            docs.insert_many([dict(document) for document in batch])
+        assert ordered.value.details["nInserted"] == 1
+        assert sorted(document["_id"] for document in docs.find({})) == [1]
+
+        docs.delete_many({})
+
+        with pytest.raises(BulkWriteError) as unordered:
+            docs.insert_many(
+                [dict(document) for document in batch],
+                ordered=False,
+            )
+        assert unordered.value.details["nInserted"] == 2
+        assert [
+            (error["index"], error["code"])
+            for error in unordered.value.details["writeErrors"]
+        ] == [(1, 11000)]
+        assert sorted(document["_id"] for document in docs.find({})) == [1, 2]
+    finally:
+        docs.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_typed_and_legacy_id_migration(backend, env_name):
+    bson = pytest.importorskip("bson")
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_typed_ids"
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][collection]
+    generic_binary = bytes(range(16))
+    custom_binary = bson.Binary(generic_binary, subtype=4)
+    ordered_document_id = {"longer": 1, "a": 2}
+    reordered_document_id = {"a": 2, "longer": 1}
+    try:
+        docs.insert_many(
+            [
+                {"_id": 1, "label": "number"},
+                {"_id": True, "label": "boolean"},
+                {"_id": generic_binary, "label": "generic-binary"},
+                {"_id": custom_binary, "label": "custom-binary"},
+                {"_id": ordered_document_id, "label": "ordered-document"},
+                {"_id": reordered_document_id, "label": "reordered-document"},
+                {"_id": float("nan"), "label": "not-a-number"},
+                {"_id": float("inf"), "label": "positive-infinity"},
+                {"_id": float("-inf"), "label": "negative-infinity"},
+            ]
+        )
+
+        assert docs.find_one({"_id": 1})["label"] == "number"
+        assert docs.find_one({"_id": True})["label"] == "boolean"
+        assert (
+            docs.find_one({"_id": bson.Binary(generic_binary, 0)})["label"]
+            == "generic-binary"
+        )
+        assert docs.find_one({"_id": custom_binary})["label"] == "custom-binary"
+        assert docs.find_one({"_id": ordered_document_id})["label"] == (
+            "ordered-document"
+        )
+        assert docs.find_one({"_id": reordered_document_id})["label"] == (
+            "reordered-document"
+        )
+        assert docs.find_one({"_id": float("nan")})["label"] == "not-a-number"
+        assert docs.find_one({"_id": float("inf")})["label"] == "positive-infinity"
+        assert docs.find_one({"_id": float("-inf")})["label"] == "negative-infinity"
+        with pytest.raises(DuplicateKeyError):
+            docs.insert_one({"_id": 1.0, "label": "equivalent-number"})
+        with pytest.raises(DuplicateKeyError):
+            docs.insert_one(
+                {
+                    "_id": UserDict([("longer", 1.0), ("a", 2.0)]),
+                    "label": "equivalent-document",
+                }
+            )
+
+        docs.replace_one({"_id": True}, {"label": "updated-boolean"})
+        docs.delete_one({"_id": generic_binary})
+        assert docs.find_one({"_id": True})["label"] == "updated-boolean"
+        assert docs.find_one({"_id": 1})["label"] == "number"
+        assert docs.find_one({"_id": generic_binary}) is None
+        assert docs.find_one({"_id": custom_binary})["label"] == "custom-binary"
+        nonfinite_ids = [
+            document["_id"]
+            for document in docs.find(
+                {
+                    "$or": [
+                        {"label": "not-a-number"},
+                        {"label": "positive-infinity"},
+                        {"label": "negative-infinity"},
+                    ]
+                }
+            )
+        ]
+        assert any(math.isnan(value) for value in nonfinite_ids)
+        assert float("inf") in nonfinite_ids
+        assert float("-inf") in nonfinite_ids
+
+        # Seed one pre-v2 row to prove a real remote database can still resolve,
+        # replace, and delete the old stringified physical key.
+        engine = docs.parent.engine
+        _insert_legacy_remote_row(
+            engine,
+            collection,
+            "7",
+            {"_id": 7, "label": "legacy"},
+        )
+
+        assert docs.find_one({"_id": 7.0})["label"] == "legacy"
+        docs.replace_one({"_id": 7.0}, {"label": "legacy-updated"})
+        assert docs.find_one({"_id": 7})["label"] == "legacy-updated"
+        docs.delete_one({"_id": 7})
+        assert docs.find_one({"_id": 7.0}) is None
+    finally:
+        docs.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_upgrades_old_schema_and_recovers_ordered_legacy_id(
+    backend,
+    env_name,
+):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_old_schema"
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][collection]
+    engine = docs.parent.engine
+    ordered_id = {"longer": 1, "a": 2}
+    database_reordered_id = {"a": 2, "longer": 1}
+
+    try:
+        _create_legacy_remote_table(engine, collection)
+        _insert_legacy_remote_row(
+            engine,
+            collection,
+            str(ordered_id),
+            {"_id": database_reordered_id, "label": "legacy"},
+        )
+
+        assert docs.find_one({"_id": ordered_id}) == {
+            "_id": ordered_id,
+            "label": "legacy",
+        }
+        assert docs.find_one({"label": "legacy"})["_id"] == ordered_id
+        assert docs.find_one({"_id": database_reordered_id}) is None
+
+        conn = engine._connect()
+        try:
+            cursor = engine._execute(
+                conn,
+                "SELECT data_ordered FROM {0}".format(
+                    engine._quote(engine._table_name(collection))
+                ),
+            )
+            try:
+                assert list(cursor.fetchall()) == [(None,)]
+            finally:
+                engine._close_cursor(cursor)
+        finally:
+            conn.close()
+
+        docs.replace_one({"_id": ordered_id}, {"label": "updated"})
+        docs.insert_one({"_id": "fresh", "label": "new-schema"})
+        assert docs.find_one({"_id": ordered_id})["label"] == "updated"
+        assert docs.find_one({"_id": "fresh"})["label"] == "new-schema"
+
+        docs.delete_one({"_id": ordered_id})
+        assert docs.find_one({"_id": ordered_id}) is None
     finally:
         docs.drop()
         client.close()
@@ -70,6 +300,23 @@ def test_remote_sql_native_index_catalog_and_unique_enforcement(backend, env_nam
             "_id_": {"key": [("_id", 1)]},
             "email_unique": {"key": [("email", 1)], "unique": True},
         }
+
+        # Simulate a 1.2.0 table after its native index already exists. The
+        # 1.2.1 sidecar upgrade must leave that index usable by later writes.
+        engine = scalar.parent.engine
+        conn = engine._connect()
+        try:
+            cursor = engine._execute(
+                conn,
+                "ALTER TABLE {0} DROP COLUMN data_ordered".format(
+                    engine._quote(engine._table_name(scalar_name))
+                ),
+            )
+            engine._close_cursor(cursor)
+            engine._commit(conn)
+            engine._ordered_data_collections.discard(scalar_name)
+        finally:
+            conn.close()
 
         scalar.insert_many(
             [

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -151,6 +151,26 @@ def test_storage_work_does_not_block_the_event_loop(monkeypatch):
     run(scenario())
 
 
+def test_async_clients_reject_invalid_backends_without_opening_storage(tmp_path):
+    default_client = AsyncTinyMongoClient()
+    assert default_client._state._client is None
+    run(default_client.close())
+
+    native_path = tmp_path / "native"
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        AsyncTinyMongoClient(str(native_path), "invalid-native")
+    assert not native_path.exists()
+
+    pymongo_path = tmp_path / "pymongo"
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        AsyncMongoClient(
+            "mongodb://localhost:27017",
+            tinymongo_folder=str(pymongo_path),
+            backend="invalid-pymongo",
+        )
+    assert not pymongo_path.exists()
+
+
 def test_cursor_validation_close_and_limit_zero():
     async def scenario():
         client = AsyncTinyMongoClient(

--- a/tests/test_bson_codec.py
+++ b/tests/test_bson_codec.py
@@ -5,10 +5,12 @@ from uuid import uuid4
 import pytest
 
 import tinymongo as tm
-from tinymongo import bson_codec
+from tinymongo import bson_codec, bson_types
 
 
-ObjectId = pytest.importorskip("bson").ObjectId
+bson = pytest.importorskip("bson")
+ObjectId = bson.ObjectId
+Binary = bson.Binary
 
 
 def _extended_document():
@@ -95,7 +97,9 @@ def test_codec_preserves_malformed_escaped_mapping_tags(payload):
     assert bson_codec.decode_value(tagged) == tagged
 
 
-@pytest.mark.parametrize("kind", ["datetime", "objectid", "mapping", "future-type"])
+@pytest.mark.parametrize(
+    "kind", ["datetime", "objectid", "binary", "mapping", "future-type"]
+)
 def test_codec_escapes_user_mappings_that_look_like_internal_tags(kind):
     tagged = {
         "__tinymongo_type_v1__": kind,
@@ -131,6 +135,170 @@ def test_object_id_decode_explains_optional_dependency(monkeypatch):
         bson_codec.decode_value(encoded)
 
 
+@pytest.mark.parametrize("value", [b"\x00\xffabc", bytearray(b"\x00\xffabc")])
+def test_codec_round_trips_native_binary_values_as_bytes(value):
+    encoded = bson_codec.encode_value(value)
+
+    assert encoded == {
+        "__tinymongo_type_v1__": "binary",
+        "value": {"base64": "AP9hYmM=", "subtype": 0},
+    }
+    restored = bson_codec.decode_value(encoded)
+    assert restored == bytes(value)
+    assert type(restored) is bytes
+
+
+@pytest.mark.parametrize("subtype", [0, 3, 4, 128])
+def test_codec_round_trips_bson_binary_subtypes(subtype):
+    payload = bytes(range(16)) if subtype == 4 else b"\x01payload"
+    value = Binary(payload, subtype=subtype)
+
+    encoded = bson_codec.encode_value(value)
+    restored = bson_codec.decode_value(encoded)
+
+    assert encoded["value"]["subtype"] == subtype
+    assert bytes(restored) == bytes(value)
+    if subtype == 0:
+        assert type(restored) is bytes
+    else:
+        assert isinstance(restored, Binary)
+        assert restored.subtype == subtype
+
+
+def test_binary_subclass_is_encoded_before_native_bytes():
+    encoded = bson_codec.encode_value(Binary(bytes(range(16)), subtype=4))
+
+    assert encoded["value"] == {
+        "base64": "AAECAwQFBgcICQoLDA0ODw==",
+        "subtype": 4,
+    }
+
+
+def test_generic_binary_decodes_without_optional_bson(monkeypatch):
+    encoded = {
+        "__tinymongo_type_v1__": "binary",
+        "value": {"base64": "AAE=", "subtype": 0},
+    }
+    monkeypatch.setattr(bson_codec, "_Binary", None)
+
+    assert bson_codec.decode_value(encoded) == b"\x00\x01"
+
+
+def test_nonzero_binary_subtype_explains_optional_dependency(monkeypatch):
+    encoded = {
+        "__tinymongo_type_v1__": "binary",
+        "value": {"base64": "AAE=", "subtype": 4},
+    }
+    monkeypatch.setattr(bson_codec, "_Binary", None)
+
+    with pytest.raises(
+        ImportError,
+        match=r"Binary values with a non-zero subtype.*tinymongo\[bson\]",
+    ):
+        bson_codec.decode_value(encoded)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-a-mapping",
+        {"base64": "AAE="},
+        {"base64": 123, "subtype": 0},
+        {"base64": "not base64!", "subtype": 0},
+        {"base64": "AAE=", "subtype": True},
+        {"base64": "AAE=", "subtype": 256},
+    ],
+)
+def test_codec_preserves_malformed_binary_tags(payload):
+    tagged = {
+        "__tinymongo_type_v1__": "binary",
+        "value": payload,
+    }
+
+    assert bson_codec.decode_value(tagged) == tagged
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"raw",
+        bytearray(b"mutable"),
+        Binary(bytes(range(16)), subtype=4),
+        {"nested": [b"raw"]},
+    ],
+)
+def test_binary_values_require_python_filter_comparison(value):
+    assert bson_codec.contains_extended_value(value) is True
+
+
+@pytest.mark.parametrize(
+    ("value", "payload"),
+    [
+        (float("nan"), "nan"),
+        (float("inf"), "infinity"),
+        (float("-inf"), "-infinity"),
+    ],
+)
+def test_nonfinite_floats_use_strict_json_tags(value, payload):
+    encoded = bson_codec.encode_value(value)
+    serialized = bson_codec.dumps({"value": value})
+    restored = bson_codec.loads(serialized)["value"]
+
+    assert encoded == {
+        "__tinymongo_type_v1__": "float",
+        "value": payload,
+    }
+    assert "NaN" not in serialized
+    assert "Infinity" not in serialized
+    assert bson_codec.contains_extended_value(value)
+    if payload == "nan":
+        assert restored != restored
+    else:
+        assert restored == value
+
+
+def test_malformed_nonfinite_float_tag_is_preserved():
+    tagged = {
+        "__tinymongo_type_v1__": "float",
+        "value": "not-a-float",
+    }
+
+    assert bson_codec.decode_value(tagged) == tagged
+
+
+def test_bson_type_registry_uses_mongodb_scalar_order_and_subclass_precedence():
+    assert bson_types.bson_scalar_sort_key(None) == (0, None)
+    assert bson_types.bson_scalar_sort_key(1) == (1, (1, 1))
+    assert bson_types.bson_scalar_sort_key("text") == (2, "text")
+    assert bson_types.bson_scalar_sort_key(Binary(b"x", subtype=128)) == (
+        5,
+        (1, 128, b"x"),
+    )
+    assert bson_types.bson_scalar_sort_key(b"x") == (5, (1, 0, b"x"))
+    assert bson_types.bson_scalar_sort_key(ObjectId("000000000000000000000001")) == (
+        6,
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+    )
+    assert bson_types.bson_type_spec(True).name == "boolean"
+    assert bson_types.bson_type_spec(1).name == "number"
+
+
+def test_bson_type_registry_normalizes_naive_and_aware_dates_to_utc():
+    naive = datetime(2026, 7, 20, 12, 30)
+    aware = datetime(
+        2026,
+        7,
+        20,
+        8,
+        30,
+        tzinfo=timezone(timedelta(hours=-4)),
+    )
+
+    assert bson_types.bson_scalar_sort_key(naive) == bson_types.bson_scalar_sort_key(
+        aware
+    )
+
+
 @pytest.mark.parametrize("backend", ["memory", "tinydb", "sqlite", "duckdb", "parquet"])
 def test_extended_values_round_trip_through_public_backends(tmp_path, backend):
     if backend in ("duckdb", "parquet"):
@@ -152,6 +320,48 @@ def test_extended_values_round_trip_through_public_backends(tmp_path, backend):
 
         assert restored == document
         assert reader.app.events.find_one({"created": document["created"]}) == document
+    finally:
+        reader.close()
+
+
+@pytest.mark.parametrize("backend", ["memory", "tinydb", "sqlite", "duckdb", "parquet"])
+def test_binary_values_round_trip_through_public_backends(tmp_path, backend):
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+    if backend == "parquet":
+        pytest.importorskip("pyarrow")
+
+    binary_id = b"binary-id"
+    uuid_binary = Binary(bytes(range(16)), subtype=4)
+    blob = b"\x89PNG\r\n\x1a\n" + (b"x" * 100_000)
+    if backend == "memory":
+        location = "memory://binary-codec-{0}".format(uuid4().hex)
+    else:
+        location = str(tmp_path / backend)
+
+    writer = tm.TinyMongoClient(location, backend=backend)
+    writer.app.assets.insert_one(
+        {
+            "_id": binary_id,
+            "blob": blob,
+            "mutable": bytearray(b"abc"),
+            "nested": {"tokens": [uuid_binary]},
+        }
+    )
+    writer.close()
+
+    reader = tm.TinyMongoClient(location, backend=backend)
+    try:
+        restored = reader.app.assets.find_one({"nested.tokens": uuid_binary})
+
+        assert restored["_id"] == binary_id
+        assert type(restored["_id"]) is bytes
+        assert restored["blob"] == blob
+        assert restored["mutable"] == b"abc"
+        assert type(restored["mutable"]) is bytes
+        assert isinstance(restored["nested"]["tokens"][0], Binary)
+        assert restored["nested"]["tokens"][0].subtype == 4
+        assert bytes(restored["nested"]["tokens"][0]) == bytes(uuid_binary)
     finally:
         reader.close()
 

--- a/tests/test_bson_registry_hardening.py
+++ b/tests/test_bson_registry_hardening.py
@@ -1,0 +1,320 @@
+"""Focused invariants for the shared BSON type registry and JSON codec."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+from uuid import uuid4
+
+import pytest
+
+import tinymongo
+from tinymongo import bson_codec, bson_types
+from tinymongo.errors import BulkWriteError
+
+
+def test_core_datetime_and_binary_values_do_not_require_pymongo():
+    moment = datetime(2026, 7, 29, 12, 30)
+    document = {
+        "created": moment,
+        "raw": b"\x00\x01\xff",
+        "buffer": bytearray(b"mutable"),
+    }
+
+    restored = bson_codec.loads(bson_codec.dumps(document))
+
+    assert restored == {
+        "created": moment,
+        "raw": b"\x00\x01\xff",
+        "buffer": b"mutable",
+    }
+
+
+def test_core_memory_crud_sort_and_batch_work_without_pymongo():
+    client = tinymongo.TinyMongoClient(
+        "memory://core-bson-registry-{0}".format(uuid4().hex),
+        backend="memory",
+    )
+    collection = client.app.events
+    earlier = datetime(2026, 7, 29, 11, 30)
+    later = datetime(2026, 7, 29, 12, 30)
+
+    result = collection.insert_many(
+        (
+            {"_id": "later", "created": later, "payload": b"b"},
+            {"_id": "earlier", "created": earlier, "payload": bytearray(b"a")},
+        )
+    )
+
+    assert result.inserted_ids == ["later", "earlier"]
+    assert collection.find_one({"payload": b"a"})["_id"] == "earlier"
+    assert [document["_id"] for document in collection.find({}).sort("created", 1)] == [
+        "earlier",
+        "later",
+    ]
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many(
+            [{"_id": "later"}, {"_id": "new"}],
+            ordered=False,
+        )
+    assert caught.value.details["nInserted"] == 1
+    assert collection.find_one({"_id": "new"}) is not None
+    client.close()
+
+
+def test_registry_is_the_encoding_metadata_source():
+    bson = pytest.importorskip("bson")
+    uuid_binary = bson.Binary(bytes(range(16)), subtype=4)
+    values = [
+        (datetime(2026, 7, 29, 12, 30), "datetime"),
+        (bson.ObjectId("000000000000000000000001"), "objectid"),
+        (b"native", "binary"),
+        (bytearray(b"mutable"), "binary"),
+        (uuid_binary, "binary"),
+    ]
+
+    for value, expected_tag in values:
+        spec = bson_types.bson_type_spec(value)
+        encoded = bson_codec.encode_value(value)
+
+        assert spec is not None
+        assert spec.storage_tag == expected_tag
+        assert spec.requires_python_comparison is True
+        assert encoded["__tinymongo_type_v1__"] == spec.storage_tag
+        assert bson_codec.contains_extended_value(value) is True
+
+
+def test_binary_and_numeric_identity_keys_follow_bson_equality():
+    bson = pytest.importorskip("bson")
+    generic_binary = bson.Binary(b"same", subtype=0)
+    uuid_binary = bson.Binary(bytes(range(16)), subtype=4)
+
+    assert bson_types.bson_identity_key(generic_binary) == bson_types.bson_identity_key(
+        b"same"
+    )
+    assert bson_types.bson_identity_key(bytearray(b"same")) == (
+        "binary",
+        (0, b"same"),
+    )
+    assert bson_types.bson_values_equal(generic_binary, b"same") is True
+    assert bson_types.bson_values_equal(uuid_binary, bytes(uuid_binary)) is False
+    assert bson_types.bson_identity_key(1) == bson_types.bson_identity_key(1.0)
+    assert bson_types.bson_values_equal(1, 1.0) is True
+    assert bson_types.bson_values_equal(True, 1) is False
+    assert bson_types.bson_identity_key(float("nan")) == bson_types.bson_identity_key(
+        float("nan")
+    )
+
+
+def test_numeric_sort_places_nan_below_all_other_numbers():
+    values = [
+        ("one", 1.0),
+        ("nan", float("nan")),
+        ("negative", -1.0),
+        ("negative-infinity", float("-inf")),
+        ("zero", 0.0),
+        ("infinity", float("inf")),
+    ]
+
+    assert [
+        label
+        for label, _value in sorted(
+            values,
+            key=lambda item: bson_types.bson_scalar_sort_key(item[1]),
+        )
+    ] == [
+        "nan",
+        "negative-infinity",
+        "negative",
+        "zero",
+        "one",
+        "infinity",
+    ]
+
+
+def test_recursive_bson_equality_preserves_nested_scalar_types():
+    assert bson_types.bson_values_equal(
+        {"items": [1, {"active": True}]},
+        {"items": [1.0, {"active": True}]},
+    )
+    assert not bson_types.bson_values_equal(
+        {"items": [1, {"active": True}]},
+        {"items": [1.0, {"active": 1}]},
+    )
+    assert not bson_types.bson_values_equal({"value": True}, {"value": 1})
+    assert not bson_types.bson_values_equal({"value": 1}, 1)
+    assert bson_types.bson_values_equal({1}, {1})
+    assert not bson_types.bson_values_equal({1}, {2})
+    assert not bson_types.bson_values_equal(
+        {"first": 1, "second": 2},
+        {"second": 2, "first": 1},
+    )
+    assert not bson_types.bson_values_equal({"value": 1}, ["value", 1])
+
+    unsupported = object()
+    assert bson_types.bson_values_equal(unsupported, unsupported)
+    assert not bson_types.bson_values_equal(unsupported, object())
+
+
+def test_datetime_identity_normalizes_to_signed_utc_milliseconds():
+    first = datetime(
+        2026,
+        7,
+        29,
+        8,
+        30,
+        0,
+        123001,
+        tzinfo=timezone(timedelta(hours=-4)),
+    )
+    same_millisecond = datetime(
+        2026,
+        7,
+        29,
+        12,
+        30,
+        0,
+        123999,
+        tzinfo=timezone.utc,
+    )
+    next_millisecond = same_millisecond.replace(microsecond=124000)
+    before_epoch = datetime(1969, 12, 31, 23, 59, 59, 999999)
+
+    assert bson_types.bson_identity_key(first) == bson_types.bson_identity_key(
+        same_millisecond
+    )
+    assert bson_types.bson_values_equal(first, same_millisecond) is True
+    assert bson_types.bson_values_equal(first, next_millisecond) is False
+    assert bson_types.bson_identity_key(before_epoch) == ("datetime", -1)
+
+
+@pytest.mark.parametrize(
+    "tagged",
+    [
+        {"__tinymongo_type_v1__": "datetime", "value": "not-a-date"},
+        {"__tinymongo_type_v1__": "datetime", "value": 123},
+        {"__tinymongo_type_v1__": "objectid", "value": "too-short"},
+        {"__tinymongo_type_v1__": "objectid", "value": "z" * 24},
+        {"__tinymongo_type_v1__": "objectid", "value": "00 " * 8},
+        {"__tinymongo_type_v1__": "objectid", "value": 123},
+        {
+            "__tinymongo_type_v1__": "future-type",
+            "value": {
+                "__tinymongo_type_v1__": "datetime",
+                "value": "2026-07-29T12:30:00",
+            },
+        },
+    ],
+)
+def test_malformed_and_unknown_tags_are_preserved_exactly(tagged):
+    assert bson_codec.decode_value(tagged) == tagged
+
+
+def test_valid_datetime_and_object_id_tags_still_decode():
+    bson = pytest.importorskip("bson")
+    moment = datetime(
+        2026,
+        7,
+        29,
+        8,
+        30,
+        tzinfo=timezone(timedelta(hours=-4)),
+    )
+    object_id = bson.ObjectId("000000000000000000000001")
+
+    assert (
+        bson_codec.decode_value(
+            {"__tinymongo_type_v1__": "datetime", "value": moment.isoformat()}
+        )
+        == moment
+    )
+    assert (
+        bson_codec.decode_value(
+            {"__tinymongo_type_v1__": "objectid", "value": str(object_id)}
+        )
+        == object_id
+    )
+
+
+def test_fresh_process_without_pymongo_keeps_core_codec_available():
+    # Import bson first, then block pymongo. This models an environment where a
+    # top-level bson distribution exists but PyMongo's complete implementation
+    # is unavailable; the registry must not report partial BSON capability.
+    script = textwrap.dedent(
+        """
+        import builtins
+        from datetime import datetime
+
+        real_import = builtins.__import__
+
+        try:
+            import bson
+        except ImportError:
+            bson = None
+
+        def without_pymongo(name, *args, **kwargs):
+            if name == "pymongo" or name.startswith("pymongo."):
+                raise ModuleNotFoundError(
+                    "No module named 'pymongo'", name="pymongo"
+                )
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = without_pymongo
+
+        from tinymongo import bson_codec, bson_types
+
+        assert bson_types.bson_capabilities() == {
+            "objectid": False,
+            "binary": False,
+        }
+        assert bson_codec.bson_available() is False
+        assert bson_codec.object_id_available() is False
+        assert bson_codec.binary_available() is False
+        assert bson_codec.loads(bson_codec.dumps(b"core")) == b"core"
+
+        moment = datetime(2026, 7, 29, 12, 30)
+        assert bson_codec.loads(bson_codec.dumps(moment)) == moment
+
+        generic = {
+            "__tinymongo_type_v1__": "binary",
+            "value": {"base64": "Y29yZQ==", "subtype": 0},
+        }
+        assert bson_codec.decode_value(generic) == b"core"
+
+        non_generic = {
+            "__tinymongo_type_v1__": "binary",
+            "value": {
+                "base64": "AAECAwQFBgcICQoLDA0ODw==",
+                "subtype": 4,
+            },
+        }
+        try:
+            bson_codec.decode_value(non_generic)
+        except ImportError as error:
+            assert "tinymongo[bson]" in str(error)
+        else:
+            raise AssertionError("non-zero Binary subtype decoded without PyMongo")
+
+        object_id = {
+            "__tinymongo_type_v1__": "objectid",
+            "value": "000000000000000000000001",
+        }
+        try:
+            bson_codec.decode_value(object_id)
+        except ImportError as error:
+            assert "tinymongo[bson]" in str(error)
+        else:
+            raise AssertionError("ObjectId decoded without PyMongo")
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(Path(__file__).resolve().parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 import json
+from datetime import datetime, timezone
 
 import pytest
 import tinymongo as tm
 from tinymongo import cli
+from tinymongo.errors import BulkWriteError
 
 
 def test_cli_inspect_export_import_and_migrate(tmp_path, capsys):
@@ -103,6 +105,124 @@ def test_cli_backend_option_exports_sqlite_backend(tmp_path, capsys):
     assert json.loads(capsys.readouterr().out) == [{"_id": 1, "name": "Ada"}]
 
 
+def test_cli_export_import_preserves_datetime_and_bytes_without_bson(tmp_path, capsys):
+    source = tmp_path / "core-source"
+    target = tmp_path / "core-target"
+    export_file = tmp_path / "core-events.json"
+    created = datetime(2026, 7, 29, 14, 30)
+
+    tm.TinyMongoClient(str(source)).app.events.insert_one(
+        {
+            "_id": "core",
+            "created": created,
+            "raw": b"\x00\x01\xff",
+            "buffer": bytearray(b"mutable"),
+        }
+    )
+    assert (
+        cli.main(
+            [
+                "export",
+                str(source),
+                "app",
+                "events",
+                "--output",
+                str(export_file),
+            ]
+        )
+        == 0
+    )
+    assert cli.main(["import", str(target), "app", "events", str(export_file)]) == 0
+
+    assert "imported 1 documents" in capsys.readouterr().out
+    assert tm.TinyMongoClient(str(target)).app.events.find_one({"_id": "core"}) == {
+        "_id": "core",
+        "created": created,
+        "raw": b"\x00\x01\xff",
+        "buffer": b"mutable",
+    }
+
+
+def test_cli_export_import_and_migrate_preserve_supported_bson_values(tmp_path, capsys):
+    bson = pytest.importorskip("bson")
+    source = tmp_path / "bson-source"
+    imported_target = tmp_path / "bson-imported"
+    migrated_target = tmp_path / "bson-migrated"
+    export_file = tmp_path / "events.json"
+    object_id = bson.ObjectId("507f1f77bcf86cd799439011")
+    created = datetime(2026, 7, 29, 14, 30, tzinfo=timezone.utc)
+    document = {
+        "_id": object_id,
+        "created": created,
+        "raw": b"\x00\x01\xff",
+        "buffer": bytearray(b"mutable"),
+        "binary": bson.Binary(b"0123456789abcdef", subtype=4),
+    }
+
+    tm.TinyMongoClient(str(source)).app.events.insert_one(document)
+    assert (
+        cli.main(
+            [
+                "export",
+                str(source),
+                "app",
+                "events",
+                "--output",
+                str(export_file),
+            ]
+        )
+        == 0
+    )
+
+    exported_json = json.loads(export_file.read_text(encoding="utf-8"))
+    assert exported_json[0]["_id"]["__tinymongo_type_v1__"] == "objectid"
+    assert exported_json[0]["created"]["__tinymongo_type_v1__"] == "datetime"
+    assert exported_json[0]["raw"]["__tinymongo_type_v1__"] == "binary"
+    assert exported_json[0]["binary"]["value"]["subtype"] == 4
+
+    assert (
+        cli.main(
+            [
+                "import",
+                str(imported_target),
+                "app",
+                "events",
+                str(export_file),
+            ]
+        )
+        == 0
+    )
+    assert "imported 1 documents" in capsys.readouterr().out
+    imported = tm.TinyMongoClient(str(imported_target)).app.events.find_one(
+        {"_id": object_id}
+    )
+    assert imported == {
+        "_id": object_id,
+        "created": created,
+        "raw": b"\x00\x01\xff",
+        "buffer": b"mutable",
+        "binary": bson.Binary(b"0123456789abcdef", subtype=4),
+    }
+
+    assert (
+        cli.main(
+            [
+                "migrate",
+                str(source),
+                str(migrated_target),
+                "--to-backend",
+                "sqlite",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    migrated = tm.TinyMongoClient(
+        str(migrated_target), backend="sqlite"
+    ).app.events.find_one({"_id": object_id})
+    assert migrated == document
+
+
 def test_cli_import_from_stdin_and_replace_mode(tmp_path, monkeypatch, capsys):
     db_dir = tmp_path / "db"
     client = tm.TinyMongoClient(str(db_dir))
@@ -128,7 +248,155 @@ def test_cli_import_from_stdin_and_replace_mode(tmp_path, monkeypatch, capsys):
     )
 
     assert "imported 1 documents" in capsys.readouterr().out
-    assert list(client.app.users.find({})) == [{"_id": 2, "name": "new"}]
+    client.close()
+    refreshed = tm.TinyMongoClient(str(db_dir))
+    assert list(refreshed.app.users.find({})) == [{"_id": 2, "name": "new"}]
+    refreshed.close()
+
+
+def test_cli_export_import_preserves_embedded_document_field_order(tmp_path):
+    source = tmp_path / "ordered-source"
+    target = tmp_path / "ordered-target"
+    export_file = tmp_path / "ordered.json"
+    document_id = {"z": 1, "a": 2}
+    nested = {"second": 2, "first": 1}
+
+    source_client = tm.TinyMongoClient(str(source))
+    source_client.app.items.insert_one({"_id": document_id, "nested": nested})
+    source_client.close()
+
+    assert (
+        cli.main(
+            [
+                "export",
+                str(source),
+                "app",
+                "items",
+                "-o",
+                str(export_file),
+            ]
+        )
+        == 0
+    )
+    exported = json.loads(export_file.read_text(encoding="utf-8"))
+    assert list(exported[0]["_id"]) == ["z", "a"]
+    assert list(exported[0]["nested"]) == ["second", "first"]
+
+    assert (
+        cli.main(
+            [
+                "import",
+                str(target),
+                "app",
+                "items",
+                str(export_file),
+                "--mode",
+                "replace",
+            ]
+        )
+        == 0
+    )
+    restored_client = tm.TinyMongoClient(str(target))
+    restored = restored_client.app.items.find_one({"_id": document_id})
+    assert restored is not None
+    assert list(restored["_id"]) == ["z", "a"]
+    assert list(restored["nested"]) == ["second", "first"]
+    restored_client.close()
+
+
+def test_copy_indexes_preserves_names_keys_and_uniqueness():
+    class Source:
+        def list_indexes(self):
+            return [
+                {"name": "_id_", "key": [("_id", 1)]},
+                {
+                    "name": "email_unique",
+                    "key": [("email", 1)],
+                    "unique": True,
+                },
+                {"name": "created_desc", "key": [("created", -1)]},
+            ]
+
+    class Target:
+        def __init__(self):
+            self.created = []
+
+        def create_index(self, keys, **options):
+            self.created.append((keys, options))
+
+    target = Target()
+    cli._copy_indexes(Source(), target)
+
+    assert target.created == [
+        (
+            [("email", 1)],
+            {"name": "email_unique", "unique": True},
+        ),
+        ([("created", -1)], {"name": "created_desc"}),
+    ]
+
+
+@pytest.mark.parametrize("previous", [[], [{"_id": "old"}]])
+def test_replace_collection_rolls_back_a_failed_destination_write(previous):
+    class Collection:
+        def __init__(self):
+            self.documents = list(previous)
+            self.insert_calls = 0
+
+        def list_indexes(self):
+            return [{"name": "_id_", "key": [("_id", 1)]}]
+
+        def find(self, _filter):
+            return list(self.documents)
+
+        def delete_many(self, _filter):
+            self.documents = []
+
+        def insert_many(self, documents):
+            self.insert_calls += 1
+            if self.insert_calls == 1:
+                raise RuntimeError("destination write failed")
+            self.documents.extend(documents)
+
+    collection = Collection()
+    with pytest.raises(RuntimeError, match="destination write failed"):
+        cli._replace_collection(
+            {"users": collection},
+            "users",
+            [{"_id": "new"}],
+        )
+
+    assert collection.documents == previous
+
+
+def test_replace_collection_reports_a_failed_rollback_with_runtime_error():
+    class Collection:
+        def __init__(self):
+            self.documents = [{"_id": "old"}]
+
+        def list_indexes(self):
+            return [{"name": "_id_", "key": [("_id", 1)]}]
+
+        def find(self, _filter):
+            return list(self.documents)
+
+        def delete_many(self, _filter):
+            self.documents = []
+
+        def insert_many(self, _documents):
+            raise RuntimeError("storage unavailable")
+
+    with pytest.raises(
+        RuntimeError,
+        match="previous data could not be restored",
+    ) as error:
+        cli._replace_collection(
+            {"users": Collection()},
+            "users",
+            [{"_id": "new"}],
+        )
+
+    assert isinstance(error.value.__cause__, RuntimeError)
 
 
 def test_cli_import_rejects_non_array_input(tmp_path):
@@ -160,12 +428,169 @@ def test_cli_migrate_all_databases(tmp_path, capsys):
     assert tm.TinyMongoClient(str(target), backend="sqlite").audit.events.count() == 1
 
 
+def test_cli_hides_tinydb_default_table_from_listing_inspection_and_migration(
+    tmp_path, capsys
+):
+    source = tmp_path / "source-with-default"
+    target = tmp_path / "target-without-default"
+    database = tm.TinyMongoClient(str(source)).app
+    database.users.insert_one({"_id": 1})
+    assert "_default" not in database.collection_names()
+
+    assert cli.main(["list-collections", str(source), "app"]) == 0
+    assert capsys.readouterr().out.splitlines() == ["users"]
+
+    assert cli.main(["inspect", str(source)]) == 0
+    inspected = json.loads(capsys.readouterr().out)
+    assert [
+        collection["name"] for collection in inspected["databases"][0]["collections"]
+    ] == ["users"]
+
+    assert (
+        cli.main(["migrate", str(source), str(target), "--to-backend", "sqlite"]) == 0
+    )
+    migrated = json.loads(capsys.readouterr().out)
+    assert [
+        item["collection"] for item in migrated["migrated"] if item["database"] == "app"
+    ] == ["users"]
+    assert tm.TinyMongoClient(
+        str(target), backend="sqlite"
+    ).app.list_collection_names() == ["users"]
+
+
+def test_replace_import_preflights_before_deleting_existing_data(tmp_path):
+    target = tmp_path / "replace-preflight"
+    input_file = tmp_path / "duplicates.json"
+    client = tm.TinyMongoClient(str(target))
+    client.app.users.insert_one({"_id": "old", "name": "Keep me"})
+    client.close()
+    input_file.write_text(
+        json.dumps([{"_id": 1}, {"_id": 1}, {"_id": 2}]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BulkWriteError):
+        cli.main(
+            [
+                "import",
+                str(target),
+                "app",
+                "users",
+                str(input_file),
+                "--mode",
+                "replace",
+            ]
+        )
+
+    documents = list(tm.TinyMongoClient(str(target)).app.users.find({}))
+    assert documents == [{"_id": "old", "name": "Keep me"}]
+
+
+def test_migrate_preflights_target_indexes_before_deleting_existing_data(tmp_path):
+    source = tmp_path / "migration-source"
+    target = tmp_path / "migration-target"
+    source_client = tm.TinyMongoClient(str(source))
+    source_client.app.users.insert_many(
+        [
+            {"_id": 1, "email": "duplicate@example.com"},
+            {"_id": 2, "email": "duplicate@example.com"},
+        ]
+    )
+    source_client.close()
+    target_client = tm.TinyMongoClient(str(target))
+    target_client.app.users.create_index("email", unique=True)
+    target_client.app.users.insert_one({"_id": "old", "email": "old@example.com"})
+    target_client.close()
+
+    with pytest.raises(BulkWriteError):
+        cli.main(
+            [
+                "migrate",
+                str(source),
+                str(target),
+                "--to-backend",
+                "tinydb",
+                "--database",
+                "app",
+            ]
+        )
+
+    documents = list(tm.TinyMongoClient(str(target)).app.users.find({}))
+    assert documents == [{"_id": "old", "email": "old@example.com"}]
+
+
+def test_replace_collection_restores_previous_data_after_late_write_failure():
+    class Collection:
+        def __init__(self):
+            self.documents = [{"_id": "old"}]
+            self.insert_attempts = 0
+
+        def list_indexes(self):
+            return [
+                {"name": "_id_", "key": [("_id", 1)]},
+                {"name": "label_1", "key": [("label", 1)]},
+            ]
+
+        def find(self, _filter):
+            return list(self.documents)
+
+        def delete_many(self, _filter):
+            self.documents = []
+
+        def insert_many(self, documents):
+            self.insert_attempts += 1
+            if self.insert_attempts == 1:
+                raise ValueError("late destination failure")
+            self.documents = list(documents)
+
+    collection = Collection()
+    database = {"events": collection}
+
+    with pytest.raises(ValueError, match="late destination failure"):
+        cli._replace_collection(database, "events", [{"_id": "new"}])
+
+    assert collection.documents == [{"_id": "old"}]
+    assert collection.insert_attempts == 2
+
+
+def test_replace_collection_reports_a_failed_rollback():
+    class Collection:
+        def __init__(self):
+            self.documents = [{"_id": "old"}]
+
+        def list_indexes(self):
+            return [{"name": "_id_", "key": [("_id", 1)]}]
+
+        def find(self, _filter):
+            return list(self.documents)
+
+        def delete_many(self, _filter):
+            self.documents = []
+
+        def insert_many(self, _documents):
+            raise ValueError("destination unavailable")
+
+    collection = Collection()
+
+    with pytest.raises(
+        RuntimeError,
+        match="previous data could not be restored",
+    ) as caught:
+        cli._replace_collection(
+            {"events": collection},
+            "events",
+            [{"_id": "new"}],
+        )
+
+    assert isinstance(caught.value.__cause__, ValueError)
+
+
 def test_cli_storage_uri_options_are_passed_through(monkeypatch, tmp_path, capsys):
     calls = []
 
     class FakeCollection:
-        def __init__(self):
-            self.docs = [{"_id": 1}]
+        def __init__(self, docs=None):
+            self.docs = list(docs or [])
 
         def find(self, _filter=None):
             return self.docs
@@ -174,17 +599,27 @@ def test_cli_storage_uri_options_are_passed_through(monkeypatch, tmp_path, capsy
             return None
 
         def insert_many(self, docs):
-            self.docs = docs
+            self.docs = list(docs)
+
+        def list_indexes(self):
+            return [{"name": "_id_", "key": [("_id", 1)]}]
+
+        def create_index(self, *args, **kwargs):
+            return kwargs.get("name")
+
+        def drop(self):
+            self.docs = []
+            return True
 
     class FakeDatabase:
         def __init__(self):
-            self.users = FakeCollection()
+            self.collections = {"users": FakeCollection([{"_id": 1}])}
 
         def __getitem__(self, name):
-            return self.users
+            return self.collections.setdefault(name, FakeCollection())
 
         def collection_names(self):
-            return ["users"]
+            return ["_default", "users"]
 
     class FakeClient:
         def __init__(self, path, backend, storage_uri=None, dsn=None):
@@ -271,6 +706,8 @@ def test_cli_storage_uri_options_are_passed_through(monkeypatch, tmp_path, capsy
 
 
 def test_cli_storage_uri_inspect_and_db_names(monkeypatch, tmp_path, capsys):
+    clients = []
+
     class FakeCollection:
         def count(self):
             return 3
@@ -284,6 +721,7 @@ def test_cli_storage_uri_inspect_and_db_names(monkeypatch, tmp_path, capsys):
 
     class FakeClient:
         def __init__(self, path, backend, storage_uri=None, dsn=None):
+            clients.append(self)
             self.storage_uri = storage_uri
             self.dsn = dsn
 
@@ -315,3 +753,130 @@ def test_cli_storage_uri_inspect_and_db_names(monkeypatch, tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["storage_uri"] == "s3://bucket/root"
     assert payload["databases"][0]["collections"][0]["count"] == 3
+
+    monkeypatch.setenv("TINYMONGO_STORAGE_URI", "gs://env-bucket/root")
+    assert cli._db_names(str(tmp_path), "parquet") == ["app"]
+    assert clients[-1].storage_uri == "gs://env-bucket/root"
+
+    assert (
+        cli.main(
+            [
+                "inspect",
+                str(tmp_path),
+                "--backend",
+                "parquet",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["storage_uri"] == "gs://env-bucket/root"
+
+    monkeypatch.setenv("TINYMONGO_POSTGRES_DSN", "postgresql://env-db")
+    assert cli._db_names(str(tmp_path), "postgres") == ["app"]
+    assert clients[-1].dsn == "postgresql://env-db"
+
+
+def test_cli_migrate_reports_environment_only_remote_configuration(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    calls = []
+
+    class EmptyClient:
+        def __init__(self, path, backend, storage_uri=None, dsn=None):
+            calls.append((path, backend, storage_uri, dsn))
+
+        def list_database_names(self):
+            return []
+
+    monkeypatch.setattr(cli, "TinyMongoClient", EmptyClient)
+    monkeypatch.setenv("TINYMONGO_STORAGE_URI", "s3://source/root")
+    monkeypatch.setenv("TINYMONGO_POSTGRES_DSN", "postgresql://env-db")
+
+    assert (
+        cli.main(
+            [
+                "migrate",
+                str(tmp_path / "unused-source"),
+                str(tmp_path / "unused-target"),
+                "--from-backend",
+                "parquet",
+                "--to-backend",
+                "postgres",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source_uri"] == "s3://source/root"
+    assert payload["target_uri"] is None
+    assert payload["source_dsn_configured"] is False
+    assert payload["target_dsn_configured"] is True
+    assert calls == [
+        (
+            str(tmp_path / "unused-source"),
+            "parquet",
+            "s3://source/root",
+            None,
+        ),
+        (
+            str(tmp_path / "unused-target"),
+            "postgres",
+            None,
+            "postgresql://env-db",
+        ),
+        (
+            str(tmp_path / "unused-source"),
+            "parquet",
+            "s3://source/root",
+            None,
+        ),
+    ]
+
+
+def test_cli_effective_remote_configuration_precedence(monkeypatch, tmp_path):
+    names = (
+        "TINYMONGO_POSTGRES_DSN",
+        "TINYMONGO_POSTGRESQL_DSN",
+        "DATABASE_URL",
+        "TINYMONGO_MYSQL_DSN",
+        "TINYMONGO_MARIADB_DSN",
+        "MYSQL_URL",
+        "MARIADB_URL",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+    assert cli._effective_dsn("mysql") is None
+    assert cli._effective_dsn("tinydb") is None
+
+    monkeypatch.setenv("MARIADB_URL", "mysql://mariadb-url")
+    monkeypatch.setenv("MYSQL_URL", "mysql://mysql-url")
+    monkeypatch.setenv("TINYMONGO_MARIADB_DSN", "mysql://mariadb-dsn")
+    monkeypatch.setenv("TINYMONGO_MYSQL_DSN", "mysql://mysql-dsn")
+
+    assert cli._effective_dsn("mariadb") == "mysql://mysql-dsn"
+    assert cli._effective_dsn("mysql", "mysql://explicit") == "mysql://explicit"
+    assert cli._effective_dsn("tinydb", "mysql://irrelevant") is None
+
+    monkeypatch.setenv("TINYMONGO_STORAGE_URI", "s3://environment/root")
+    assert cli._effective_storage_uri("tinydb", "s3://irrelevant/root") is None
+    assert (
+        cli._client(
+            str(tmp_path / "local-parquet"),
+            "parquet",
+            storage_uri="",
+        )._storage_uri
+        is None
+    )
+    assert (
+        cli._client(
+            str(tmp_path / "remote"),
+            "mysql",
+            dsn="",
+        )._dsn
+        is None
+    )

--- a/tests/test_cli_replacement_safety.py
+++ b/tests/test_cli_replacement_safety.py
@@ -1,0 +1,62 @@
+"""Fault-injection coverage for destructive CLI collection replacement."""
+
+import copy
+
+import pytest
+
+from tinymongo import cli
+
+
+class _Database:
+    def __init__(self, collection):
+        self.collection = collection
+
+    def __getitem__(self, _name):
+        return self.collection
+
+
+class _FaultingCollection:
+    def __init__(self, documents, fail_delete=False, fail_insert=False):
+        self.documents = copy.deepcopy(documents)
+        self.fail_delete = fail_delete
+        self.fail_insert = fail_insert
+
+    def find(self, _filter):
+        return copy.deepcopy(self.documents)
+
+    def list_indexes(self):
+        return [{"name": "_id_", "key": [("_id", 1)]}]
+
+    def delete_many(self, _filter):
+        if self.fail_delete:
+            self.fail_delete = False
+            self.documents = self.documents[1:]
+            raise RuntimeError("delete interrupted")
+        self.documents = []
+
+    def insert_many(self, documents):
+        if self.fail_insert:
+            self.fail_insert = False
+            self.documents.extend(copy.deepcopy(documents[:1]))
+            raise RuntimeError("insert interrupted")
+        self.documents.extend(copy.deepcopy(documents))
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        ("fail_delete", "delete interrupted"),
+        ("fail_insert", "insert interrupted"),
+    ],
+)
+def test_replace_collection_restores_previous_data_after_destructive_failure(
+    failure, message
+):
+    previous = [{"_id": "old-1"}, {"_id": "old-2"}]
+    replacement = [{"_id": "new-1"}, {"_id": "new-2"}]
+    collection = _FaultingCollection(previous, **{failure: True})
+
+    with pytest.raises(RuntimeError, match=message):
+        cli._replace_collection(_Database(collection), "items", replacement)
+
+    assert collection.documents == previous

--- a/tests/test_collection_attributes.py
+++ b/tests/test_collection_attributes.py
@@ -1,0 +1,97 @@
+import asyncio
+
+import pytest
+
+import tinymongo as tm
+from tinymongo.asyncio import AsyncTinyMongoClient
+
+
+BACKENDS = ("memory", "tinydb", "sqlite", "duckdb", "parquet")
+
+
+def _client_location(tmp_path, backend):
+    if backend == "memory":
+        return "memory://collection-attributes-{0}".format(tmp_path.name)
+    return str(tmp_path / backend)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_collection_attributes_select_dotted_children_across_backends(
+    tmp_path, backend
+):
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+
+    client = tm.TinyMongoClient(_client_location(tmp_path, backend), backend=backend)
+    try:
+        database = client.app
+        parent = database.users
+        child = parent.archive
+
+        assert child is not parent
+        assert child.name == "users.archive"
+        assert child.full_name == "app.users.archive"
+        assert parent["archive"].name == "users.archive"
+
+        with pytest.raises(AttributeError, match="users\\._private"):
+            parent._private
+        with pytest.raises(AttributeError, match="_private"):
+            database._private
+        assert parent["_private"].name == "users._private"
+        assert database["users._private"].name == "users._private"
+
+        parent.insert_one({"_id": "parent"})
+        child.insert_one({"_id": "child"})
+        assert parent.find_one({})["_id"] == "parent"
+        assert child.find_one({})["_id"] == "child"
+
+        with pytest.raises(TypeError, match="find_oni.*no such method exists"):
+            parent.find_oni({"_id": "parent"})
+        with pytest.raises(TypeError, match="pingg.*TinyMongoDatabase"):
+            database.pingg()
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_async_collection_attributes_select_dotted_children_across_backends(
+    tmp_path, backend
+):
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            _client_location(tmp_path, "async-{0}".format(backend)),
+            backend=backend,
+        )
+        try:
+            database = client.app
+            parent = database.users
+            child = parent.archive
+
+            assert child is not parent
+            assert child.name == "users.archive"
+            assert child.full_name == "app.users.archive"
+            assert parent["archive"].name == "users.archive"
+
+            with pytest.raises(AttributeError, match="users\\._private"):
+                parent._private
+            with pytest.raises(AttributeError, match="_private"):
+                database._private
+            assert parent["_private"].name == "users._private"
+            assert database["users._private"].name == "users._private"
+
+            await parent.insert_one({"_id": "parent"})
+            await child.insert_one({"_id": "child"})
+            assert (await parent.find_one({}))["_id"] == "parent"
+            assert (await child.find_one({}))["_id"] == "child"
+
+            with pytest.raises(TypeError, match="find_oni.*no such method exists"):
+                parent.find_oni({"_id": "parent"})
+            with pytest.raises(TypeError, match="pingg.*AsyncTinyMongoDatabase"):
+                database.pingg()
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -14,7 +14,7 @@ from tinymongo import cli
 from tinymongo import tinymongo as core
 from tinymongo import parquet_storage as ps
 from tinymongo import storage_backends as sb
-from tinymongo.errors import DuplicateKeyError, OperationFailure
+from tinymongo.errors import BulkWriteError, DuplicateKeyError, OperationFailure
 from tinymongo.results import (
     DeleteResult,
     InsertManyResult,
@@ -569,11 +569,11 @@ def test_collection_error_and_compatibility_edges(tmp_path):
     client = tm.TinyMongoClient(str(tmp_path / "db"))
     collection = client.db.collection
     assert repr(collection) == "collection"
-    assert collection.anything is collection
+    assert collection.anything.tablename == "collection.anything"
 
     with pytest.raises(ValueError):
         collection.insert_one(["not", "a", "dict"])
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         collection.insert_many({"not": "a list"})
     with pytest.raises(AttributeError):
         getattr(client, "_private")
@@ -586,7 +586,7 @@ def test_collection_error_and_compatibility_edges(tmp_path):
         collection.insert_one({"_id": 0}, bypass_document_validation=True)
     with pytest.raises(DuplicateKeyError):
         collection.insert_one({"_id": 0})
-    with pytest.raises(DuplicateKeyError):
+    with pytest.raises(BulkWriteError):
         collection.insert_many([{"_id": "dupe"}, {"_id": "dupe"}])
     assert collection.insert_many([{"name": "generated-many"}]).inserted_ids[0]
 
@@ -720,7 +720,7 @@ def test_collection_write_and_no_match_edges(tmp_path):
     assert c.drop() is True
     c.insert_many([{"_id": 1}, {"_id": 2}], bypass_document_validation=True)
     assert c.delete_many({}).deleted_count == 3
-    assert "_default" in db.collection_names()
+    assert "_default" not in db.collection_names()
 
 
 def test_update_operator_error_edges(tmp_path):
@@ -781,7 +781,7 @@ def test_database_refresh_ignores_close_errors(tmp_path):
 
     db.tinydb = BadTinyDB()
     db._refresh_table()
-    assert "_default" in db.collection_names()
+    assert "_default" not in db.collection_names()
 
 
 def test_parquet_storage_uri_client_paths_and_listing(tmp_path, monkeypatch):
@@ -845,6 +845,78 @@ def test_parquet_storage_uri_env_var(tmp_path, monkeypatch):
     assert client.app._path == "gs://bucket/root/app.parquet"
 
 
+def test_nonlocal_clients_skip_placeholder_folders_and_validate_eagerly(
+    tmp_path,
+    monkeypatch,
+):
+    remote_path = tmp_path / "unused-remote"
+    tm.TinyMongoClient(
+        str(remote_path),
+        backend="postgres",
+        dsn="postgresql://configured",
+    )
+    assert not remote_path.exists()
+
+    object_path = tmp_path / "unused-object"
+    tm.TinyMongoClient(
+        str(object_path),
+        backend="parquet",
+        storage_uri="s3://bucket/root",
+    )
+    assert not object_path.exists()
+
+    with pytest.raises(ValueError) as error:
+        tm.TinyMongoClient(str(tmp_path / "invalid"), backend="not-a-backend")
+    assert "json" in str(error.value)
+    assert "postgresql" in str(error.value)
+    assert "mysql" in str(error.value)
+
+    monkeypatch.setenv("TINYMONGO_STORAGE_URI", "s3://unrelated/root")
+    local_path = tmp_path / "local-json"
+    local = tm.TinyMongoClient(str(local_path))
+    local.app.items.insert_one({"_id": 1})
+    assert local.server_info()["storageUri"] is None
+    assert local._dsn_from_env("tinydb") is None
+    assert local.drop_database("app") is None
+    assert local.list_database_names() == []
+    assert not (local_path / "app.json").exists()
+
+    local_parquet_path = tmp_path / "local-parquet"
+    local_parquet = tm.TinyMongoClient(
+        str(local_parquet_path),
+        backend="parquet",
+        storage_uri="",
+    )
+    assert local_parquet._storage_uri is None
+    assert local_parquet_path.is_dir()
+
+    monkeypatch.setenv("TINYMONGO_POSTGRES_DSN", "postgresql://environment")
+    remote_without_dsn = tm.TinyMongoClient(
+        str(tmp_path / "remote-without-dsn"),
+        backend="postgres",
+        dsn="",
+    )
+    assert remote_without_dsn.server_info()["dsnConfigured"] is False
+
+
+def test_closed_client_rejects_metadata_and_listing_operations():
+    client = tm.TinyMongoClient(backend="memory")
+    client.close()
+
+    operations = (
+        client.server_info,
+        client.capabilities,
+        lambda: client.supports("projections"),
+        client.list_database_names,
+        client.list_databases,
+        client.database_names,
+        lambda: client.drop_database("missing"),
+    )
+    for operation in operations:
+        with pytest.raises(InvalidOperation, match="closed TinyMongoClient"):
+            operation()
+
+
 def test_mysql_dsn_env_var(tmp_path, monkeypatch):
     monkeypatch.setenv("TINYMONGO_MYSQL_DSN", "mysql://user:pass@localhost/db")
 
@@ -863,9 +935,10 @@ def test_cursor_sort_order_branches():
         ]
     )
 
-    assert cursor.sort("value", 1).count() == 4
+    with pytest.warns(tm.TinyMongoUnsupportedWarning):
+        assert cursor.sort("value", 1).count() == 4
     assert cursor.sort("value").count() == 4
-    assert cursor._order(True) == (5, True)
+    assert cursor._order(True) == (7, True)
     assert cursor._order([1, "a"], None)[0] == 4
     assert cursor.sort([("value", 1), ("_id", -1)]).count() == 4
     assert (

--- a/tests/test_durable_indexes.py
+++ b/tests/test_durable_indexes.py
@@ -9,6 +9,7 @@ import pytest
 
 import tinymongo
 from tinymongo.errors import (
+    BulkWriteError,
     DuplicateKeyError,
     OperationFailure,
     TinyMongoNotSupportedError,
@@ -186,7 +187,9 @@ def test_unique_index_rejects_existing_duplicates_without_adding_metadata(
     assert users.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
 
 
-def test_unique_insert_operations_fail_atomically(durable_index_backend):
+def test_unique_insert_operations_follow_single_and_bulk_semantics(
+    durable_index_backend,
+):
     client = durable_index_backend.open()
     users = client.app.users
     users.create_index("email", unique=True)
@@ -204,14 +207,14 @@ def test_unique_insert_operations_fail_atomically(durable_index_backend):
             {"_id": 1, "email": "replacement@example.com"},
             bypass_document_validation=True,
         )
-    with pytest.raises(DuplicateKeyError):
+    with pytest.raises(BulkWriteError) as existing_conflict:
         users.insert_many(
             [
                 {"_id": 4, "email": "grace@example.com"},
                 {"_id": 5, "email": "ada@example.com"},
             ]
         )
-    with pytest.raises(DuplicateKeyError):
+    with pytest.raises(BulkWriteError) as batch_conflict:
         users.insert_many(
             [
                 {"_id": 6, "email": "hopper@example.com"},
@@ -219,7 +222,13 @@ def test_unique_insert_operations_fail_atomically(durable_index_backend):
             ]
         )
 
-    assert list(users.find({})) == [{"_id": 1, "email": "ada@example.com"}]
+    assert existing_conflict.value.details["nInserted"] == 1
+    assert batch_conflict.value.details["nInserted"] == 1
+    assert list(users.find({})) == [
+        {"_id": 1, "email": "ada@example.com"},
+        {"_id": 4, "email": "grace@example.com"},
+        {"_id": 6, "email": "hopper@example.com"},
+    ]
 
 
 def test_unique_update_replace_and_upsert_fail_atomically(durable_index_backend):

--- a/tests/test_exact_id_semantics.py
+++ b/tests/test_exact_id_semantics.py
@@ -1,0 +1,161 @@
+"""Regression tests for exact, BSON-aware document identity."""
+
+from collections import UserDict
+
+import pytest
+
+import tinymongo as tm
+from tinymongo.errors import BulkWriteError, DuplicateKeyError
+from tinymongo.table_backends import matches_filter
+from tinymongo.tinymongo import _cached_value_matches
+
+
+def test_embedded_document_equality_preserves_field_order(tmp_path):
+    collection = tm.TinyMongoClient(tmp_path).db.items
+    collection.insert_one(
+        {
+            "_id": "ordered",
+            "value": {"first": 1, "second": 2},
+        }
+    )
+
+    assert collection.find_one({"value": {"first": 1.0, "second": 2.0}}) is not None
+    assert collection.find_one({"value": {"second": 2, "first": 1}}) is None
+    assert not matches_filter(
+        {"value": {"first": 1, "second": 2}},
+        {"value": {"second": 2, "first": 1}},
+    )
+
+
+def test_reordered_embedded_document_ids_remain_distinct(tmp_path):
+    collection = tm.TinyMongoClient(tmp_path).db.items
+    first_id = {"first": 1, "second": 2}
+    reordered_id = {"second": 2, "first": 1}
+
+    result = collection.insert_many(
+        [
+            {"_id": first_id, "label": "first"},
+            {"_id": reordered_id, "label": "reordered"},
+        ]
+    )
+
+    assert result.inserted_ids == [first_id, reordered_id]
+    assert collection.find_one({"_id": first_id})["label"] == "first"
+    assert collection.find_one({"_id": reordered_id})["label"] == "reordered"
+
+
+def test_equivalent_embedded_document_ids_are_duplicates(tmp_path):
+    collection = tm.TinyMongoClient(tmp_path).db.items
+
+    with pytest.raises(BulkWriteError) as error:
+        collection.insert_many(
+            [
+                {"_id": {"number": 1}, "label": "integer"},
+                {"_id": {"number": 1.0}, "label": "float"},
+            ]
+        )
+
+    assert error.value.details["nInserted"] == 1
+
+
+def test_exact_id_mutations_do_not_match_array_members(tmp_path):
+    collection = tm.TinyMongoClient(tmp_path).db.items
+    array_id = [1, 2]
+    collection.insert_many(
+        [
+            {"_id": array_id, "label": "array"},
+            {"_id": 1, "label": "scalar"},
+        ]
+    )
+
+    update = collection.update_one({"_id": 1}, {"$set": {"updated": True}})
+    assert update.matched_count == 1
+    assert collection.find_one({"_id": 1})["updated"] is True
+    assert "updated" not in collection.find_one({"_id": array_id})
+
+    replacement = collection.replace_one({"_id": 1}, {"label": "replacement"})
+    assert replacement.matched_count == 1
+    assert collection.find_one({"_id": 1})["label"] == "replacement"
+    assert collection.find_one({"_id": array_id})["label"] == "array"
+
+    deletion = collection.delete_one({"_id": 1})
+    assert deletion.deleted_count == 1
+    assert collection.find_one({"_id": 1}) is None
+    assert collection.find_one({"_id": array_id})["label"] == "array"
+
+
+@pytest.mark.parametrize("backend", ["tinydb", "memory"])
+def test_compound_and_logical_id_filters_keep_exact_identity(tmp_path, backend):
+    client = tm.TinyMongoClient(str(tmp_path / backend), backend=backend)
+    collection = client.db.items
+    array_id = [1, 2]
+    collection.insert_many(
+        [
+            {"_id": array_id, "score": 1},
+            {"_id": 1, "score": 0},
+        ]
+    )
+
+    compound = {"_id": 1, "score": {"$gt": 0}}
+    logical = {"$and": [{"_id": 1}, {"score": {"$gt": 0}}]}
+    assert collection.find_one(compound) is None
+    assert collection.find_one(logical) is None
+    assert collection.update_one(compound, {"$set": {"wrong": True}}).matched_count == 0
+
+    exact_scalar = {"$and": [{"_id": 1}, {"score": 0}]}
+    update = collection.update_one(exact_scalar, {"$set": {"updated": True}})
+    assert update.matched_count == 1
+    assert collection.find_one({"_id": 1})["updated"] is True
+    assert "updated" not in collection.find_one({"_id": array_id})
+
+    assert collection.delete_one({"_id": 1, "updated": True}).deleted_count == 1
+    assert collection.find_one({"_id": 1}) is None
+    assert collection.find_one({"_id": array_id}) is not None
+    client.close()
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["tinydb", "memory", "sqlite", "duckdb", "parquet"],
+)
+def test_mapping_subclasses_share_document_id_identity(tmp_path, backend):
+    client = tm.TinyMongoClient(str(tmp_path / backend), backend=backend)
+    collection = client.db.items
+    document_id = {"z": 1, "a": 2}
+    equivalent = UserDict([("z", 1.0), ("a", 2.0)])
+    collection.insert_one({"_id": document_id, "label": "original"})
+
+    assert collection.find_one({"_id": equivalent})["label"] == "original"
+    with pytest.raises(DuplicateKeyError):
+        collection.insert_one({"_id": equivalent, "label": "duplicate"})
+
+    assert collection.count_documents({}) == 1
+    client.close()
+
+
+def test_exact_id_operator_queries_and_parser_write_paths(tmp_path):
+    collection = tm.TinyMongoClient(tmp_path).db.items
+    collection.insert_many(
+        [
+            {"_id": 1, "score": 1},
+            {"_id": 2, "score": 2},
+        ]
+    )
+
+    assert collection.find_one({"_id": {"$eq": 1}})["_id"] == 1
+    assert collection.find_one({"_id": {"$in": [2]}})["_id"] == 2
+    assert _cached_value_matches([1, 2], 2, None)
+
+    update = collection.update_one(
+        {"score": {"$gt": 1}},
+        {"$set": {"updated": True}},
+    )
+    assert update.matched_count == 1
+    assert collection.find_one({"_id": 2})["updated"] is True
+
+    replacement = collection.replace_one(
+        {"score": {"$lt": 2}},
+        {"score": 10},
+    )
+    assert replacement.matched_count == 1
+    assert collection.find_one({"_id": 1})["score"] == 10

--- a/tests/test_insert_many_semantics.py
+++ b/tests/test_insert_many_semantics.py
@@ -1,0 +1,440 @@
+import asyncio
+import builtins
+from collections import UserDict
+from contextlib import contextmanager
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+import tinymongo
+from tinymongo.asyncio import AsyncTinyMongoClient
+from tinymongo.errors import BulkWriteError, DuplicateKeyError
+from tinymongo.tinymongo import TinyMongoCollection
+
+
+BACKENDS = ("memory", "tinydb", "sqlite", "duckdb", "parquet")
+
+
+def _client(tmp_path, backend):
+    folder = (
+        "memory://insert-many-{0}".format(uuid4().hex)
+        if backend == "memory"
+        else str(tmp_path / backend)
+    )
+    return tinymongo.TinyMongoClient(folder, backend=backend)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ordered_insert_many_stops_at_first_duplicate(tmp_path, backend):
+    client = _client(tmp_path, backend)
+    collection = client.app.items
+    collection.insert_one({"_id": "seed"})
+    documents = [{"name": "first"}, {"_id": "seed"}, {"name": "last"}]
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many(documents)
+
+    details = caught.value.details
+    assert details["nInserted"] == 1
+    assert details["writeConcernErrors"] == []
+    assert len(details["writeErrors"]) == 1
+    assert details["writeErrors"][0] == {
+        "index": 1,
+        "code": 11000,
+        "errmsg": details["writeErrors"][0]["errmsg"],
+        "keyPattern": {"_id": 1},
+        "keyValue": {"_id": "seed"},
+        "op": documents[1],
+    }
+    assert "index: _id_" in details["writeErrors"][0]["errmsg"]
+    assert details["writeErrors"][0]["op"] is documents[1]
+    assert all("_id" in document for document in documents)
+    assert {document["_id"] for document in collection.find({})} == {
+        "seed",
+        documents[0]["_id"],
+    }
+    client.close()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_unordered_insert_many_continues_and_reports_every_duplicate(tmp_path, backend):
+    client = _client(tmp_path, backend)
+    collection = client.app.items
+    collection.insert_one({"_id": "seed"})
+    documents = [
+        {"_id": "first"},
+        {"_id": "seed"},
+        {"_id": "seed"},
+        {"_id": "last"},
+    ]
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many(documents, ordered=False)
+
+    details = caught.value.details
+    assert details["nInserted"] == 2
+    assert [error["index"] for error in details["writeErrors"]] == [1, 2]
+    assert [error["code"] for error in details["writeErrors"]] == [11000, 11000]
+    assert {document["_id"] for document in collection.find({})} == {
+        "seed",
+        "first",
+        "last",
+    }
+    client.close()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    ("ordered", "expected_inserted"),
+    [(True, {"seed", "first"}), (False, {"seed", "first", "last"})],
+)
+def test_insert_many_applies_ordering_to_unique_index_failures(
+    tmp_path, backend, ordered, expected_inserted
+):
+    client = _client(tmp_path, backend)
+    collection = client.app.users
+    collection.create_index("email", unique=True)
+    collection.insert_one({"_id": "seed", "email": "taken@example.com"})
+    documents = [
+        {"_id": "first", "email": "first@example.com"},
+        {"_id": "duplicate", "email": "taken@example.com"},
+        {"_id": "last", "email": "last@example.com"},
+    ]
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many(documents, ordered=ordered)
+
+    details = caught.value.details
+    assert details["nInserted"] == len(expected_inserted) - 1
+    assert details["writeErrors"][0]["index"] == 1
+    assert details["writeErrors"][0]["keyPattern"] == {"email": 1}
+    assert details["writeErrors"][0]["keyValue"] == {"email": "taken@example.com"}
+    assert "index: email_1" in details["writeErrors"][0]["errmsg"]
+    assert {document["_id"] for document in collection.find({})} == expected_inserted
+    client.close()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("ordered", [True, False])
+def test_insert_many_serialization_preflight_is_all_or_nothing(
+    tmp_path, backend, ordered
+):
+    client = _client(tmp_path, backend)
+    collection = client.app.items
+    documents = [
+        {"name": "first"},
+        {"name": "invalid", "value": object()},
+        {"name": "last"},
+    ]
+
+    with pytest.raises(TypeError):
+        collection.insert_many(documents, ordered=ordered)
+
+    assert all("_id" in document for document in documents)
+    assert collection.count_documents({}) == 0
+    client.close()
+
+
+def test_async_insert_many_uses_the_same_unordered_semantics():
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            "memory://async-insert-many-{0}".format(uuid4().hex),
+            backend="memory",
+        )
+        collection = client.app.items
+        await collection.insert_one({"_id": "seed"})
+        documents = [
+            {"_id": "first"},
+            {"_id": "seed"},
+            {"_id": "last"},
+        ]
+
+        with pytest.raises(BulkWriteError) as caught:
+            await collection.insert_many(documents, ordered=False)
+
+        assert caught.value.details["nInserted"] == 2
+        assert [error["index"] for error in caught.value.details["writeErrors"]] == [1]
+        assert {
+            document["_id"] for document in await collection.find({}).to_list()
+        } == {"seed", "first", "last"}
+        await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_insert_many_validates_batch_and_ordering_arguments(tmp_path):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.items
+
+    with pytest.raises(TypeError, match="non-empty"):
+        collection.insert_many([])
+    with pytest.raises(TypeError, match="ordered"):
+        collection.insert_many([{"_id": 1}], ordered=1)
+    with pytest.raises(TypeError, match="each document"):
+        collection.insert_many([{"_id": 1}, None])
+
+    assert collection.count_documents({}) == 0
+    client.close()
+
+
+@pytest.mark.parametrize(
+    "documents",
+    [
+        ({"_id": "tuple-one"}, {"_id": "tuple-two"}),
+        iter(({"_id": "generator-one"}, {"_id": "generator-two"})),
+    ],
+)
+def test_insert_many_accepts_document_iterables(tmp_path, documents):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.items
+
+    result = collection.insert_many(documents)
+
+    assert result.inserted_ids == [
+        document["_id"] for document in collection.find({}).sort("_id", 1)
+    ]
+    client.close()
+
+
+def test_insert_many_accepts_mutable_mapping_documents(tmp_path):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.items
+    document = UserDict({"label": "mapping"})
+
+    result = collection.insert_many((document,))
+
+    assert result.inserted_ids == [document["_id"]]
+    assert collection.find_one({"_id": document["_id"]})["label"] == "mapping"
+    client.close()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_embedded_document_ids_keep_boolean_and_number_identity_distinct(
+    tmp_path, backend
+):
+    client = _client(tmp_path, backend)
+    collection = client.app.items
+
+    result = collection.insert_many(
+        [
+            {"_id": {"value": True}, "label": "boolean"},
+            {"_id": {"value": 1}, "label": "number"},
+        ]
+    )
+
+    assert result.inserted_ids == [{"value": True}, {"value": 1}]
+    assert sorted(document["label"] for document in collection.find({})) == [
+        "boolean",
+        "number",
+    ]
+    client.close()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_explicit_none_id_is_preserved_and_remains_unique(tmp_path, backend):
+    client = _client(tmp_path, backend)
+    singles = client.app.singles
+    document = {"_id": None, "label": "explicit"}
+
+    result = singles.insert_one(document)
+
+    assert result.inserted_id is None
+    assert document["_id"] is None
+    assert singles.find_one({"_id": None})["label"] == "explicit"
+    with pytest.raises(DuplicateKeyError):
+        singles.insert_one({"_id": None, "label": "duplicate"})
+
+    batch = client.app.batch
+    batch_documents = [{"_id": None}, {"_id": "other"}]
+    batch_result = batch.insert_many(batch_documents)
+    assert batch_result.inserted_ids == [None, "other"]
+    with pytest.raises(BulkWriteError) as caught:
+        batch.insert_many([{"_id": None}], ordered=False)
+    assert caught.value.details["nInserted"] == 0
+    client.close()
+
+
+def test_tinydb_physical_id_operations_do_not_use_array_membership(tmp_path):
+    client = _client(tmp_path, "tinydb")
+    collection = client.app.items
+    collection.insert_many(
+        [
+            {"_id": 1, "kind": "scalar"},
+            {"_id": [1, 2], "kind": "array"},
+        ]
+    )
+
+    collection.update_one({"_id": 1}, {"$set": {"updated": True}})
+    assert collection.find_one({"_id": 1})["updated"] is True
+    assert collection.find_one({"_id": [1, 2]}).get("updated") is None
+
+    collection.delete_one({"_id": 1})
+    assert collection.find_one({"_id": 1}) is None
+    assert collection.find_one({"_id": [1, 2]})["kind"] == "array"
+    client.close()
+
+
+def test_tinydb_rejects_tuple_and_list_ids_in_the_same_batch(tmp_path):
+    client = _client(tmp_path, "tinydb")
+    collection = client.app.items
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many([{"_id": (1, 2)}, {"_id": [1, 2]}])
+
+    assert caught.value.details["nInserted"] == 1
+    assert [document["_id"] for document in collection.find({})] == [[1, 2]]
+    client.close()
+
+
+def test_insert_many_all_duplicate_batch_reports_zero_inserts(tmp_path):
+    client = _client(tmp_path, "tinydb")
+    collection = client.app.items
+    collection.insert_one({"_id": "seed"})
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many([{"_id": "seed"}], ordered=False)
+
+    assert caught.value.details["nInserted"] == 0
+    assert caught.value.details["writeErrors"][0]["index"] == 0
+    assert collection.count_documents({}) == 1
+    client.close()
+
+
+def test_insert_many_unique_missing_field_reports_null_key(tmp_path):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.items
+    collection.create_index("email", unique=True)
+    collection.insert_one({"_id": "seed"})
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many([{"_id": "duplicate-missing"}])
+
+    assert caught.value.details["writeErrors"][0]["keyValue"] == {"email": None}
+    assert collection.count_documents({}) == 1
+    client.close()
+
+
+def test_bulk_write_error_remains_available_without_pymongo(monkeypatch):
+    original_import = builtins.__import__
+
+    def import_without_pymongo(name, *args, **kwargs):
+        if name == "pymongo" or name.startswith("pymongo."):
+            raise ImportError("pymongo intentionally unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_pymongo)
+    namespace = runpy.run_path(
+        str(Path(tinymongo.__file__).with_name("errors.py")),
+        run_name="tinymongo_errors_without_pymongo",
+    )
+    error = namespace["BulkWriteError"](
+        {
+            "writeErrors": [{"index": 0, "code": 11000}],
+            "writeConcernErrors": [],
+            "nInserted": 0,
+        }
+    )
+
+    assert error.code == 65
+    assert error.details["writeErrors"][0]["index"] == 0
+    assert error.timeout is False
+
+
+def test_native_duplicate_race_is_replanned_as_a_bulk_write_error():
+    class RacingEngine:
+        def __init__(self):
+            self.documents = []
+            self.attempts = 0
+
+        @contextmanager
+        def _write_lock(self):
+            yield
+
+        def find(self, _collection, _filter):
+            return [dict(document) for document in self.documents]
+
+        def get_index_specs(self, _collection):
+            return []
+
+        def insert_many(
+            self,
+            _collection,
+            documents,
+            bypass_document_validation=False,
+        ):
+            self.attempts += 1
+            if self.attempts == 1:
+                self.documents.append({"_id": "raced"})
+                raise DuplicateKeyError("concurrent duplicate")
+            self.documents.extend(dict(document) for document in documents)
+            return list(range(len(documents)))
+
+    engine = RacingEngine()
+    collection = TinyMongoCollection(
+        "items",
+        SimpleNamespace(name="app", engine=engine),
+    )
+    documents = [
+        {"_id": "first"},
+        {"_id": "raced"},
+        {"_id": "last"},
+    ]
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many(documents, ordered=False)
+
+    assert engine.attempts == 2
+    assert caught.value.details["nInserted"] == 2
+    assert [error["index"] for error in caught.value.details["writeErrors"]] == [1]
+    assert {document["_id"] for document in engine.documents} == {
+        "first",
+        "raced",
+        "last",
+    }
+
+
+@pytest.mark.parametrize("ordered", [True, False])
+def test_persistent_native_duplicate_still_uses_bulk_write_error_shape(ordered):
+    class RejectingEngine:
+        def __init__(self):
+            self.attempts = 0
+
+        @contextmanager
+        def _write_lock(self):
+            yield
+
+        def find(self, _collection, _filter):
+            return []
+
+        def get_index_specs(self, _collection):
+            return []
+
+        def insert_many(
+            self,
+            _collection,
+            _documents,
+            bypass_document_validation=False,
+        ):
+            self.attempts += 1
+            raise DuplicateKeyError("persistent native duplicate")
+
+    engine = RejectingEngine()
+    collection = TinyMongoCollection(
+        "items",
+        SimpleNamespace(name="app", engine=engine),
+    )
+    document = {"_id": "conflict"}
+
+    with pytest.raises(BulkWriteError) as caught:
+        collection.insert_many([document], ordered=ordered)
+
+    assert engine.attempts == 3
+    assert caught.value.details["nInserted"] == 0
+    assert caught.value.details["writeErrors"][0]["index"] == 0
+    assert caught.value.details["writeErrors"][0]["op"] is document
+    assert "persistent native duplicate" in (
+        caught.value.details["writeErrors"][0]["errmsg"]
+    )

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -1,0 +1,288 @@
+"""Focused coverage for small compatibility and backend branches."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tinymongo import bson_types, cli
+from tinymongo import tinymongo as core
+from tinymongo.errors import DuplicateKeyError
+from tinymongo.tinymongo import TinyMongoCollection
+
+
+def test_bson_capabilities_are_enabled_atomically(monkeypatch):
+    marker = object()
+
+    monkeypatch.setattr(bson_types, "_ObjectId", marker)
+    monkeypatch.setattr(bson_types, "_Binary", marker)
+    assert bson_types.bson_capabilities() == {
+        "objectid": True,
+        "binary": True,
+    }
+
+    monkeypatch.setattr(bson_types, "_Binary", None)
+    assert bson_types.bson_capabilities() == {
+        "objectid": False,
+        "binary": False,
+    }
+
+    monkeypatch.setattr(bson_types, "_ObjectId", None)
+    monkeypatch.setattr(bson_types, "_Binary", marker)
+    assert bson_types.bson_capabilities() == {
+        "objectid": False,
+        "binary": False,
+    }
+
+
+def test_bson_recursive_equality_handles_mixed_and_unregistered_values():
+    marker = object()
+
+    assert bson_types.bson_values_equal({"value": 1}, 1) is False
+    assert bson_types.bson_values_equal(marker, marker) is True
+    assert bson_types.bson_values_equal(object(), object()) is False
+
+
+def test_cli_copies_unique_and_nonunique_indexes():
+    class Source:
+        def list_indexes(self):
+            return [
+                {"name": "_id_", "key": [("_id", 1)]},
+                {"name": "name_1", "key": [("name", 1)]},
+                {
+                    "name": "email_1",
+                    "key": [("email", 1)],
+                    "unique": True,
+                },
+            ]
+
+    class Target:
+        def __init__(self):
+            self.created = []
+
+        def create_index(self, keys, **options):
+            self.created.append((keys, options))
+
+    target = Target()
+
+    cli._copy_indexes(Source(), target)
+
+    assert target.created == [
+        ([("name", 1)], {"name": "name_1"}),
+        ([("email", 1)], {"name": "email_1", "unique": True}),
+    ]
+
+
+class _ReplacementCollection:
+    def __init__(self, previous, failing_insert_calls):
+        self.documents = list(previous)
+        self.failing_insert_calls = set(failing_insert_calls)
+        self.insert_calls = 0
+
+    def list_indexes(self):
+        return [{"name": "_id_", "key": [("_id", 1)]}]
+
+    def find(self, _filter):
+        return list(self.documents)
+
+    def delete_many(self, _filter):
+        self.documents = []
+
+    def insert_many(self, documents):
+        self.insert_calls += 1
+        if self.insert_calls in self.failing_insert_calls:
+            raise RuntimeError("insert failure {0}".format(self.insert_calls))
+        self.documents.extend(documents)
+
+
+@pytest.mark.parametrize("previous", [[{"_id": "old"}], []])
+def test_cli_replace_collection_restores_or_preserves_previous_data(previous):
+    collection = _ReplacementCollection(previous, failing_insert_calls={1})
+
+    with pytest.raises(RuntimeError, match="insert failure 1"):
+        cli._replace_collection(
+            {"items": collection},
+            "items",
+            [{"_id": "new"}],
+        )
+
+    assert collection.documents == previous
+
+
+def test_cli_replace_collection_reports_a_rollback_failure():
+    collection = _ReplacementCollection(
+        [{"_id": "old"}],
+        failing_insert_calls={1, 2},
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="previous data could not be restored",
+    ) as caught:
+        cli._replace_collection(
+            {"items": collection},
+            "items",
+            [{"_id": "new"}],
+        )
+
+    assert isinstance(caught.value.__cause__, RuntimeError)
+    assert str(caught.value.__cause__) == "insert failure 2"
+
+
+def test_cli_migrate_records_an_empty_collection_without_inserting(monkeypatch, capsys):
+    class SourceCollection:
+        def __init__(self, documents):
+            self.documents = documents
+
+        def find(self, _filter):
+            return self.documents
+
+    class TargetCollection:
+        def __init__(self, documents=None):
+            self.documents = list(documents or [])
+            self.deleted = False
+            self.inserted = None
+            self.dropped = False
+
+        def find(self, _filter):
+            return list(self.documents)
+
+        def list_indexes(self):
+            return [{"name": "_id_", "key": [("_id", 1)]}]
+
+        def delete_many(self, _filter):
+            self.deleted = True
+            self.documents = []
+
+        def insert_many(self, documents):
+            self.inserted = list(documents)
+            self.documents.extend(self.inserted)
+
+        def drop(self):
+            self.dropped = True
+
+    source_collections = {
+        "empty": SourceCollection([]),
+        "filled": SourceCollection([{"_id": 1}]),
+    }
+    target_collections = {
+        "empty": TargetCollection(),
+        "filled": TargetCollection(),
+    }
+
+    class Database:
+        def __init__(self, collections):
+            self.collections = collections
+
+        def __getitem__(self, name):
+            return self.collections.setdefault(name, TargetCollection())
+
+        def list_collection_names(self):
+            return list(self.collections)
+
+    clients = iter(
+        [
+            {"app": Database(source_collections)},
+            {"app": Database(target_collections)},
+        ]
+    )
+    monkeypatch.setattr(cli, "_client", lambda *args, **kwargs: next(clients))
+    args = SimpleNamespace(
+        source="source",
+        target="target",
+        from_backend="tinydb",
+        to_backend="sqlite",
+        source_uri=None,
+        target_uri=None,
+        source_dsn=None,
+        target_dsn=None,
+        database="app",
+        output="-",
+    )
+
+    assert cli.cmd_migrate(args) == 0
+    assert target_collections["empty"].deleted is True
+    assert target_collections["empty"].inserted is None
+    assert target_collections["filled"].inserted == [{"_id": 1}]
+    assert '"count": 0' in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("ordered", [True, False])
+def test_persistent_native_insert_rejection_returns_bulk_errors(ordered):
+    class Engine:
+        def __init__(self):
+            self.attempts = 0
+
+        def find(self, _collection, _filter):
+            return []
+
+        def get_index_specs(self, _collection):
+            return []
+
+        def insert_many(
+            self,
+            _collection,
+            _documents,
+            bypass_document_validation=False,
+        ):
+            self.attempts += 1
+            raise DuplicateKeyError("persistent conflict")
+
+    engine = Engine()
+    collection = TinyMongoCollection(
+        "items",
+        SimpleNamespace(name="app", engine=engine),
+    )
+    document = {"_id": "conflict"}
+
+    eids, accepted, write_errors = core._execute_engine_insert_many(
+        collection,
+        [document],
+        ordered=ordered,
+        bypass_document_validation=False,
+    )
+
+    assert engine.attempts == 3
+    assert eids == []
+    assert accepted == []
+    assert [error["index"] for error in write_errors] == [0]
+
+
+def test_direct_id_and_cached_match_helpers_cover_operator_routes():
+    assert core._direct_id_equality({"_id": {"$eq": 1}}) == 1
+    assert core._direct_id_equality({"_id": {"$in": [1]}}) is core._MISSING
+    assert core._cached_value_matches(1.0, 1, ("number", 1)) is True
+
+
+def test_tinydb_updates_and_replacements_parse_regular_queries(tmp_path):
+    client = core.TinyMongoClient(str(tmp_path / "db"))
+    collection = client.app.people
+    collection.insert_one({"_id": 1, "name": "Ada", "score": 1})
+
+    updated = collection.update_one({"score": {"$gt": 0}}, {"$set": {"score": 2}})
+    replaced = collection.replace_one({"score": {"$gt": 0}}, {"name": "Grace"})
+
+    assert updated.matched_count == 1
+    assert updated.modified_count == 1
+    assert replaced.matched_count == 1
+    assert collection.find_one({"_id": 1}) == {"_id": 1, "name": "Grace"}
+    client.close()
+
+
+def test_build_table_delegates_to_a_table_backend():
+    class Engine:
+        def __init__(self):
+            self.created = []
+
+        def create_collection(self, name):
+            self.created.append(name)
+
+    engine = Engine()
+    collection = TinyMongoCollection(
+        "events",
+        SimpleNamespace(engine=engine),
+    )
+
+    collection.build_table()
+
+    assert engine.created == ["events"]
+    assert collection.table is None

--- a/tests/test_storage_backends.py
+++ b/tests/test_storage_backends.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 import tinymongo as tm
 from tinymongo.storage_backends import DuckDBStorage, SQLiteStorage
@@ -44,7 +46,7 @@ def test_sqlite_backend_uses_collection_tables(tmp_path):
 
     assert {"users", "events"}.issubset(tables)
     assert "tinydb" not in tables
-    assert rows[0][0] == "1"
+    assert rows[0][0].startswith("__tinymongo_id_v2__:")
     assert '"name":"Ada"' in rows[0][1]
 
 
@@ -87,7 +89,7 @@ def test_duckdb_backend_uses_collection_tables(tmp_path):
 
     assert {"users", "events"}.issubset(tables)
     assert "tinydb" not in tables
-    assert rows[0][0] == "1"
+    assert rows[0][0].startswith("__tinymongo_id_v2__:")
     assert '"name":"Ada"' in rows[0][1]
 
 
@@ -116,6 +118,48 @@ def test_duckdb_backend_migrates_legacy_blob_file(tmp_path):
     assert client.legacy.users.count_documents({}) == 2
     assert client.legacy.users.find_one({"name": "Grace"})["_id"] == 2
     assert "tinydb" not in client.legacy.collection_names()
+
+
+@pytest.mark.parametrize(
+    ("backend", "storage_class", "extension"),
+    [
+        ("sqlite", SQLiteStorage, "sqlite"),
+        ("duckdb", DuckDBStorage, "duckdb"),
+    ],
+)
+def test_legacy_blob_migration_restores_tagged_bson_values(
+    tmp_path,
+    backend,
+    storage_class,
+    extension,
+):
+    if backend == "duckdb":
+        pytest.importorskip("duckdb")
+    bson = pytest.importorskip("bson")
+
+    database_id = bson.ObjectId("000000000000000000000001")
+    created = datetime(2026, 7, 29, 12, 30)
+    binary = bson.Binary(bytes(range(16)), subtype=4)
+    document = {
+        "_id": database_id,
+        "created": created,
+        "binary": binary,
+    }
+    db_file = tmp_path / "db" / "legacy.{0}".format(extension)
+    storage_class(str(db_file)).write({"events": {"1": document}})
+
+    client = tm.TinyMongoClient(str(tmp_path / "db"), backend=backend)
+    try:
+        restored = client.legacy.events.find_one({"_id": database_id})
+
+        assert restored == {
+            "_id": database_id,
+            "created": created,
+            "binary": binary,
+        }
+        assert "tinydb" not in client.legacy.collection_names()
+    finally:
+        client.close()
 
 
 def test_duckdb_backend_multiple_writes(tmp_path):

--- a/tests/test_table_backend_id_and_error_edges.py
+++ b/tests/test_table_backend_id_and_error_edges.py
@@ -1,0 +1,507 @@
+"""Focused coverage for typed row IDs and native backend error boundaries."""
+
+from datetime import datetime, timezone
+import sqlite3
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tinymongo import table_backends as backends
+from tinymongo.errors import DuplicateKeyError
+
+
+def test_physical_id_keys_cover_nonfinite_container_and_fallback_values(monkeypatch):
+    positive = backends._physical_id_key(float("inf"))
+    negative = backends._physical_id_key(float("-inf"))
+    not_a_number = backends._physical_id_key(float("nan"))
+
+    assert positive.startswith(backends._PHYSICAL_ID_PREFIX)
+    assert len({positive, negative, not_a_number}) == 3
+    assert backends._canonical_id_value((1, "two")) == [
+        "array",
+        [
+            ["registered-scalar", ["number", [1, 1]]],
+            ["registered-scalar", ["string", "two"]],
+        ],
+    ]
+
+    monkeypatch.setattr(backends, "bson_identity_key", lambda _value: None)
+    assert backends._canonical_id_value("plain JSON") == [
+        "encoded-scalar",
+        "plain JSON",
+    ]
+
+
+def test_legacy_id_candidate_and_scan_edge_cases():
+    assert "0.0" in backends._physical_id_candidates(0)
+    assert "-0.0" in backends._physical_id_candidates(0)
+    assert str(2**53 + 1) in backends._physical_id_candidates(2**53 + 1)
+    assert str(float(2**53 + 1)) not in backends._physical_id_candidates(2**53 + 1)
+    assert backends._physical_id_candidates(10**400)[-1] == str(10**400)
+    assert backends._requires_legacy_id_scan((1, 2))
+
+
+def test_legacy_id_comparison_and_temporary_remote_wrapper_compatibility():
+    assert backends._legacy_id_values_equal([1, {"b": 2}], (1.0, {"b": 2.0}))
+    assert not backends._legacy_id_values_equal([1], [1, 2])
+
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    document = {"_id": 1, "value": "wrapped"}
+    temporarily_wrapped = backends._json_dumps(backends._json_dumps(document))
+
+    assert backend._decode_data_value(temporarily_wrapped) == document
+
+
+def test_local_matching_id_falls_back_to_a_legacy_container_scan():
+    target = {"first": 1, "second": 2}
+    data = backends._json_dumps({"_id": target, "label": "legacy"})
+
+    class Connection:
+        def execute(self, sql, _params=None):
+            if " WHERE " in sql:
+                return _RemoteCursor(rows=[])
+            return _RemoteCursor(rows=[("unpredictable-legacy-key", data)])
+
+    assert (
+        backends._local_matching_physical_row_id(
+            Connection(),
+            '"items"',
+            target,
+        )
+        == "unpredictable-legacy-key"
+    )
+
+
+def test_legacy_scan_detection_and_postfilter_fallbacks():
+    container = {"value": 1}
+    assert backends._id_condition_requires_legacy_scan(container)
+    assert backends._id_condition_requires_legacy_scan({"$eq": container})
+    assert backends._id_condition_requires_legacy_scan({"$in": container})
+    assert backends._id_condition_requires_legacy_scan({"$in": [container]})
+    assert backends._id_condition_requires_legacy_scan({"$in": [1], "$eq": container})
+    assert not backends._id_condition_requires_legacy_scan({"$eq": 1})
+    assert not backends._id_condition_requires_legacy_scan({"$unknown": container})
+    assert not backends._filter_requires_legacy_id_scan("not-a-filter")
+    assert backends._filter_requires_legacy_id_scan({"_id": container})
+
+    recovered = {"_id": container, "label": "legacy"}
+    assert backends._postfilter_id_candidates(
+        [],
+        {"_id": {"$eq": container}},
+        lambda: [recovered],
+    ) == [recovered]
+
+
+def test_legacy_id_candidate_and_scan_routing_edges():
+    huge = 10**400
+    nonrepresentable = 2**53 + 1
+
+    assert backends._physical_id_candidates(huge)[1:] == (str(huge),)
+    assert backends._physical_id_candidates(nonrepresentable)[1:] == (
+        str(nonrepresentable),
+    )
+    assert backends._physical_id_candidates(0)[1:] == ("0", "0.0", "-0.0")
+    assert "1" in backends._physical_id_candidates(1.0)
+    assert backends._requires_legacy_id_scan({"nested": 1})
+    assert backends._requires_legacy_id_scan(datetime(2026, 7, 29))
+    assert not backends._requires_legacy_id_scan("ordinary")
+
+    moment = datetime(2026, 7, 29, tzinfo=timezone.utc)
+    assert backends._id_condition_requires_legacy_scan({"nested": 1})
+    assert backends._id_condition_requires_legacy_scan({"$eq": moment})
+    assert backends._id_condition_requires_legacy_scan({"$in": [moment]})
+    assert not backends._id_condition_requires_legacy_scan(
+        {"$in": ["ordinary"], "$ne": "ordinary"}
+    )
+    assert not backends._id_condition_requires_legacy_scan({"$ne": moment})
+    assert not backends._filter_requires_legacy_id_scan("not-a-filter")
+    assert backends._filter_requires_legacy_id_scan({"_id": moment})
+
+    legacy_document = {"_id": moment.replace(tzinfo=None), "value": "legacy"}
+    assert backends._postfilter_id_candidates(
+        [],
+        {"_id": moment},
+        lambda: [legacy_document],
+    ) == [legacy_document]
+
+
+def test_matching_physical_row_id_skips_malformed_and_mismatched_rows():
+    rows = [
+        ("invalid-json", "{"),
+        ("missing-id", '{"value": 1}'),
+        ("different-id", '{"_id": 2}'),
+    ]
+
+    assert backends._matching_physical_row_id(rows, 1) is None
+
+
+def test_legacy_id_recovery_and_wrapped_remote_payload_edges():
+    assert backends._legacy_id_values_equal(
+        [{"nested": {"number": 1}}],
+        [{"nested": {"number": 1.0}}],
+    )
+    assert not backends._legacy_id_values_equal([1], [1, 2])
+
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    wrapped = backends._json_dumps(backends._json_dumps({"_id": 1}))
+    assert backend._decode_data_value(wrapped) == {"_id": 1}
+
+
+def test_sql_compiler_supports_explicit_id_equality():
+    where, params = backends.SQLCompiler("sqlite").compile({"_id": {"$eq": 1}})
+
+    assert "_id = ?" in where
+    assert params == list(backends._physical_id_candidates(1))
+
+
+def test_sqlite_maps_native_insert_conflicts_and_ignores_missing_replacements(
+    tmp_path, monkeypatch
+):
+    backend = backends.SQLiteTableBackend(str(tmp_path / "items.sqlite"))
+
+    class ConflictConnection:
+        def executemany(self, _sql, _rows):
+            raise sqlite3.IntegrityError("native primary-key conflict")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(backend, "create_collection", lambda _collection: None)
+    monkeypatch.setattr(backend, "find", lambda _collection, _filter: [])
+    monkeypatch.setattr(backend, "validate_unique_post_image", lambda *_args: None)
+    monkeypatch.setattr(backend, "_connect", ConflictConnection)
+
+    with pytest.raises(DuplicateKeyError, match="native primary-key conflict"):
+        backend.insert_many("items", [{"_id": 1}])
+
+    missing = backends.SQLiteTableBackend(str(tmp_path / "missing.sqlite"))
+    assert missing.replace_one("items", 1, {"_id": 1, "value": "new"}) is None
+
+
+def test_duckdb_maps_native_insert_conflicts_and_ignores_missing_replacements(
+    tmp_path, monkeypatch
+):
+    pytest.importorskip("duckdb")
+    backend = backends.DuckDBTableBackend(str(tmp_path / "items.duckdb"))
+
+    class ConflictConnection:
+        def executemany(self, _sql, _rows):
+            raise backend.duckdb.ConstraintException("native primary-key conflict")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(backend, "create_collection", lambda _collection: None)
+    monkeypatch.setattr(backend, "find", lambda _collection, _filter: [])
+    monkeypatch.setattr(backend, "validate_unique_post_image", lambda *_args: None)
+    monkeypatch.setattr(backend, "_connect", ConflictConnection)
+
+    with pytest.raises(DuplicateKeyError, match="native primary-key conflict"):
+        backend.insert_many("items", [{"_id": 1}])
+
+    missing = backends.DuckDBTableBackend(str(tmp_path / "missing.duckdb"))
+    assert missing.replace_one("items", 1, {"_id": 1, "value": "new"}) is None
+
+
+def test_parquet_rejects_a_physical_id_collision_in_inconsistent_rows(
+    tmp_path, monkeypatch
+):
+    pytest.importorskip("duckdb")
+    backend = backends.ParquetDuckDBBackend(str(tmp_path / "items.parquet"))
+    inconsistent_rows = [
+        (
+            backends._physical_id_key(1),
+            backends._json_dumps({"_id": 2, "value": "mismatched"}),
+        )
+    ]
+    monkeypatch.setattr(
+        backend,
+        "_read_all_rows",
+        lambda collection: inconsistent_rows if collection == "items" else [],
+    )
+
+    with pytest.raises(DuplicateKeyError, match="_id:1 already exists"):
+        backend.insert_many("items", [{"_id": 1, "value": "new"}])
+
+
+class _RemoteConnection:
+    def close(self):
+        pass
+
+
+class _RemoteCursor:
+    def __init__(self, row=None, rows=None):
+        self.row = row
+        self.rows = [] if rows is None else rows
+
+    def fetchone(self):
+        return self.row
+
+    def fetchall(self):
+        return self.rows
+
+    def close(self):
+        pass
+
+
+def test_remote_backend_maps_insert_conflicts_and_ignores_missing_replacements(
+    monkeypatch,
+):
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    monkeypatch.setattr(backend, "create_collection", lambda _collection: None)
+    monkeypatch.setattr(backend, "_all_docs_unfiltered", lambda _collection: [])
+    monkeypatch.setattr(backend, "validate_unique_post_image", lambda *_args: None)
+    monkeypatch.setattr(backend, "_connect", _RemoteConnection)
+    monkeypatch.setattr(
+        backend,
+        "_insert_rows",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("duplicate key")),
+    )
+
+    with pytest.raises(DuplicateKeyError, match="duplicate key"):
+        backend.insert_many("items", [{"_id": 1}])
+
+    monkeypatch.setattr(
+        backend, "_stored_row_by_id", lambda _collection, _doc_id: (None, None)
+    )
+    assert backend.replace_one("items", 1, {"_id": 1, "value": "new"}) is None
+
+
+def test_remote_stored_row_lookup_skips_a_mismatched_current_row(monkeypatch):
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    candidates = backends._physical_id_candidates(1)
+    responses = {
+        candidates[0]: (backends._json_dumps({"_id": 2}),),
+        candidates[1]: (backends._json_dumps({"_id": 1}),),
+    }
+
+    monkeypatch.setattr(backend, "_connect", _RemoteConnection)
+    monkeypatch.setattr(
+        backend,
+        "_execute",
+        lambda _conn, _sql, params=None: _RemoteCursor(responses.get(params[0])),
+    )
+
+    assert backend._stored_row_by_id("items", 1) == (
+        candidates[1],
+        {"_id": 1},
+    )
+
+
+def test_remote_missing_scalar_id_does_not_scan_the_complete_table(monkeypatch):
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    statements = []
+
+    def execute(_conn, sql, params=None):
+        statements.append((sql, params))
+        return _RemoteCursor(None)
+
+    monkeypatch.setattr(backend, "_connect", _RemoteConnection)
+    monkeypatch.setattr(backend, "_execute", execute)
+
+    assert backend._stored_row_by_id("items", "missing") == (None, None)
+    assert statements
+    assert all("SELECT _id, data" not in sql for sql, _params in statements)
+
+
+def test_remote_stored_row_lookup_recovers_a_legacy_numeric_equivalent(monkeypatch):
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    legacy_data = backends._json_dumps({"_id": 1, "value": "legacy"})
+    statements = []
+
+    def execute(_conn, sql, params=None):
+        statements.append((sql, params))
+        row = (legacy_data,) if params == ("1",) else None
+        return _RemoteCursor(row)
+
+    monkeypatch.setattr(backend, "_connect", _RemoteConnection)
+    monkeypatch.setattr(backend, "_execute", execute)
+
+    assert backend._stored_row_by_id("items", 1.0) == (
+        "1",
+        {"_id": 1, "value": "legacy"},
+    )
+    assert all("SELECT _id, data" not in sql for sql, _params in statements)
+
+
+@pytest.mark.parametrize("matching", [True, False])
+def test_remote_stored_row_lookup_scans_legacy_container_ids(monkeypatch, matching):
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    target = {"first": 1, "second": 2}
+    stored = target if matching else {"different": 1}
+    rows = [
+        (
+            "malformed-legacy-key",
+            backends._json_dumps({"label": "missing-id"}),
+        ),
+        (
+            "unpredictable-legacy-key",
+            backends._json_dumps({"_id": stored, "label": "legacy"}),
+        ),
+    ]
+
+    def execute(_conn, _sql, params=None):
+        if params is not None:
+            return _RemoteCursor(None)
+        return _RemoteCursor(rows=rows)
+
+    monkeypatch.setattr(backend, "_connect", _RemoteConnection)
+    monkeypatch.setattr(backend, "_execute", execute)
+
+    result = backend._stored_row_by_id("items", target)
+    if matching:
+        assert result == (
+            "unpredictable-legacy-key",
+            {"_id": target, "label": "legacy"},
+        )
+    else:
+        assert result == (None, None)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError(1060, "already exists"),
+        RuntimeError(9999, "duplicate column name"),
+    ],
+)
+def test_mysql_ordered_column_upgrade_tolerates_duplicate_column_races(
+    monkeypatch,
+    error,
+):
+    backend = object.__new__(backends.MySQLTableBackend)
+    backend.database = "app"
+    calls = []
+
+    def execute(_conn, sql, params=None):
+        calls.append((sql, params))
+        if "information_schema.columns" in sql:
+            return _RemoteCursor()
+        raise error
+
+    monkeypatch.setattr(backend, "_execute", execute)
+
+    backend._ensure_ordered_data_column(_RemoteConnection(), "items", "`app__items`")
+    assert len(calls) == 2
+
+
+def test_mysql_ordered_column_upgrade_propagates_unrelated_errors(monkeypatch):
+    backend = object.__new__(backends.MySQLTableBackend)
+    backend.database = "app"
+
+    def execute(_conn, sql, params=None):
+        if "information_schema.columns" in sql:
+            return _RemoteCursor()
+        raise RuntimeError(9999, "permission denied")
+
+    monkeypatch.setattr(backend, "_execute", execute)
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        backend._ensure_ordered_data_column(
+            _RemoteConnection(),
+            "items",
+            "`app__items`",
+        )
+
+
+def test_remote_stored_row_lookup_scans_for_legacy_datetime_ids(monkeypatch):
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+    stored_id = datetime(2026, 7, 29, 12, 30)
+    requested_id = stored_id.replace(tzinfo=timezone.utc)
+    legacy_row = (
+        str(stored_id),
+        backends._json_dumps({"_id": stored_id, "value": "legacy"}),
+    )
+
+    def execute_with_match(_conn, _sql, params=None):
+        if params is not None:
+            return _RemoteCursor()
+        return _RemoteCursor(rows=[legacy_row])
+
+    monkeypatch.setattr(backend, "_connect", _RemoteConnection)
+    monkeypatch.setattr(backend, "_execute", execute_with_match)
+    assert backend._stored_row_by_id("items", requested_id) == (
+        str(stored_id),
+        {"_id": stored_id, "value": "legacy"},
+    )
+
+    monkeypatch.setattr(
+        backend,
+        "_execute",
+        lambda _conn, _sql, params=None: _RemoteCursor(),
+    )
+    assert backend._stored_row_by_id("items", requested_id) == (None, None)
+
+
+def test_remote_legacy_scan_skips_rows_without_an_id(monkeypatch):
+    backend = backends.RemoteSQLTableBackend("", database="app", dsn="remote")
+
+    def execute(_conn, _sql, params=None):
+        if params is not None:
+            return _RemoteCursor()
+        return _RemoteCursor(rows=[("legacy", None, '{"value": "missing-id"}')])
+
+    monkeypatch.setattr(backend, "_connect", _RemoteConnection)
+    monkeypatch.setattr(backend, "_execute", execute)
+
+    assert backend._stored_row_by_id("items", {"target": 1}) == (None, None)
+
+
+@pytest.mark.parametrize(
+    ("error", "should_raise"),
+    [
+        (RuntimeError(1060, "duplicate column"), False),
+        (RuntimeError("duplicate column name"), False),
+        (RuntimeError("permission denied"), True),
+    ],
+)
+def test_mysql_ordered_column_upgrade_handles_only_duplicate_races(
+    monkeypatch,
+    error,
+    should_raise,
+):
+    monkeypatch.setitem(sys.modules, "pymysql", SimpleNamespace())
+    backend = backends.MySQLTableBackend(
+        "",
+        database="app",
+        dsn="mysql://localhost/db",
+    )
+
+    def execute(_conn, sql, params=None):
+        if "information_schema.columns" in sql:
+            return _RemoteCursor()
+        raise error
+
+    monkeypatch.setattr(backend, "_execute", execute)
+
+    if should_raise:
+        with pytest.raises(RuntimeError, match="permission denied"):
+            backend._ensure_ordered_data_column(None, "items", "`app__items`")
+    else:
+        backend._ensure_ordered_data_column(None, "items", "`app__items`")
+
+    assert backend.ordered_data_type == "LONGTEXT"
+
+
+def test_local_stored_row_lookup_scans_for_legacy_datetime_ids():
+    connection = sqlite3.connect(":memory:")
+    stored_id = datetime(2026, 7, 29, 12, 30)
+    requested_id = stored_id.replace(tzinfo=timezone.utc)
+    connection.execute("CREATE TABLE items (_id TEXT PRIMARY KEY, data TEXT)")
+    connection.execute(
+        "INSERT INTO items (_id, data) VALUES (?, ?)",
+        (
+            str(stored_id),
+            backends._json_dumps({"_id": stored_id, "value": "legacy"}),
+        ),
+    )
+
+    try:
+        assert backends._local_matching_physical_row_id(
+            connection,
+            '"items"',
+            requested_id,
+        ) == str(stored_id)
+    finally:
+        connection.close()

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -28,6 +28,7 @@ from tinymongo.table_backends import (
     _duckdb_setup_sql_from_env,
     _import_optional_driver,
     _is_object_store_uri,
+    _json_dumps,
     _json_loads,
     _join_uri,
     _reject_remote_unique_arrays,
@@ -106,9 +107,11 @@ def test_parquet_temporary_file_cleanup_branch(tmp_path, monkeypatch):
 class FakeRemoteStore:
     def __init__(self):
         self.tables = {}
+        self.columns = {}
         self.metadata = set()
         self.indexes = {}
         self.index_ddl = []
+        self.schema_ddl = []
 
 
 class FakeRemoteCursor:
@@ -122,9 +125,17 @@ class FakeRemoteCursor:
         if upper.startswith("CREATE TABLE"):
             table = self._table_from_create(normalized)
             if "TINYMONGO_" not in table.upper():
-                self.store.tables.setdefault(table, {})
+                if table not in self.store.tables:
+                    self.store.tables[table] = {}
+                    self.store.columns[table] = {"_id", "data"}
+                    if "DATA_ORDERED" in upper:
+                        self.store.columns[table].add("data_ordered")
         elif upper.startswith(("CREATE INDEX", "CREATE UNIQUE INDEX")):
             self.store.index_ddl.append(normalized)
+        elif upper.startswith("ALTER TABLE") and "DATA_ORDERED" in upper:
+            table = self._table_after(normalized, "TABLE")
+            self.store.columns.setdefault(table, {"_id", "data"}).add("data_ordered")
+            self.store.schema_ddl.append(normalized)
         elif upper.startswith(("ALTER TABLE", "DROP INDEX")):
             self.store.index_ddl.append(normalized)
         elif upper.startswith("INSERT") and "TINYMONGO_INDEXES" in upper:
@@ -132,6 +143,11 @@ class FakeRemoteCursor:
             self.store.indexes[(database, collection, name)] = (field, bool(unique))
         elif upper.startswith("INSERT") and "TINYMONGO_COLLECTIONS" in upper:
             self.store.metadata.add(tuple(params))
+        elif upper.startswith("SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS"):
+            table = params[0]
+            self.rows = (
+                [(1,)] if "data_ordered" in self.store.columns.get(table, set()) else []
+            )
         elif upper.startswith("SELECT DISTINCT"):
             self.rows = sorted({(database,) for database, _ in self.store.metadata})
         elif upper.startswith("SELECT INDEX_NAME"):
@@ -152,9 +168,9 @@ class FakeRemoteCursor:
                 if metadata_database == database
             )
         elif upper.startswith("DROP TABLE"):
-            self.store.tables.pop(
-                self._table_after(normalized, "TABLE IF EXISTS"), None
-            )
+            table = self._table_after(normalized, "TABLE IF EXISTS")
+            self.store.tables.pop(table, None)
+            self.store.columns.pop(table, None)
         elif upper.startswith("DELETE FROM") and "TINYMONGO_COLLECTIONS" in upper:
             self.store.metadata.discard(tuple(params))
         elif upper.startswith("DELETE FROM") and "TINYMONGO_INDEXES" in upper:
@@ -174,16 +190,52 @@ class FakeRemoteCursor:
             self.store.tables.setdefault(self._table_after(normalized, "FROM"), {}).pop(
                 params[0], None
             )
+        elif upper.startswith("SELECT _ID, DATA_ORDERED, DATA"):
+            table = self._table_after(normalized, "FROM")
+            self.rows = [
+                (
+                    doc_id,
+                    self._payload_columns(value)[1],
+                    self._payload_columns(value)[0],
+                )
+                for doc_id, value in self.store.tables.get(table, {}).items()
+            ]
+        elif upper.startswith("SELECT DATA_ORDERED, DATA") and "WHERE _ID" in upper:
+            table = self._table_after(normalized, "FROM")
+            value = self.store.tables.get(table, {}).get(params[0])
+            if value is None:
+                self.rows = []
+            else:
+                data, ordered_data = self._payload_columns(value)
+                self.rows = [(ordered_data, data)]
+        elif upper.startswith("SELECT DATA_ORDERED, DATA"):
+            table = self._table_after(normalized, "FROM")
+            self.rows = [
+                (self._payload_columns(value)[1], self._payload_columns(value)[0])
+                for value in self.store.tables.get(table, {}).values()
+            ]
         elif upper.startswith("SELECT DATA") and "WHERE _ID" in upper:
             table = self._table_after(normalized, "FROM")
-            data = self.store.tables.get(table, {}).get(params[0])
+            value = self.store.tables.get(table, {}).get(params[0])
+            data = self._payload_columns(value)[0] if value is not None else None
             self.rows = [(data,)] if data is not None else []
         elif upper.startswith("SELECT DATA"):
             table = self._table_after(normalized, "FROM")
-            self.rows = [(data,) for data in self.store.tables.get(table, {}).values()]
+            self.rows = [
+                (self._payload_columns(value)[0],)
+                for value in self.store.tables.get(table, {}).values()
+            ]
         elif upper.startswith("UPDATE"):
             table = self._table_after(normalized, "UPDATE")
-            self.store.tables.setdefault(table, {})[params[1]] = params[0]
+            if len(params) == 3:
+                data, ordered_data, doc_id = params
+                self.store.tables.setdefault(table, {})[doc_id] = (
+                    data,
+                    ordered_data,
+                )
+            else:
+                data, doc_id = params
+                self.store.tables.setdefault(table, {})[doc_id] = data
         return self
 
     def executemany(self, sql, rows):
@@ -196,14 +248,15 @@ class FakeRemoteCursor:
 
         table = self._table_after(" ".join(sql.split()), "INTO")
         target = self.store.tables.setdefault(table, {})
-        for doc_id, data in rows:
+        for row in rows:
+            doc_id, data = row[:2]
             if (
                 doc_id in target
                 and "CONFLICT" not in sql.upper()
                 and "REPLACE" not in sql.upper()
             ):
                 raise RuntimeError("duplicate key")
-            target[doc_id] = data
+            target[doc_id] = (data, row[2]) if len(row) == 3 else data
 
     def fetchone(self):
         return self.rows[0] if self.rows else None
@@ -213,6 +266,11 @@ class FakeRemoteCursor:
 
     def close(self):
         pass
+
+    def _payload_columns(self, value):
+        if isinstance(value, tuple) and len(value) == 2:
+            return value
+        return value, None
 
     def _table_from_create(self, sql):
         return self._clean(sql.split("IF NOT EXISTS", 1)[1].strip().split()[0])
@@ -814,7 +872,8 @@ def test_tinymongo_table_backend_api_branches(tmp_path):
     db._refresh_table()
     collection = db.users
 
-    assert collection.any_attribute is collection
+    assert collection.any_attribute is not collection
+    assert collection.any_attribute.name == "users.any_attribute"
     assert collection.create_index("email") == "email_1"
     assert collection.drop_index("email") is None
     assert collection.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
@@ -823,7 +882,7 @@ def test_tinymongo_table_backend_api_branches(tmp_path):
 
     with pytest.raises(ValueError):
         collection.insert_one("bad")
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         collection.insert_many("bad")
 
     one = collection.insert_one({"email": "one@example.com"})
@@ -914,7 +973,8 @@ def test_remote_sql_backend_defensive_edges(monkeypatch):
         backend._execute(BadConn(), "SELECT 1")
     with pytest.raises(RuntimeError, match="executemany"):
         backend._executemany(BadConn(), "SELECT 1", [])
-    assert backend._commit(BadConn()) is None
+    with pytest.raises(RuntimeError, match="commit"):
+        backend._commit(BadConn())
     assert backend._close_cursor(BadCursor()) is None
     assert backend._data_placeholder() == "%s"
     with backend._write_lock():
@@ -976,6 +1036,7 @@ def test_postgres_indexes_are_native_durable_unique_and_droppable(monkeypatch):
     assert any(
         "CREATE UNIQUE INDEX" in sql
         and "COALESCE(jsonb_extract_path(data, 'email'), 'null'::jsonb)" in sql
+        and "jsonb_typeof(data)" not in sql
         for sql in store.index_ddl
     )
 
@@ -1018,6 +1079,24 @@ def test_remote_native_errors_are_mapped_without_hiding_other_failures(monkeypat
     store = FakeRemoteStore()
     backend = _postgres_backend(monkeypatch, store)
     backend.insert_many("users", [{"_id": 1, "email": "one@example.com"}])
+    assert backend.find_one("users", {"_id": {"$eq": 1}})["email"] == (
+        "one@example.com"
+    )
+    assert (
+        backend.replace_one(
+            "users",
+            "missing",
+            {"_id": "missing", "email": "missing@example.com"},
+        )
+        is None
+    )
+
+    table = backend._table_name("users")
+    store.tables[table]["legacy-collision"] = _json_dumps(
+        {"_id": 2, "email": "legacy@example.com"}
+    )
+    assert backend.find_one("users", {"_id": "legacy-collision"}) is None
+
     original_execute = backend._execute
 
     def fail_update(message):
@@ -1055,9 +1134,16 @@ def test_remote_native_errors_are_mapped_without_hiding_other_failures(monkeypat
     def fail_insert(conn, collection, rows, bypass_document_validation):
         raise RuntimeError("insert syntax error")
 
+    def fail_duplicate_insert(conn, collection, rows, bypass_document_validation):
+        raise RuntimeError("duplicate key")
+
+    monkeypatch.setattr(backend, "_insert_rows", fail_duplicate_insert)
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many("users", [{"_id": 3, "email": "three@example.com"}])
+
     monkeypatch.setattr(backend, "_insert_rows", fail_insert)
     with pytest.raises(RuntimeError, match="insert syntax error"):
-        backend.insert_many("users", [{"_id": 2, "email": "two@example.com"}])
+        backend.insert_many("users", [{"_id": 4, "email": "four@example.com"}])
 
 
 def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
@@ -1086,6 +1172,7 @@ def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
     assert any(
         "GENERATED ALWAYS AS" in sql
         and "JSON_TYPE(JSON_EXTRACT(data, '$.\"value\"'))" in sql
+        and "JSON_TYPE(data)" not in sql
         and "CONCAT('bool:'" in sql
         and "AS DECIMAL(65, 30)" in sql
         and "SHA2(CASE" in sql
@@ -1164,6 +1251,77 @@ def test_postgres_table_backend_with_fake_driver(monkeypatch):
     assert backend.drop_collection("users") is True
     assert backend.drop_collection("users") is False
     assert backend._data_placeholder() == "%s::jsonb"
+
+
+@pytest.mark.parametrize("backend_factory", [_postgres_backend, _mysql_backend])
+def test_remote_dual_payload_preserves_order_and_nonfinite_values(
+    monkeypatch,
+    backend_factory,
+):
+    store = FakeRemoteStore()
+    backend = backend_factory(monkeypatch, store)
+    ordered_id = {"longer": 1, "a": 2}
+    reordered_id = {"a": 2, "longer": 1}
+
+    backend.insert_many(
+        "values",
+        [
+            {
+                "_id": ordered_id,
+                "value": float("nan"),
+            },
+            {
+                "_id": reordered_id,
+                "value": float("inf"),
+            },
+        ],
+    )
+
+    raw_values = list(store.tables[backend._table_name("values")].values())
+    assert all(isinstance(value, tuple) for value in raw_values)
+    assert all(data == ordered_data for data, ordered_data in raw_values)
+    assert all(data.startswith("{") for data, _ordered_data in raw_values)
+    assert all("NaN" not in data and "Infinity" not in data for data, _ in raw_values)
+    assert backend.find_one("values", {"_id": ordered_id})["_id"] == ordered_id
+    assert backend.find_one("values", {"_id": reordered_id})["_id"] == reordered_id
+    assert backend.find_one("values", {"_id": ordered_id})["value"] != (
+        backend.find_one("values", {"_id": ordered_id})["value"]
+    )
+    assert backend.find_one("values", {"_id": reordered_id})["value"] == float("inf")
+
+
+@pytest.mark.parametrize("backend_factory", [_postgres_backend, _mysql_backend])
+def test_remote_dual_payload_upgrades_and_recovers_legacy_rows(
+    monkeypatch,
+    backend_factory,
+):
+    store = FakeRemoteStore()
+    backend = backend_factory(monkeypatch, store)
+    table = backend._table_name("legacy")
+    ordered_id = {"longer": 1, "a": 2}
+    database_reordered_id = {"a": 2, "longer": 1}
+    legacy_row_id = str(ordered_id)
+    store.tables[table] = {
+        legacy_row_id: _json_dumps({"_id": database_reordered_id, "label": "legacy"})
+    }
+    store.columns[table] = {"_id", "data"}
+
+    found = backend.find_one("legacy", {"_id": ordered_id})
+
+    assert found == {"_id": ordered_id, "label": "legacy"}
+    assert backend.find_one("legacy", {"label": "legacy"}) == found
+    assert "data_ordered" in store.columns[table]
+    assert sum("DATA_ORDERED" in sql.upper() for sql in store.schema_ddl) == 1
+
+    backend.replace_one(
+        "legacy",
+        ordered_id,
+        {"_id": ordered_id, "label": "updated"},
+    )
+
+    assert isinstance(store.tables[table][legacy_row_id], tuple)
+    assert backend.find_one("legacy", {"_id": ordered_id})["label"] == "updated"
+    assert backend.find_one("legacy", {"_id": database_reordered_id}) is None
 
 
 def test_mysql_table_backend_with_fake_driver(monkeypatch):

--- a/tests/test_talkpython_regressions.py
+++ b/tests/test_talkpython_regressions.py
@@ -1,0 +1,186 @@
+"""Regressions reduced from Mike Kennedy's Talk Python acceptance run."""
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+import tinymongo as tm
+from tinymongo.indexes import TinyMongoUnsupportedWarning
+
+
+bson = pytest.importorskip("bson")
+Binary = bson.Binary
+ObjectId = bson.ObjectId
+
+BACKENDS = ("memory", "tinydb", "sqlite")
+INSERTION_ORDER = (3, 1, 5, 2, 4)
+
+
+@pytest.fixture(params=BACKENDS)
+def talkpython_collection(request, tmp_path):
+    """Return the same isolated collection on each backend Mike exercised."""
+
+    client = tm.TinyMongoClient(
+        str(tmp_path / request.param),
+        backend=request.param,
+    )
+    try:
+        yield client.talkpython.documents
+    finally:
+        client.close()
+
+
+def _labels(cursor):
+    return [document["label"] for document in cursor]
+
+
+def test_datetime_and_object_id_sort_in_both_directions(talkpython_collection):
+    """TM-003: supported BSON values must not collapse to insertion order."""
+
+    collection = talkpython_collection
+    base = datetime(2026, 1, 1)
+    object_ids = {
+        number: ObjectId("{0:024x}".format(number)) for number in INSERTION_ORDER
+    }
+    collection.insert_many(
+        [
+            {
+                "_id": object_ids[number],
+                "label": number,
+                "published": base + timedelta(days=number),
+            }
+            for number in INSERTION_ORDER
+        ]
+    )
+
+    for field in ("published", "_id"):
+        assert _labels(collection.find({}).sort(field, 1)) == [1, 2, 3, 4, 5]
+        assert _labels(collection.find({}).sort(field, -1)) == [5, 4, 3, 2, 1]
+
+
+def test_binary_sort_uses_mongodb_length_subtype_and_byte_order(
+    talkpython_collection,
+):
+    """BinData sorts by length, then subtype, then unsigned byte content."""
+
+    collection = talkpython_collection
+    values = {
+        1: Binary(b"\xff", 128),
+        2: Binary(b"\xff\xff", 0),
+        3: Binary(b"\x00\x00", 128),
+        4: Binary(b"\xff\x00", 128),
+        5: Binary(b"\x00\x00\x00", 0),
+    }
+    collection.insert_many(
+        [
+            {"_id": "binary-{0}".format(label), "label": label, "value": values[label]}
+            for label in (4, 1, 5, 3, 2)
+        ]
+    )
+
+    assert _labels(collection.find({}).sort("value", 1)) == [1, 2, 3, 4, 5]
+    assert _labels(collection.find({}).sort("value", -1)) == [5, 4, 3, 2, 1]
+
+
+def test_mixed_naive_and_aware_datetimes_sort_as_utc(talkpython_collection):
+    """Naive dates are UTC and aware dates compare by their UTC instant."""
+
+    collection = talkpython_collection
+    collection.insert_many(
+        [
+            {
+                "_id": "late",
+                "label": "late",
+                "published": datetime(2026, 1, 1, 3, tzinfo=timezone.utc),
+            },
+            {
+                "_id": "early",
+                "label": "early",
+                "published": datetime(
+                    2025,
+                    12,
+                    31,
+                    21,
+                    tzinfo=timezone(timedelta(hours=-3)),
+                ),
+            },
+            {
+                "_id": "middle",
+                "label": "middle",
+                "published": datetime(2026, 1, 1, 1),
+            },
+        ]
+    )
+
+    assert _labels(collection.find({}).sort("published", 1)) == [
+        "early",
+        "middle",
+        "late",
+    ]
+    assert _labels(collection.find({}).sort("published", -1)) == [
+        "late",
+        "middle",
+        "early",
+    ]
+
+
+def test_compound_sort_uses_datetime_to_break_ties(talkpython_collection):
+    """The BSON sort key must also work in the cursor's multi-key path."""
+
+    collection = talkpython_collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "label": 1,
+                "group": "a",
+                "published": datetime(2026, 1, 2),
+            },
+            {
+                "_id": 2,
+                "label": 2,
+                "group": "b",
+                "published": datetime(2026, 1, 3),
+            },
+            {
+                "_id": 3,
+                "label": 3,
+                "group": "a",
+                "published": datetime(2026, 1, 3),
+            },
+            {
+                "_id": 4,
+                "label": 4,
+                "group": "b",
+                "published": datetime(2026, 1, 1),
+            },
+        ]
+    )
+
+    assert _labels(collection.find({}).sort([("group", 1), ("published", -1)])) == [
+        3,
+        1,
+        2,
+        4,
+    ]
+
+
+def test_unsupported_sort_type_warns_once_per_field_and_type():
+    """An unsupported sort must be visible without warning for every document."""
+
+    cursor = tm.TinyMongoCursor(
+        [
+            {"_id": 1, "published": date(2026, 1, 3)},
+            {"_id": 2, "published": date(2026, 1, 1)},
+            {"_id": 3, "published": date(2026, 1, 2)},
+        ]
+    )
+
+    with pytest.warns(TinyMongoUnsupportedWarning) as caught:
+        cursor.sort("published", 1)
+        cursor.sort("published", -1)
+
+    assert len(caught) == 1
+    message = str(caught[0].message)
+    assert "published" in message
+    assert "date" in message

--- a/tests/test_tinymongo.py
+++ b/tests/test_tinymongo.py
@@ -103,7 +103,7 @@ def test_list_collections():
     Should list out all collections/tables in database
     """
     tables = tiny_database.collection_names()
-    assert "_default" in tables
+    assert "_default" not in tables
     assert "tinyCollection" in tables
 
 
@@ -518,12 +518,12 @@ def test_insert_many(collection):
 
 def test_insert_many_wrong_input(collection):
     """
-    Testing the 'insert_many' method with a non-list input
+    Testing the 'insert_many' method with a mapping input
     :param collection: pytest fixture that returns the collection
     :return:
     """
     item = {"my_key": "my value"}
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         collection["tiny"].insert_many(item)
 
 

--- a/tests/test_typed_physical_ids.py
+++ b/tests/test_typed_physical_ids.py
@@ -1,0 +1,291 @@
+"""Focused contracts for BSON-aware SQL and Parquet physical `_id` keys."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import tinymongo.table_backends as table_backends
+from tinymongo.errors import DuplicateKeyError
+from tinymongo.table_backends import (
+    DuckDBTableBackend,
+    ParquetDuckDBBackend,
+    SQLCompiler,
+    SQLiteTableBackend,
+    _canonical_id_value,
+    _json_dumps,
+    _matching_physical_row_id,
+    _physical_id_candidates,
+    _physical_id_key,
+    _quote_identifier,
+)
+
+
+bson = pytest.importorskip("bson")
+Binary = bson.Binary
+ObjectId = bson.ObjectId
+
+
+@pytest.fixture(params=("sqlite", "duckdb", "parquet"))
+def typed_backend(request, tmp_path):
+    if request.param == "sqlite":
+        backend = SQLiteTableBackend(str(tmp_path / "typed.sqlite"))
+    elif request.param == "duckdb":
+        pytest.importorskip("duckdb")
+        backend = DuckDBTableBackend(str(tmp_path / "typed.duckdb"))
+    else:
+        pytest.importorskip("duckdb")
+        pytest.importorskip("pyarrow")
+        backend = ParquetDuckDBBackend(str(tmp_path / "parquet"))
+    try:
+        yield backend
+    finally:
+        backend.close()
+
+
+def _stored_keys(backend, collection):
+    if isinstance(backend, ParquetDuckDBBackend):
+        return [row[0] for row in backend._read_all_rows(collection)]
+    conn = backend._connect()
+    try:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT _id FROM {0}".format(_quote_identifier(collection))
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def _write_legacy_row(backend, collection, document):
+    data = _json_dumps(document)
+    legacy_id = str(document["_id"])
+    if isinstance(backend, ParquetDuckDBBackend):
+        backend._write_rows(collection, [(legacy_id, data)])
+        return
+
+    backend.create_collection(collection)
+    conn = backend._connect()
+    try:
+        conn.execute(
+            "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
+                _quote_identifier(collection)
+            ),
+            (legacy_id, data),
+        )
+        try:
+            conn.commit()
+        except AttributeError:
+            pass
+    finally:
+        conn.close()
+
+
+def test_physical_id_keys_follow_registered_bson_identity():
+    raw = bytes(range(16))
+    instant = datetime(2026, 7, 29, 12, 0, 0, 999)
+    same_instant = instant.replace(tzinfo=timezone.utc).astimezone(
+        timezone(timedelta(hours=-4))
+    )
+
+    assert _physical_id_key(raw) == _physical_id_key(bytearray(raw))
+    assert _physical_id_key(raw) == _physical_id_key(Binary(raw, subtype=0))
+    assert _physical_id_key(raw) != _physical_id_key(Binary(raw, subtype=4))
+    assert _physical_id_key(1) == _physical_id_key(1.0)
+    assert _physical_id_key(1) != _physical_id_key(True)
+    assert _physical_id_key(instant) == _physical_id_key(same_instant)
+    assert _physical_id_key(ObjectId("000000000000000000000001")) != (
+        _physical_id_key("000000000000000000000001")
+    )
+    assert _physical_id_key(float("inf")) != _physical_id_key(float("-inf"))
+    assert _physical_id_key(float("nan")) == _physical_id_key(float("nan"))
+    assert _physical_id_key([1, True]) == _physical_id_key((1, True))
+
+
+def test_physical_id_fallback_and_malformed_legacy_rows(monkeypatch):
+    monkeypatch.setattr(table_backends, "bson_identity_key", lambda value: None)
+
+    assert _canonical_id_value(1) == ["encoded-scalar", 1]
+    assert (
+        _matching_physical_row_id(
+            [
+                ("invalid-json", "{"),
+                ("missing-id", '{"value": 1}'),
+            ],
+            1,
+        )
+        is None
+    )
+
+
+def test_sql_compiler_supports_explicit_id_equality():
+    where, params = SQLCompiler("sqlite").compile({"_id": {"$eq": 1}})
+
+    assert "_id = ?" in where
+    assert params == list(_physical_id_candidates(1))
+
+
+def test_distinct_bson_id_types_coexist_and_remain_addressable(typed_backend):
+    binary_zero = bytes(range(16))
+    binary_four = Binary(bytes(range(16)), subtype=4)
+    documents = [
+        {"_id": binary_zero, "label": "generic"},
+        {"_id": binary_four, "label": "custom"},
+        {"_id": 1, "label": "number"},
+        {"_id": True, "label": "boolean"},
+    ]
+
+    typed_backend.insert_many("items", documents)
+
+    assert len(set(_stored_keys(typed_backend, "items"))) == 4
+    assert all(
+        key.startswith("__tinymongo_id_v2__:")
+        for key in _stored_keys(typed_backend, "items")
+    )
+    assert typed_backend.find_one("items", {"_id": binary_zero})["label"] == "generic"
+    assert (
+        typed_backend.find_one("items", {"_id": Binary(binary_zero, 0)})["label"]
+        == "generic"
+    )
+    assert typed_backend.find_one("items", {"_id": binary_four})["label"] == "custom"
+    assert typed_backend.find_one("items", {"_id": 1})["label"] == "number"
+    assert typed_backend.find_one("items", {"_id": True})["label"] == "boolean"
+
+    typed_backend.replace_one(
+        "items",
+        binary_four,
+        {"_id": binary_four, "label": "updated"},
+    )
+    typed_backend.delete_ids("items", [binary_zero])
+
+    assert typed_backend.find_one("items", {"_id": binary_zero}) is None
+    assert typed_backend.find_one("items", {"_id": binary_four})["label"] == "updated"
+    assert (
+        typed_backend.replace_one(
+            "items",
+            "missing",
+            {"_id": "missing", "label": "missing"},
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("first", "equivalent"),
+    [
+        (b"same", Binary(b"same", subtype=0)),
+        (1, 1.0),
+    ],
+)
+def test_bson_equivalent_ids_share_one_native_key(
+    typed_backend,
+    first,
+    equivalent,
+):
+    typed_backend.insert_many("duplicates", [{"_id": first}])
+
+    with pytest.raises(DuplicateKeyError):
+        typed_backend.insert_many("duplicates", [{"_id": equivalent}])
+
+
+def test_legacy_stringified_rows_remain_readable_mutable_and_type_safe(
+    typed_backend,
+):
+    _write_legacy_row(
+        typed_backend,
+        "legacy",
+        {"_id": 1, "label": "before"},
+    )
+
+    # The fallback legacy key "1" must not make a BSON string ID find an
+    # existing numeric document that happens to have the same old storage key.
+    assert typed_backend.find_one("legacy", {"_id": "1"}) is None
+    assert typed_backend.find_one("legacy", {"_id": 1})["label"] == "before"
+
+    typed_backend.replace_one(
+        "legacy",
+        1,
+        {"_id": 1, "label": "after"},
+    )
+    assert typed_backend.find_one("legacy", {"_id": 1})["label"] == "after"
+
+    typed_backend.delete_ids("legacy", [1])
+    assert typed_backend.find_one("legacy", {"_id": 1}) is None
+
+
+def test_legacy_string_id_survives_a_negated_numeric_id_filter(typed_backend):
+    _write_legacy_row(
+        typed_backend,
+        "legacy_nor",
+        {"_id": "1", "label": "string"},
+    )
+
+    assert typed_backend.find(
+        "legacy_nor",
+        {"$nor": [{"_id": 1}]},
+    ) == [{"_id": "1", "label": "string"}]
+
+
+def test_legacy_numeric_ids_accept_bson_equivalent_lookup_forms(typed_backend):
+    _write_legacy_row(
+        typed_backend,
+        "legacy_numeric",
+        {"_id": 1.0, "label": "legacy"},
+    )
+    typed_backend.insert_many(
+        "legacy_numeric",
+        [{"_id": 2, "label": "current"}],
+    )
+
+    assert typed_backend.find_one("legacy_numeric", {"_id": 1})["label"] == "legacy"
+    assert sorted(
+        document["label"]
+        for document in typed_backend.find(
+            "legacy_numeric",
+            {"$or": [{"_id": 1}, {"_id": 2}]},
+        )
+    ) == ["current", "legacy"]
+
+    typed_backend.replace_one(
+        "legacy_numeric",
+        1,
+        {"_id": 1.0, "label": "updated"},
+    )
+    assert typed_backend.find_one("legacy_numeric", {"_id": 1})["label"] == "updated"
+
+    typed_backend.delete_ids("legacy_numeric", [1])
+    assert typed_backend.find_one("legacy_numeric", {"_id": 1.0}) is None
+
+
+def test_native_key_collision_guards_remain_mapped_to_duplicate_errors(
+    typed_backend,
+):
+    collection = "defensive_collision"
+    mismatched_row = (
+        _physical_id_key("target"),
+        _json_dumps({"_id": 1, "label": "mismatched"}),
+    )
+    if isinstance(typed_backend, ParquetDuckDBBackend):
+        typed_backend._write_rows(collection, [mismatched_row])
+    else:
+        typed_backend.create_collection(collection)
+        conn = typed_backend._connect()
+        try:
+            conn.execute(
+                "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
+                    _quote_identifier(collection)
+                ),
+                mismatched_row,
+            )
+            try:
+                conn.commit()
+            except AttributeError:
+                pass
+        finally:
+            conn.close()
+
+    with pytest.raises(DuplicateKeyError):
+        typed_backend.insert_many(
+            collection,
+            [{"_id": "target", "label": "new"}],
+        )

--- a/tests/test_unset_semantics.py
+++ b/tests/test_unset_semantics.py
@@ -1,0 +1,160 @@
+"""Mongo-compatible ``$unset`` behavior across embedded backends."""
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from tinymongo import TinyMongoClient
+from tinymongo.asyncio import AsyncTinyMongoClient
+
+
+BACKENDS = ("memory", "tinydb", "sqlite", "duckdb", "parquet")
+
+
+def _location(tmp_path, backend, prefix):
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+    if backend == "memory":
+        return "memory://{0}-{1}".format(prefix, uuid4().hex)
+    return str(tmp_path / "{0}-{1}".format(prefix, backend))
+
+
+def _seed_documents():
+    return [
+        {
+            "_id": 1,
+            "group": "many",
+            "obsolete": "remove",
+            "nested": {"obsolete": True, "keep": 1},
+            "keep": "one",
+        },
+        {
+            "_id": 2,
+            "group": "many",
+            "obsolete": "remove",
+            "nested": {"keep": 2},
+            "keep": "two",
+        },
+        {
+            "_id": 3,
+            "group": "many",
+            "nested": {"keep": 3},
+            "keep": "three",
+        },
+    ]
+
+
+def _assert_post_images(documents):
+    assert documents == [
+        {
+            "_id": 1,
+            "group": "many",
+            "nested": {"keep": 1},
+            "keep": "one",
+        },
+        {
+            "_id": 2,
+            "group": "many",
+            "nested": {"keep": 2},
+            "keep": "two",
+        },
+        {
+            "_id": 3,
+            "group": "many",
+            "nested": {"keep": 3},
+            "keep": "three",
+        },
+    ]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_unset_removes_top_level_and_nested_fields_on_embedded_backends(
+    tmp_path, backend
+):
+    client = TinyMongoClient(
+        _location(tmp_path, backend, "sync-unset"),
+        backend=backend,
+    )
+    collection = client.app.items
+    collection.insert_many(_seed_documents())
+
+    one = collection.update_one(
+        {"_id": 1},
+        {
+            "$unset": {
+                "obsolete": "",
+                "nested.obsolete": "",
+                "missing": "",
+                "nested.missing": "",
+            }
+        },
+    )
+    assert one.matched_count == 1
+    assert one.modified_count == 1
+
+    one_noop = collection.update_one(
+        {"_id": 1},
+        {"$unset": {"obsolete": "", "nested.obsolete": "", "missing": ""}},
+    )
+    assert one_noop.matched_count == 1
+    assert one_noop.modified_count == 0
+
+    many = collection.update_many(
+        {"group": "many"},
+        {
+            "$unset": {
+                "obsolete": "",
+                "nested.obsolete": "",
+                "missing": "",
+                "nested.missing": "",
+            }
+        },
+    )
+    assert many.matched_count == 3
+    assert many.modified_count == 1
+    _assert_post_images(list(collection.find({}).sort("_id")))
+
+    many_noop = collection.update_many(
+        {"group": "many"},
+        {"$unset": {"obsolete": "", "nested.obsolete": "", "missing": ""}},
+    )
+    assert many_noop.matched_count == 3
+    assert many_noop.modified_count == 0
+    client.close()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_async_unset_has_the_same_embedded_backend_semantics(tmp_path, backend):
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            _location(tmp_path, backend, "async-unset"),
+            backend=backend,
+        )
+        collection = client.app.items
+        await collection.insert_many(_seed_documents())
+
+        result = await collection.update_many(
+            {"group": "many"},
+            {
+                "$unset": {
+                    "obsolete": "",
+                    "nested.obsolete": "",
+                    "missing": "",
+                    "nested.missing": "",
+                }
+            },
+        )
+        assert result.matched_count == 3
+        assert result.modified_count == 2
+        _assert_post_images(await collection.find({}).sort("_id").to_list())
+
+        noop = await collection.update_many(
+            {"group": "many"},
+            {"$unset": {"obsolete": "", "nested.obsolete": "", "missing": ""}},
+        )
+        assert noop.matched_count == 3
+        assert noop.modified_count == 0
+        await client.close()
+
+    asyncio.run(scenario())

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -14,6 +14,7 @@ import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .errors import InvalidOperation, TinyMongoNotSupportedError
+from .storage_backends import get_storage_class
 from .tinymongo import (
     _CompatibilityConcern,
     MongoClient,
@@ -87,9 +88,19 @@ class _AsyncClientBase:
     """Shared implementation for the native and PyMongo-shaped clients."""
 
     _sync_client_class: Any = TinyMongoClient
+    _backend_position: Optional[int] = 1
 
     def __init__(self, *args: Any, **kwargs: Any):
         sync_client_class = self._sync_client_class
+        if "backend" in kwargs:
+            backend = kwargs["backend"]
+        elif self._backend_position is not None and len(args) > self._backend_position:
+            backend = args[self._backend_position]
+        else:
+            backend = "tinydb"
+        # Validate without constructing the synchronous client, which keeps
+        # database selection and all storage work lazy and off the event loop.
+        get_storage_class(backend or "tinydb")
         self._state = _AsyncClientState(lambda: sync_client_class(*args, **kwargs))
 
     def __getitem__(self, name: str) -> "AsyncTinyMongoDatabase":
@@ -182,6 +193,7 @@ class AsyncMongoClient(_AsyncClientBase):
     """PyMongo-shaped asynchronous client backed by local TinyMongo storage."""
 
     _sync_client_class = MongoClient
+    _backend_position = None
 
 
 class AsyncTinyMongoDatabase:
@@ -283,6 +295,50 @@ class AsyncTinyMongoCollection:
 
     def __repr__(self) -> str:
         return self.name
+
+    def __getattr__(self, name: str) -> "AsyncTinyMongoCollection":
+        """Return a dotted child collection selected by attribute."""
+
+        if name.startswith("_"):
+            full_name = "{}.{}".format(self.name, name)
+            raise AttributeError(
+                "{0} has no attribute {1!r}. To access the {2} collection, "
+                "use database[{2!r}].".format(
+                    type(self).__name__,
+                    name,
+                    full_name,
+                )
+            )
+        return self[name]
+
+    def __getitem__(self, name: str) -> "AsyncTinyMongoCollection":
+        """Return a dotted child collection selected by subscription."""
+
+        return AsyncTinyMongoCollection(
+            self.database,
+            "{}.{}".format(self.name, name),
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Explain method typos that resolved to a child collection."""
+
+        if "." not in self.name:
+            raise TypeError(
+                "'{0}' object is not callable. If you meant to call the "
+                "'{1}' method on an 'AsyncTinyMongoDatabase' object it is "
+                "failing because no such method exists.".format(
+                    type(self).__name__,
+                    self.name,
+                )
+            )
+        raise TypeError(
+            "'{0}' object is not callable. If you meant to call the '{1}' "
+            "method on a '{0}' object it is failing because no such method "
+            "exists.".format(
+                type(self).__name__,
+                self.name.rsplit(".", 1)[-1],
+            )
+        )
 
     async def _call(self, method: str, *args: Any, **kwargs: Any) -> Any:
         def operation(client: TinyMongoClient) -> Any:

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -3,36 +3,77 @@
 Storage backends keep using ordinary JSON payloads. Values JSON cannot
 represent are wrapped at the persistence boundary and restored on read, so
 callers continue to work with the original Python objects.
+
+``__tinymongo_type_v1__`` is TinyMongo's reserved persisted tag namespace and
+must remain readable for backward compatibility. A user mapping with the exact
+two-key tag shape is escaped before storage so new writes remain unambiguous.
 """
 
 from __future__ import absolute_import
 
+import base64
+import binascii
+from collections.abc import Mapping
 from datetime import datetime
 import json
+import math
+
+from . import bson_types
+
+
+# Compatibility aliases remain patchable for dependency-error tests and older
+# integrations. Type recognition and encoding metadata come exclusively from
+# ``bson_types``.
+_ObjectId = bson_types.object_id_type()
+_Binary = bson_types.binary_type()
 
 
 _TYPE_MARKER = "__tinymongo_type_v1__"
 _VALUE_MARKER = "value"
 _ESCAPED_MAPPING = "mapping"
-
-try:
-    from bson import ObjectId as _ObjectId
-except ImportError:  # pragma: no cover - environment without optional bson
-    _ObjectId = None  # type: ignore[misc,assignment]
+_BINARY_VALUE = "binary"
+_BINARY_DATA = "base64"
+_BINARY_SUBTYPE = "subtype"
+_NONFINITE_FLOAT = "float"
 
 
 def bson_available():
     """Return whether the optional BSON implementation can be used."""
+    return object_id_available() and binary_available()
+
+
+def object_id_available():
+    """Return whether PyMongo ``ObjectId`` values can be restored."""
+
     return _ObjectId is not None
+
+
+def binary_available():
+    """Return whether non-generic PyMongo ``Binary`` values can be restored."""
+
+    return _Binary is not None
 
 
 def encode_value(value):
     """Recursively convert supported non-JSON values into tagged JSON data."""
-    if _ObjectId is not None and isinstance(value, _ObjectId):
+    spec = bson_types.bson_type_spec(value)
+    storage_tag = spec.storage_tag if spec is not None else None
+    if storage_tag == "objectid":
         return {_TYPE_MARKER: "objectid", _VALUE_MARKER: str(value)}
-    if isinstance(value, datetime):
+    if storage_tag == "datetime":
         return {_TYPE_MARKER: "datetime", _VALUE_MARKER: value.isoformat()}
-    if isinstance(value, dict):
+    if storage_tag == _BINARY_VALUE:
+        raw, subtype = bson_types.binary_components(value)
+        return _encode_binary(raw, subtype)
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            payload = "nan"
+        elif value < 0:
+            payload = "-infinity"
+        else:
+            payload = "infinity"
+        return {_TYPE_MARKER: _NONFINITE_FLOAT, _VALUE_MARKER: payload}
+    if isinstance(value, Mapping):
         # A user mapping can legitimately have the same two keys as one of our
         # scalar tags. Wrap that exact shape so it cannot be silently decoded as
         # a datetime/ObjectId when it crosses a persistence boundary.
@@ -49,6 +90,42 @@ def encode_value(value):
     return value
 
 
+def _encode_binary(value, subtype):
+    payload = {
+        _BINARY_DATA: base64.b64encode(bytes(value)).decode("ascii"),
+        _BINARY_SUBTYPE: int(subtype),
+    }
+    return {_TYPE_MARKER: _BINARY_VALUE, _VALUE_MARKER: payload}
+
+
+def _decode_binary(payload):
+    if not isinstance(payload, dict):
+        raise ValueError("Binary payload must be a mapping")
+    if set(payload) != {_BINARY_DATA, _BINARY_SUBTYPE}:
+        raise ValueError("Binary payload has an unexpected shape")
+
+    encoded = payload[_BINARY_DATA]
+    subtype = payload[_BINARY_SUBTYPE]
+    if not isinstance(encoded, str):
+        raise ValueError("Binary data must be base64 text")
+    if isinstance(subtype, bool) or not isinstance(subtype, int):
+        raise ValueError("Binary subtype must be an integer")
+    if not 0 <= subtype <= 255:
+        raise ValueError("Binary subtype must be between 0 and 255")
+
+    raw = base64.b64decode(encoded.encode("ascii"), validate=True)
+    if subtype == 0:
+        # PyMongo also decodes BSON's generic binary subtype to plain bytes.
+        return raw
+    if _Binary is None:
+        raise ImportError(
+            "Reading BSON Binary values with a non-zero subtype requires the "
+            "optional 'pymongo' package. Install it with: "
+            "pip install 'tinymongo[bson]'"
+        )
+    return _Binary(raw, subtype=subtype)
+
+
 def decode_value(value):
     """Recursively restore values previously produced by :func:`encode_value`."""
     if isinstance(value, dict):
@@ -56,22 +133,45 @@ def decode_value(value):
             kind = value[_TYPE_MARKER]
             payload = value[_VALUE_MARKER]
             if kind == "datetime":
-                return datetime.fromisoformat(payload)
+                if isinstance(payload, str):
+                    try:
+                        return datetime.fromisoformat(payload)
+                    except ValueError:
+                        # Preserve malformed or future-shaped tags below.
+                        pass
             if kind == "objectid":
-                if _ObjectId is None:
-                    raise ImportError(
-                        "Reading BSON ObjectId values requires the optional "
-                        "'pymongo' package. Install it with: "
-                        "pip install 'tinymongo[bson]'"
-                    )
-                return _ObjectId(payload)
+                if _valid_object_id_payload(payload):
+                    if _ObjectId is None:
+                        raise ImportError(
+                            "Reading BSON ObjectId values requires the optional "
+                            "'pymongo' package. Install it with: "
+                            "pip install 'tinymongo[bson]'"
+                        )
+                    return _ObjectId(payload)
+            if kind == _BINARY_VALUE:
+                try:
+                    return _decode_binary(payload)
+                except (binascii.Error, UnicodeEncodeError, ValueError):
+                    # Preserve malformed or future-shaped tags just like an
+                    # unknown tag rather than turning user data into a value.
+                    return value
+            if kind == _NONFINITE_FLOAT:
+                if payload == "nan":
+                    return float("nan")
+                if payload == "-infinity":
+                    return float("-inf")
+                if payload == "infinity":
+                    return float("inf")
             if kind == _ESCAPED_MAPPING:
                 if not isinstance(payload, list):
-                    return {key: decode_value(item) for key, item in value.items()}
+                    return value
                 try:
                     return {str(key): decode_value(item) for key, item in payload}
                 except (TypeError, ValueError):
-                    return {key: decode_value(item) for key, item in value.items()}
+                    return value
+            # Unknown tags and malformed datetime/ObjectId tags are user data,
+            # not partially decodable containers.
+            return value
         return {key: decode_value(item) for key, item in value.items()}
     if isinstance(value, list):
         return [decode_value(item) for item in value]
@@ -80,6 +180,7 @@ def decode_value(value):
 
 def dumps(value, **kwargs):
     """Serialize a TinyMongo value as JSON with BSON-compatible tagging."""
+    kwargs.setdefault("allow_nan", False)
     return json.dumps(encode_value(value), **kwargs)
 
 
@@ -97,12 +198,25 @@ def clone(value):
 
 def contains_extended_value(value):
     """Return whether a filter contains a value requiring Python comparison."""
-    if isinstance(value, datetime):
+    if isinstance(value, float) and not math.isfinite(value):
         return True
-    if _ObjectId is not None and isinstance(value, _ObjectId):
+    spec = bson_types.bson_type_spec(value)
+    if spec is not None and spec.requires_python_comparison:
         return True
     if isinstance(value, dict):
         return any(contains_extended_value(item) for item in value.values())
     if isinstance(value, (list, tuple)):
         return any(contains_extended_value(item) for item in value)
     return False
+
+
+def _valid_object_id_payload(payload):
+    """Return whether a persisted ObjectId payload has TinyMongo's v1 shape."""
+
+    if not isinstance(payload, str) or len(payload) != 24:
+        return False
+    try:
+        decoded = bytes.fromhex(payload)
+    except ValueError:
+        return False
+    return len(decoded) == 12

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -1,0 +1,252 @@
+"""Shared BSON scalar type information.
+
+The JSON codec, query comparison, and cursor sorting all consume this registry
+so type recognition and subclass precedence cannot drift between them. PyMongo
+is optional: its bundled :mod:`bson` implementation is enabled atomically only
+when both ``ObjectId`` and ``Binary`` can be imported.
+"""
+
+from __future__ import absolute_import
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import math
+from typing import Any, Callable, Optional
+
+
+try:
+    import pymongo as _pymongo  # noqa: F401 - proves this is PyMongo's bson
+    from bson import ObjectId as _ObjectId
+    from bson.binary import Binary as _Binary
+except ImportError:  # pragma: no cover - environment without optional bson
+    # Treat the optional implementation as one capability. This avoids
+    # accidentally accepting the unrelated third-party ``bson`` distribution
+    # or reporting partial BSON support from a broken installation.
+    _ObjectId = None  # type: ignore[misc,assignment]
+    _Binary = None  # type: ignore[misc,assignment]
+
+
+@dataclass(frozen=True)
+class BSONTypeSpec:
+    """Shared behavior for one supported BSON scalar family."""
+
+    name: str
+    sort_rank: int
+    sort_key: Callable[[Any], Any]
+    identity_key: Callable[[Any], Any]
+    storage_tag: Optional[str] = None
+    requires_python_comparison: bool = False
+
+
+def _identity(value):
+    return value
+
+
+def _null_key(_value):
+    return None
+
+
+def _number_identity_key(value):
+    # MongoDB considers numeric values across integer/double representations by
+    # numeric value. Python already supplies that equality/hash behavior except
+    # for NaN, which MongoDB treats as one comparable numeric value.
+    if isinstance(value, float) and math.isnan(value):
+        return "nan"
+    return value
+
+
+def _number_sort_key(value):
+    # MongoDB gives NaN a stable position below every other numeric value.
+    # Python's raw NaN comparisons are unordered and can leave surrounding
+    # ordinary numbers unsorted.
+    if isinstance(value, float) and math.isnan(value):
+        return 0, 0
+    return 1, value
+
+
+def binary_components(value):
+    """Return a binary value as ``(bytes, subtype)``.
+
+    Native ``bytes`` and ``bytearray`` use BSON's generic subtype 0. PyMongo's
+    ``Binary`` retains its explicit subtype.
+    """
+
+    raw = bytes(value)
+    subtype = (
+        int(value.subtype) if _Binary is not None and isinstance(value, _Binary) else 0
+    )
+    return raw, subtype
+
+
+def _binary_sort_key(value):
+    raw, subtype = binary_components(value)
+    # MongoDB compares BinData by length, then subtype, then byte content.
+    return len(raw), subtype, raw
+
+
+def _binary_identity_key(value):
+    raw, subtype = binary_components(value)
+    return subtype, raw
+
+
+def _object_id_key(value):
+    return value.binary
+
+
+def normalize_datetime(value):
+    """Return a datetime normalized to UTC for stable mixed-date sorting.
+
+    MongoDB stores dates as UTC. TinyMongo treats a naive datetime as already
+    being in UTC and converts aware datetimes to the same timezone.
+    """
+
+    if value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _datetime_identity_key(value):
+    """Return MongoDB's signed UTC millisecond identity for a datetime."""
+
+    normalized = normalize_datetime(value)
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    delta = normalized - epoch
+    return delta.days * 86_400_000 + delta.seconds * 1_000 + delta.microseconds // 1_000
+
+
+# The ranks reserve 3 and 4 for mappings and arrays, which cursors recursively
+# order themselves. The remaining order follows MongoDB's documented BSON
+# comparison order for the scalar families TinyMongo currently supports.
+_NULL = BSONTypeSpec("null", 0, _null_key, _null_key)
+_NUMBER = BSONTypeSpec("number", 1, _number_sort_key, _number_identity_key)
+_STRING = BSONTypeSpec("string", 2, _identity, _identity)
+_BINARY = BSONTypeSpec(
+    "binary",
+    5,
+    _binary_sort_key,
+    _binary_identity_key,
+    storage_tag="binary",
+    requires_python_comparison=True,
+)
+_OBJECT_ID = BSONTypeSpec(
+    "objectid",
+    6,
+    _object_id_key,
+    _object_id_key,
+    storage_tag="objectid",
+    requires_python_comparison=True,
+)
+_BOOLEAN = BSONTypeSpec("boolean", 7, _identity, _identity)
+_DATETIME = BSONTypeSpec(
+    "datetime",
+    8,
+    normalize_datetime,
+    _datetime_identity_key,
+    storage_tag="datetime",
+    requires_python_comparison=True,
+)
+
+
+def bson_capabilities():
+    """Return the optional PyMongo BSON capabilities available at import time."""
+
+    available = _ObjectId is not None and _Binary is not None
+    return {"objectid": available, "binary": available}
+
+
+def object_id_type():
+    """Return PyMongo's ``ObjectId`` class, or ``None`` when unavailable."""
+
+    return _ObjectId
+
+
+def binary_type():
+    """Return PyMongo's ``Binary`` class, or ``None`` when unavailable."""
+
+    return _Binary
+
+
+def bson_type_spec(value) -> Optional[BSONTypeSpec]:
+    """Return sorting metadata for a supported scalar, or ``None``.
+
+    Checks are deliberately ordered for subclass safety: ``Binary`` precedes
+    native byte values, and ``bool`` precedes integers.
+    """
+
+    if value is None:
+        return _NULL
+    if _Binary is not None and isinstance(value, _Binary):
+        return _BINARY
+    if isinstance(value, (bytes, bytearray)):
+        return _BINARY
+    if _ObjectId is not None and isinstance(value, _ObjectId):
+        return _OBJECT_ID
+    if isinstance(value, datetime):
+        return _DATETIME
+    if isinstance(value, bool):
+        return _BOOLEAN
+    if isinstance(value, (int, float)):
+        return _NUMBER
+    if isinstance(value, str):
+        return _STRING
+    return None
+
+
+def bson_scalar_sort_key(value):
+    """Return ``(rank, value)`` for a supported BSON scalar.
+
+    ``None`` means the cursor must handle a container or unsupported value.
+    """
+
+    spec = bson_type_spec(value)
+    if spec is None:
+        return None
+    return spec.sort_rank, spec.sort_key(value)
+
+
+def bson_identity_key(value):
+    """Return a hashable, BSON-type-aware scalar equality key.
+
+    ``None`` means the value is outside the registered scalar families. Binary
+    subtype is significant, except that native byte values and ``Binary`` with
+    subtype 0 intentionally share one identity. Numeric Python types share
+    MongoDB-style numeric equality while booleans remain a separate family.
+    """
+
+    spec = bson_type_spec(value)
+    if spec is None:
+        return None
+    return spec.name, spec.identity_key(value)
+
+
+def bson_values_equal(left, right):
+    """Compare values recursively with MongoDB-compatible type semantics."""
+
+    if isinstance(left, Mapping) or isinstance(right, Mapping):
+        if not isinstance(left, Mapping) or not isinstance(right, Mapping):
+            return False
+        left_items = list(left.items())
+        right_items = list(right.items())
+        return len(left_items) == len(right_items) and all(
+            left_key == right_key and bson_values_equal(left_value, right_value)
+            for (left_key, left_value), (right_key, right_value) in zip(
+                left_items, right_items
+            )
+        )
+
+    left_is_array = isinstance(left, (list, tuple))
+    right_is_array = isinstance(right, (list, tuple))
+    if left_is_array or right_is_array:
+        if not left_is_array or not right_is_array or len(left) != len(right):
+            return False
+        return all(
+            bson_values_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right)
+        )
+
+    left_key = bson_identity_key(left)
+    right_key = bson_identity_key(right)
+    if left_key is None or right_key is None:
+        return left == right
+    return left_key == right_key

--- a/tinymongo/cli.py
+++ b/tinymongo/cli.py
@@ -3,11 +3,14 @@
 from __future__ import absolute_import
 
 import argparse
-import json
+import copy
 import os
 import sys
+from uuid import uuid4
 
-from .storage_backends import storage_extension
+from .bson_codec import dumps as bson_json_dumps
+from .bson_codec import loads as bson_json_loads
+from .storage_backends import is_remote_sql_backend, storage_extension
 from .tinymongo import TinyMongoClient
 
 
@@ -25,14 +28,53 @@ SUPPORTED_BACKENDS = (
 )
 
 
+def _effective_storage_uri(backend, storage_uri=None):
+    if str(backend).lower() not in ("parquet", "parquetv2"):
+        return None
+    if storage_uri is not None:
+        return storage_uri
+    return os.environ.get("TINYMONGO_STORAGE_URI")
+
+
+def _effective_dsn(backend, dsn=None):
+    backend = str(backend).lower()
+    if backend in ("postgres", "postgresql"):
+        names = (
+            "TINYMONGO_POSTGRES_DSN",
+            "TINYMONGO_POSTGRESQL_DSN",
+            "DATABASE_URL",
+        )
+    elif backend in ("mysql", "mariadb"):
+        names = (
+            "TINYMONGO_MYSQL_DSN",
+            "TINYMONGO_MARIADB_DSN",
+            "MYSQL_URL",
+            "MARIADB_URL",
+        )
+    else:
+        return None
+    if dsn is not None:
+        return dsn
+    return next((os.environ[name] for name in names if os.environ.get(name)), None)
+
+
 def _client(path, backend, storage_uri=None, dsn=None):
-    return TinyMongoClient(path, backend=backend, storage_uri=storage_uri, dsn=dsn)
+    return TinyMongoClient(
+        path,
+        backend=backend,
+        storage_uri=_effective_storage_uri(backend, storage_uri),
+        dsn=_effective_dsn(backend, dsn),
+    )
 
 
 def _db_names(path, backend, storage_uri=None, dsn=None):
-    if storage_uri or dsn:
+    effective_storage_uri = _effective_storage_uri(backend, storage_uri)
+    if is_remote_sql_backend(backend) or effective_storage_uri:
         return _client(
-            path, backend, storage_uri=storage_uri, dsn=dsn
+            path,
+            backend,
+            storage_uri=effective_storage_uri,
+            dsn=_effective_dsn(backend, dsn),
         ).list_database_names()
     ext = storage_extension(backend)
     if not os.path.isdir(path):
@@ -47,34 +89,92 @@ def _db_names(path, backend, storage_uri=None, dsn=None):
 
 def _load_json(path):
     if path == "-":
-        return json.load(sys.stdin)
+        return bson_json_loads(sys.stdin.read())
     with open(path, "r", encoding="utf-8") as handle:
-        return json.load(handle)
+        return bson_json_loads(handle.read())
 
 
-def _dump_json(data, path):
+def _dump_json(data, path, sort_keys=True):
+    payload = bson_json_dumps(data, indent=2, sort_keys=sort_keys)
     if path == "-":
-        json.dump(data, sys.stdout, indent=2, sort_keys=True)
-        sys.stdout.write("\n")
+        sys.stdout.write(payload + "\n")
         return
     with open(path, "w", encoding="utf-8") as handle:
-        json.dump(data, handle, indent=2, sort_keys=True)
-        handle.write("\n")
+        handle.write(payload + "\n")
+
+
+def _collection_names(database):
+    """Return user collections without TinyDB's internal default table."""
+
+    modern_listing = getattr(database, "list_collection_names", None)
+    if callable(modern_listing):
+        names = modern_listing()
+    else:
+        names = database.collection_names()
+    return [name for name in names if name != "_default"]
+
+
+def _copy_indexes(source, target):
+    """Recreate a collection's effective indexes on a staging collection."""
+
+    for metadata in source.list_indexes():
+        if metadata["name"] == "_id_":
+            continue
+        options = {"name": metadata["name"]}
+        if metadata.get("unique"):
+            options["unique"] = True
+        target.create_index(copy.deepcopy(metadata["key"]), **options)
+
+
+def _replace_collection(database, collection_name, docs):
+    """Preflight a complete replacement before changing the destination."""
+
+    # Keep validation isolated from the target client (and from CLI client
+    # factories that callers may patch for remote connection setup).
+    from .tinymongo import TinyMongoClient as PreflightClient
+
+    collection = database[collection_name]
+    with PreflightClient(backend="memory") as preflight_client:
+        stage = preflight_client.preflight[
+            "__tinymongo_stage_{0}".format(uuid4().hex[:12])
+        ]
+        _copy_indexes(collection, stage)
+        if docs:
+            stage.insert_many(copy.deepcopy(docs))
+
+    previous = list(collection.find({}))
+    try:
+        collection.delete_many({})
+        if docs:
+            collection.insert_many(docs)
+    except Exception as replacement_error:
+        # Staging eliminates deterministic codec, ID, and index failures. This
+        # rollback is the final guard for an environmental or concurrent error
+        # between preflight and the destination write.
+        try:
+            collection.delete_many({})
+            if previous:
+                collection.insert_many(previous)
+        except Exception as rollback_error:
+            raise RuntimeError(
+                "Collection replacement failed and the previous data could not "
+                "be restored: {0}".format(replacement_error)
+            ) from rollback_error
+        raise
 
 
 def cmd_inspect(args):
-    client = _client(
-        args.path, args.backend, storage_uri=args.storage_uri, dsn=args.dsn
-    )
+    storage_uri = _effective_storage_uri(args.backend, args.storage_uri)
+    client = _client(args.path, args.backend, storage_uri=storage_uri, dsn=args.dsn)
     payload = {"path": args.path, "backend": args.backend, "databases": []}
-    if args.storage_uri:
-        payload["storage_uri"] = args.storage_uri
+    if storage_uri:
+        payload["storage_uri"] = storage_uri
     for db_name in _db_names(
-        args.path, args.backend, storage_uri=args.storage_uri, dsn=args.dsn
+        args.path, args.backend, storage_uri=storage_uri, dsn=args.dsn
     ):
         db = client[db_name]
         collections = []
-        for collection_name in sorted(db.collection_names()):
+        for collection_name in sorted(_collection_names(db)):
             count = db[collection_name].count()
             collections.append({"name": collection_name, "count": count})
         payload["databases"].append({"name": db_name, "collections": collections})
@@ -94,7 +194,7 @@ def cmd_list_collections(args):
     client = _client(
         args.path, args.backend, storage_uri=args.storage_uri, dsn=args.dsn
     )
-    for name in sorted(client[args.database].collection_names()):
+    for name in sorted(_collection_names(client[args.database])):
         print(name)
     return 0
 
@@ -104,7 +204,9 @@ def cmd_export(args):
         args.path, args.backend, storage_uri=args.storage_uri, dsn=args.dsn
     )
     docs = list(client[args.database][args.collection].find({}))
-    _dump_json(docs, args.output)
+    # Embedded-document field order is part of BSON equality and can also be
+    # part of a document-valued _id. Never recursively sort exported data.
+    _dump_json(docs, args.output, sort_keys=False)
     return 0
 
 
@@ -119,21 +221,32 @@ def cmd_import(args):
     client = _client(
         args.path, args.backend, storage_uri=args.storage_uri, dsn=args.dsn
     )
-    collection = client[args.database][args.collection]
+    database = client[args.database]
+    collection = database[args.collection]
     if args.mode == "replace":
-        collection.delete_many({})
-    if docs:
+        _replace_collection(database, args.collection, docs)
+    elif docs:
         collection.insert_many(docs)
     print("imported {0} documents".format(len(docs)))
     return 0
 
 
 def cmd_migrate(args):
+    source_uri = _effective_storage_uri(args.from_backend, args.source_uri)
+    target_uri = _effective_storage_uri(args.to_backend, args.target_uri)
+    source_dsn = _effective_dsn(args.from_backend, args.source_dsn)
+    target_dsn = _effective_dsn(args.to_backend, args.target_dsn)
     source_client = _client(
-        args.source, args.from_backend, storage_uri=args.source_uri, dsn=args.source_dsn
+        args.source,
+        args.from_backend,
+        storage_uri=source_uri,
+        dsn=source_dsn,
     )
     target_client = _client(
-        args.target, args.to_backend, storage_uri=args.target_uri, dsn=args.target_dsn
+        args.target,
+        args.to_backend,
+        storage_uri=target_uri,
+        dsn=target_dsn,
     )
 
     database_names = (
@@ -142,20 +255,17 @@ def cmd_migrate(args):
         else _db_names(
             args.source,
             args.from_backend,
-            storage_uri=args.source_uri,
-            dsn=args.source_dsn,
+            storage_uri=source_uri,
+            dsn=source_dsn,
         )
     )
     migrated = []
     for db_name in database_names:
         source_db = source_client[db_name]
         target_db = target_client[db_name]
-        for collection_name in sorted(source_db.collection_names()):
+        for collection_name in sorted(_collection_names(source_db)):
             docs = list(source_db[collection_name].find({}))
-            target_collection = target_db[collection_name]
-            target_collection.delete_many({})
-            if docs:
-                target_collection.insert_many(docs)
+            _replace_collection(target_db, collection_name, docs)
             migrated.append(
                 {"database": db_name, "collection": collection_name, "count": len(docs)}
             )
@@ -166,10 +276,10 @@ def cmd_migrate(args):
             "target": args.target,
             "from_backend": args.from_backend,
             "to_backend": args.to_backend,
-            "source_uri": args.source_uri,
-            "target_uri": args.target_uri,
-            "source_dsn_configured": bool(args.source_dsn),
-            "target_dsn_configured": bool(args.target_dsn),
+            "source_uri": source_uri,
+            "target_uri": target_uri,
+            "source_dsn_configured": bool(source_dsn),
+            "target_dsn_configured": bool(target_dsn),
             "migrated": migrated,
         },
         args.output,

--- a/tinymongo/errors.py
+++ b/tinymongo/errors.py
@@ -46,6 +46,17 @@ except ImportError:  # pragma: no cover - exercised in dependency-free installs
     class _DuplicateKeyError(_WriteError):
         pass
 
+    class _BulkWriteError(_OperationFailure):
+        def __init__(self, results):
+            super(_BulkWriteError, self).__init__(
+                "batch op errors occurred", code=65, details=results
+            )
+
+        @property
+        def timeout(self):
+            write_errors = self.details.get("writeErrors", [])
+            return bool(write_errors and write_errors[-1].get("code") == 50)
+
     class _InvalidOperation(_PyMongoError):
         pass
 
@@ -57,6 +68,7 @@ else:
     _CursorNotFound = _pymongo_errors.CursorNotFound  # type: ignore[misc,assignment]
     _WriteError = _pymongo_errors.WriteError  # type: ignore[misc,assignment]
     _DuplicateKeyError = _pymongo_errors.DuplicateKeyError  # type: ignore[misc,assignment]
+    _BulkWriteError = _pymongo_errors.BulkWriteError  # type: ignore[misc,assignment]
     _InvalidOperation = _pymongo_errors.InvalidOperation  # type: ignore[misc,assignment]
 
 
@@ -86,6 +98,10 @@ class WriteError(_WriteError, OperationFailure):
 
 class DuplicateKeyError(_DuplicateKeyError, WriteError):
     """Raised when a write violates a unique key constraint."""
+
+
+class BulkWriteError(_BulkWriteError, OperationFailure):
+    """Raised when one or more operations in a batch write fail."""
 
 
 class InvalidOperation(_InvalidOperation, TinyMongoError):

--- a/tinymongo/indexes.py
+++ b/tinymongo/indexes.py
@@ -24,7 +24,7 @@ _MODEL_ALLOWED_OPTIONS = {
 
 
 class TinyMongoUnsupportedWarning(UserWarning):
-    """Warn that an index declaration was accepted with reduced behavior."""
+    """Warn that a request was accepted with explicitly reduced behavior."""
 
 
 def _unsupported(message):

--- a/tinymongo/parquet_storage.py
+++ b/tinymongo/parquet_storage.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 from .errors import StorageCorruptionError
 from .bson_codec import dumps as json_dumps
 from .bson_codec import loads as json_loads
+from .bson_types import bson_values_equal
 
 try:
     import pyarrow as _pa
@@ -30,6 +31,7 @@ portalocker: Any = _portalocker
 # acquisitions causing AlreadyLocked errors when the same process/thread
 # re-enters storage write paths.
 _local_rlocks: Dict[str, threading.RLock] = {}
+_MISSING_ID = object()
 
 
 def _require_pyarrow():
@@ -180,16 +182,18 @@ class ParquetStorage(Storage):
                     next_eid = 1
 
                 for k, v in incoming_table.items():
-                    doc_id = v.get("_id") if isinstance(v, dict) else None
+                    doc_id = (
+                        v["_id"] if isinstance(v, dict) and "_id" in v else _MISSING_ID
+                    )
                     existing_eid = next(
                         (
                             eid
                             for existing_id, eid in ids_and_eids
-                            if existing_id == doc_id
+                            if bson_values_equal(existing_id, doc_id)
                         ),
                         None,
                     )
-                    if doc_id is not None and existing_eid is not None:
+                    if doc_id is not _MISSING_ID and existing_eid is not None:
                         existing_table[existing_eid] = v
                     else:
                         existing_table[str(next_eid)] = v

--- a/tinymongo/storage_backends.py
+++ b/tinymongo/storage_backends.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from .bson_codec import clone as clone_document
 from .bson_codec import dumps as json_dumps
 from .bson_codec import loads as json_loads
+from .bson_types import bson_values_equal
 from .parquet_storage import _acquire_rlock, _fsync_dir, _local_rlocks, portalocker
 from .errors import StorageCorruptionError
 
@@ -21,6 +22,20 @@ duckdb: Any = _duckdb
 
 
 OBJECT_STORAGE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
+SUPPORTED_BACKEND_NAMES = (
+    "memory",
+    "tinydb",
+    "json",
+    "parquet",
+    "parquetv2",
+    "sqlite",
+    "duckdb",
+    "postgres",
+    "postgresql",
+    "mysql",
+    "mariadb",
+)
+_MISSING_ID = object()
 
 
 _memory_registry: dict[str, dict[str, Any]] = {}
@@ -158,12 +173,20 @@ class AtomicJSONStorage(Storage):
                 next_eid = 1
 
             for value in incoming_table.values():
-                doc_id = value.get("_id") if isinstance(value, dict) else None
+                doc_id = (
+                    value["_id"]
+                    if isinstance(value, dict) and "_id" in value
+                    else _MISSING_ID
+                )
                 existing_eid = next(
-                    (eid for existing_id, eid in ids_and_eids if existing_id == doc_id),
+                    (
+                        eid
+                        for existing_id, eid in ids_and_eids
+                        if bson_values_equal(existing_id, doc_id)
+                    ),
                     None,
                 )
-                if doc_id is not None and existing_eid is not None:
+                if doc_id is not _MISSING_ID and existing_eid is not None:
                     existing_table[existing_eid] = value
                 else:
                     existing_table[str(next_eid)] = value
@@ -375,8 +398,9 @@ def get_storage_class(name):
         return DuckDBStorage
 
     raise ValueError(
-        "Unsupported backend '{0}'. Supported backends: memory, tinydb, parquet, parquetv2, sqlite, duckdb, postgres, mariadb.".format(
-            name
+        "Unsupported backend '{0}'. Supported backends: {1}.".format(
+            name,
+            ", ".join(SUPPORTED_BACKEND_NAMES),
         )
     )
 
@@ -396,8 +420,9 @@ def storage_extension(name):
     if backend in ("postgres", "postgresql", "mysql", "mariadb"):
         return ""
     raise ValueError(
-        "Unsupported backend '{0}'. Supported backends: memory, tinydb, parquet, parquetv2, sqlite, duckdb, postgres, mariadb.".format(
-            name
+        "Unsupported backend '{0}'. Supported backends: {1}.".format(
+            name,
+            ", ".join(SUPPORTED_BACKEND_NAMES),
         )
     )
 

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -1,11 +1,15 @@
+import ast
+import copy
 import hashlib
 import importlib
 import json
+import math
 import os
 import re
 import sqlite3
 import tempfile
 import threading
+from collections.abc import Mapping
 from contextlib import contextmanager
 from functools import wraps
 from urllib.parse import parse_qs, unquote, urlparse
@@ -14,6 +18,7 @@ from typing import Optional
 from .bson_codec import contains_extended_value
 from .bson_codec import dumps as bson_json_dumps
 from .bson_codec import loads as bson_json_loads
+from .bson_types import bson_identity_key, bson_values_equal
 from .errors import (
     DuplicateKeyError,
     OperationFailure,
@@ -33,6 +38,195 @@ from .parquet_storage import _acquire_rlock, _local_rlocks, portalocker
 
 _MISSING = object()
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
+_PHYSICAL_ID_PREFIX = "__tinymongo_id_v2__:"
+
+
+def _canonical_id_value(value):
+    """Build a stable serialization of the registry's BSON identity key."""
+    identity = bson_identity_key(value)
+    if identity is not None:
+        family, key = identity
+        if family == "number":
+            if isinstance(key, float):
+                if math.isinf(key):
+                    key = "-infinity" if key < 0 else "infinity"
+                else:
+                    key = list(key.as_integer_ratio())
+            elif isinstance(key, int):
+                key = [key, 1]
+        return [
+            "registered-scalar",
+            json.loads(
+                bson_json_dumps(
+                    [family, key],
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                )
+            ),
+        ]
+
+    # MongoDB does not permit arrays as `_id` values, and TinyMongo only
+    # historically accepted containers as a local extension. Preserve that
+    # behavior with recursive typed keys while keeping registered scalars
+    # governed exclusively by the BSON registry above.
+    if isinstance(value, Mapping):
+        return [
+            "object",
+            [[str(key), _canonical_id_value(item)] for key, item in value.items()],
+        ]
+    if isinstance(value, (list, tuple)):
+        return ["array", [_canonical_id_value(item) for item in value]]
+
+    # Preserve deterministic identity for any codec-supported scalar outside
+    # the current BSON registry.
+    encoded = json.loads(
+        bson_json_dumps(
+            value,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+    )
+    return ["encoded-scalar", encoded]
+
+
+def _physical_id_key(value):
+    """Return the compact typed key stored in SQL and Parquet `_id` columns."""
+    canonical = json.dumps(
+        _canonical_id_value(value),
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    return _PHYSICAL_ID_PREFIX + hashlib.sha256(canonical).hexdigest()
+
+
+def _physical_id_candidates(value):
+    """Return the v2 key followed by compatible legacy stringified keys."""
+
+    current = _physical_id_key(value)
+    legacy = [str(value)]
+    if not isinstance(value, bool) and isinstance(value, int):
+        try:
+            float_value = float(value)
+        except OverflowError:
+            pass
+        else:
+            if float_value == value:
+                legacy.append(str(float_value))
+                if value == 0:
+                    legacy.append(str(-0.0))
+    elif isinstance(value, float) and math.isfinite(value) and value.is_integer():
+        legacy.append(str(int(value)))
+
+    return tuple(dict.fromkeys([current] + legacy))
+
+
+def _requires_legacy_id_scan(value):
+    """Return whether equivalent legacy IDs can have unpredictable strings."""
+
+    if isinstance(value, (Mapping, list, tuple)):
+        return True
+    identity = bson_identity_key(value)
+    return identity is not None and identity[0] == "datetime"
+
+
+def _validate_physical_ids(existing_documents, new_documents):
+    """Reject BSON-equivalent `_id` values before reaching native storage."""
+    seen = {
+        _physical_id_key(document["_id"])
+        for document in existing_documents
+        if "_id" in document
+    }
+    for document in new_documents:
+        key = _physical_id_key(document["_id"])
+        if key in seen:
+            raise DuplicateKeyError("_id:{0} already exists".format(document["_id"]))
+        seen.add(key)
+
+
+def _legacy_id_values_equal(left, right):
+    """Compare legacy container IDs without relying on mapping field order."""
+
+    if isinstance(left, Mapping) and isinstance(right, Mapping):
+        return len(left) == len(right) and all(
+            key in right and _legacy_id_values_equal(value, right[key])
+            for key, value in left.items()
+        )
+    if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
+        return len(left) == len(right) and all(
+            _legacy_id_values_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right)
+        )
+    return bson_values_equal(left, right)
+
+
+def _restore_legacy_document_id(row_id, document, requested_id=_MISSING):
+    """Recover the original order of a legacy container ID from its row key."""
+
+    if (
+        not isinstance(row_id, str)
+        or row_id.startswith(_PHYSICAL_ID_PREFIX)
+        or not isinstance(document, dict)
+        or "_id" not in document
+    ):
+        return document
+
+    if requested_id is not _MISSING and str(requested_id) == row_id:
+        candidate = requested_id
+    else:
+        try:
+            candidate = ast.literal_eval(row_id)
+        except (SyntaxError, ValueError):
+            return document
+
+    if (
+        not isinstance(candidate, (Mapping, list, tuple))
+        or str(candidate) != row_id
+        or not _legacy_id_values_equal(candidate, document["_id"])
+    ):
+        return document
+
+    restored = dict(document)
+    restored["_id"] = copy.deepcopy(candidate)
+    return restored
+
+
+def _matching_physical_row_id(rows, value, decode_row=None):
+    """Resolve a current or legacy physical row key by its decoded BSON ID."""
+    expected = _physical_id_key(value)
+    for row in rows:
+        row_id = row[0]
+        try:
+            document = (
+                decode_row(row) if decode_row is not None else _json_loads(row[1])
+            )
+            if _physical_id_key(document["_id"]) == expected:
+                return row_id
+        except (KeyError, TypeError, ValueError):
+            continue
+    return None
+
+
+def _local_matching_physical_row_id(conn, quoted_table, value):
+    candidates = _physical_id_candidates(value)
+    rows = conn.execute(
+        "SELECT _id, data FROM {0} WHERE _id IN ({1})".format(
+            quoted_table,
+            ", ".join("?" for _ in candidates),
+        ),
+        candidates,
+    ).fetchall()
+    stored_id = _matching_physical_row_id(rows, value)
+    if stored_id is not None:
+        return stored_id
+
+    if not _requires_legacy_id_scan(value):
+        return None
+
+    # Container IDs and equivalent datetime representations can have legacy
+    # strings that cannot be enumerated. Restrict the compatibility scan to
+    # those uncommon values so ordinary missing-ID lookups remain indexed.
+    rows = conn.execute("SELECT _id, data FROM {0}".format(quoted_table)).fetchall()
+    return _matching_physical_row_id(rows, value)
 
 
 def _write_locked(method):
@@ -176,10 +370,31 @@ def _get_nested(doc, path, default=_MISSING):
     return current
 
 
+def _values_equal(actual, expected):
+    """Compare values recursively with BSON scalar equality semantics."""
+
+    if isinstance(actual, (list, tuple)) and isinstance(expected, (list, tuple)):
+        return len(actual) == len(expected) and all(
+            _values_equal(left, right) for left, right in zip(actual, expected)
+        )
+    if isinstance(actual, dict) and isinstance(expected, dict):
+        actual_items = list(actual.items())
+        expected_items = list(expected.items())
+        return len(actual_items) == len(expected_items) and all(
+            actual_key == expected_key and _values_equal(actual_value, expected_value)
+            for (actual_key, actual_value), (expected_key, expected_value) in zip(
+                actual_items, expected_items
+            )
+        )
+    return bson_values_equal(actual, expected)
+
+
 def _value_matches(actual, expected):
     if isinstance(actual, list):
-        return actual == expected or expected in actual
-    return actual == expected
+        return _values_equal(actual, expected) or any(
+            _values_equal(item, expected) for item in actual
+        )
+    return _values_equal(actual, expected)
 
 
 def _sqlite_unique_token(data, field):
@@ -257,12 +472,13 @@ def _regex_matches(actual, pattern, options=""):
     )
 
 
-def _field_matches(actual, expected):
+def _field_matches(actual, expected, exact=False):
     exists = actual is not _MISSING
+    equality = _values_equal if exact else _value_matches
     if not isinstance(expected, dict) or not any(
         str(key).startswith("$") for key in expected
     ):
-        return exists and _value_matches(actual, expected)
+        return exists and equality(actual, expected)
 
     options = expected.get("$options", "")
     for operator, operand in expected.items():
@@ -293,19 +509,19 @@ def _field_matches(actual, expected):
             ):
                 return False
         elif operator == "$ne":
-            if exists and _value_matches(actual, operand):
+            if exists and equality(actual, operand):
                 return False
         elif operator == "$in":
             values = operand if isinstance(operand, list) else [operand]
-            if not exists or not any(_value_matches(actual, item) for item in values):
+            if not exists or not any(equality(actual, item) for item in values):
                 return False
         elif operator == "$nin":
             values = operand if isinstance(operand, list) else [operand]
-            if exists and any(_value_matches(actual, item) for item in values):
+            if exists and any(equality(actual, item) for item in values):
                 return False
         elif operator == "$all":
             if not isinstance(actual, list) or not all(
-                item in actual for item in operand
+                any(_values_equal(item, value) for value in actual) for item in operand
             ):
                 return False
         elif operator == "$regex":
@@ -313,10 +529,10 @@ def _field_matches(actual, expected):
                 return False
         elif operator == "$not":
             nested = operand if isinstance(operand, dict) else {"$eq": operand}
-            if exists and _field_matches(actual, nested):
+            if exists and _field_matches(actual, nested, exact=exact):
                 return False
         elif operator == "$eq":
-            if not exists or not _value_matches(actual, operand):
+            if not exists or not equality(actual, operand):
                 return False
         else:
             return False
@@ -341,9 +557,79 @@ def matches_filter(doc, filter_doc):
                 return False
         else:
             actual = _get_nested(doc, key)
-            if not _field_matches(actual, expected):
+            if not _field_matches(actual, expected, exact=key == "_id"):
                 return False
     return True
+
+
+def _filter_references_id(filter_doc):
+    if not isinstance(filter_doc, dict):
+        return False
+    if "_id" in filter_doc:
+        return True
+    return any(
+        _filter_references_id(item)
+        for operator in ("$and", "$or", "$nor")
+        for item in (
+            filter_doc.get(operator, [])
+            if isinstance(filter_doc.get(operator, []), list)
+            else []
+        )
+    )
+
+
+def _id_condition_requires_legacy_scan(condition):
+    if not isinstance(condition, dict):
+        return _requires_legacy_id_scan(condition)
+    if not any(str(key).startswith("$") for key in condition):
+        return _requires_legacy_id_scan(condition)
+    for operator, operand in condition.items():
+        if operator == "$eq" and _requires_legacy_id_scan(operand):
+            return True
+        if operator == "$in":
+            values = operand if isinstance(operand, list) else [operand]
+            if any(_requires_legacy_id_scan(value) for value in values):
+                return True
+    return False
+
+
+def _filter_requires_legacy_id_scan(filter_doc):
+    if not isinstance(filter_doc, dict):
+        return False
+    if "_id" in filter_doc and _id_condition_requires_legacy_scan(filter_doc["_id"]):
+        return True
+    return any(
+        _filter_requires_legacy_id_scan(item)
+        for operator in ("$and", "$or", "$nor")
+        for item in (
+            filter_doc.get(operator, [])
+            if isinstance(filter_doc.get(operator, []), list)
+            else []
+        )
+    )
+
+
+def _postfilter_id_candidates(documents, filter_doc, fallback):
+    """Verify typed/legacy ID candidates and recover legacy numeric matches."""
+
+    if not _filter_references_id(filter_doc):
+        return documents
+
+    matches = [
+        document for document in documents if matches_filter(document, filter_doc)
+    ]
+    direct_equality = (
+        isinstance(filter_doc, dict)
+        and set(filter_doc) == {"_id"}
+        and not isinstance(filter_doc["_id"], dict)
+    )
+    if direct_equality and matches:
+        return matches
+    if _filter_requires_legacy_id_scan(filter_doc):
+        return [
+            document for document in fallback() if matches_filter(document, filter_doc)
+        ]
+    return matches
 
 
 def requires_python_filter(filter_doc):
@@ -354,6 +640,12 @@ def requires_python_filter(filter_doc):
         return True
     for field, expected in filter_doc.items():
         if field in ("$and", "$or", "$nor"):
+            # Physical `_id` candidates intentionally include legacy string
+            # aliases. They are a safe superset for positive predicates, but
+            # negating that SQL superset can discard BSON-distinct legacy rows
+            # before the exact Python postfilter gets a chance to recover them.
+            if field == "$nor" and _filter_references_id({field: expected}):
+                return True
             if any(requires_python_filter(item) for item in expected):
                 return True
         else:
@@ -444,23 +736,39 @@ class SQLCompiler(object):
                 clauses = []
                 params = []
                 for operator, operand in value.items():
-                    if operator in ("$eq", "$ne"):
+                    if operator == "$eq":
+                        candidates = _physical_id_candidates(operand)
                         clauses.append(
-                            "_id {0} ?".format("!=" if operator == "$ne" else "=")
+                            "(" + " OR ".join("_id = ?" for _ in candidates) + ")"
                         )
-                        params.append(str(operand))
+                        params.extend(candidates)
+                    elif operator == "$ne":
+                        # The current typed key is sufficient for a superset.
+                        # A legacy string key may also belong to a BSON-distinct
+                        # value, so filtering it here could create false negatives.
+                        clauses.append("_id != ?")
+                        params.append(_physical_id_key(operand))
                     elif operator == "$in":
                         values = operand if isinstance(operand, list) else [operand]
+                        candidates = [
+                            candidate
+                            for item in values
+                            for candidate in _physical_id_candidates(item)
+                        ]
                         clauses.append(
-                            "_id IN (" + ", ".join("?" for _ in values) + ")"
+                            "_id IN (" + ", ".join("?" for _ in candidates) + ")"
                         )
-                        params.extend(str(item) for item in values)
+                        params.extend(candidates)
                     else:
                         raise ValueError(
                             "Unsupported _id SQL operator: {0}".format(operator)
                         )
                 return "(" + " AND ".join(clauses) + ")", params
-            return "_id = ?", [str(value)]
+            candidates = _physical_id_candidates(value)
+            return (
+                "(" + " OR ".join("_id = ?" for _ in candidates) + ")",
+                list(candidates),
+            )
 
         if isinstance(value, dict):
             clauses = []
@@ -739,7 +1047,7 @@ class SQLiteTableBackend(TableBackend):
                 conn.execute("DROP TABLE tinydb")
                 conn.commit()
                 return
-            data = json.loads(row[0])
+            data = _json_loads(row[0])
             for collection, docs in data.items():
                 conn.execute(
                     "CREATE TABLE IF NOT EXISTS {0} (_id TEXT PRIMARY KEY, data TEXT NOT NULL)".format(
@@ -747,7 +1055,7 @@ class SQLiteTableBackend(TableBackend):
                     )
                 )
                 rows = [
-                    (str(doc.get("_id", eid)), _json_dumps(doc))
+                    (_physical_id_key(doc.get("_id", eid)), _json_dumps(doc))
                     for eid, doc in (docs or {}).items()
                     if isinstance(doc, dict)
                 ]
@@ -812,7 +1120,8 @@ class SQLiteTableBackend(TableBackend):
         self.create_collection(collection)
         existing_docs = self.find(collection, {})
         self.validate_unique_post_image(collection, existing_docs + docs)
-        rows = [(str(doc["_id"]), _json_dumps(doc)) for doc in docs]
+        _validate_physical_ids(existing_docs, docs)
+        rows = [(_physical_id_key(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
             sql = "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
@@ -845,7 +1154,12 @@ class SQLiteTableBackend(TableBackend):
                 rows = conn.execute(sql, params).fetchall()
             finally:
                 conn.close()
-            return [_json_loads(row[0]) for row in rows]
+            documents = [_json_loads(row[0]) for row in rows]
+            return _postfilter_id_candidates(
+                documents,
+                filter_doc,
+                lambda: self._all_docs_unfiltered(collection),
+            )
         except Exception:
             return [
                 doc
@@ -899,21 +1213,29 @@ class SQLiteTableBackend(TableBackend):
     @_write_locked
     def replace_one(self, collection, doc_id, replacement):
         self.create_collection(collection)
+        target_id = _physical_id_key(doc_id)
         self.validate_unique_post_image(
             collection,
             [
-                replacement if doc.get("_id") == doc_id else doc
+                replacement if _physical_id_key(doc.get("_id")) == target_id else doc
                 for doc in self.find(collection, {})
             ],
         )
         conn = self._connect()
         try:
             try:
+                stored_id = _local_matching_physical_row_id(
+                    conn,
+                    _quote_identifier(collection),
+                    doc_id,
+                )
+                if stored_id is None:
+                    return
                 conn.execute(
                     "UPDATE {0} SET data = ? WHERE _id = ?".format(
                         _quote_identifier(collection)
                     ),
-                    (_json_dumps(replacement), str(doc_id)),
+                    (_json_dumps(replacement), stored_id),
                 )
                 conn.commit()
             except sqlite3.IntegrityError as exc:
@@ -928,9 +1250,17 @@ class SQLiteTableBackend(TableBackend):
         self.create_collection(collection)
         conn = self._connect()
         try:
+            stored_ids = [
+                _local_matching_physical_row_id(
+                    conn,
+                    _quote_identifier(collection),
+                    doc_id,
+                )
+                for doc_id in ids
+            ]
             conn.executemany(
                 "DELETE FROM {0} WHERE _id = ?".format(_quote_identifier(collection)),
-                [(str(doc_id),) for doc_id in ids],
+                [(stored_id,) for stored_id in stored_ids if stored_id is not None],
             )
             conn.commit()
         finally:
@@ -1109,7 +1439,7 @@ class DuckDBTableBackend(TableBackend):
             except Exception:  # pragma: no cover - corrupt legacy fallback
                 row = None
             if row and row[0]:  # pragma: no branch
-                data = json.loads(row[0])
+                data = _json_loads(row[0])
                 for collection, docs in data.items():
                     conn.execute(
                         "CREATE TABLE IF NOT EXISTS {0} (_id VARCHAR PRIMARY KEY, data VARCHAR NOT NULL)".format(
@@ -1117,7 +1447,7 @@ class DuckDBTableBackend(TableBackend):
                         )
                     )
                     rows = [
-                        (str(doc.get("_id", eid)), _json_dumps(doc))
+                        (_physical_id_key(doc.get("_id", eid)), _json_dumps(doc))
                         for eid, doc in (docs or {}).items()
                         if isinstance(doc, dict)
                     ]
@@ -1179,7 +1509,8 @@ class DuckDBTableBackend(TableBackend):
         self.create_collection(collection)
         existing_docs = self.find(collection, {})
         self.validate_unique_post_image(collection, existing_docs + docs)
-        rows = [(str(doc["_id"]), _json_dumps(doc)) for doc in docs]
+        _validate_physical_ids(existing_docs, docs)
+        rows = [(_physical_id_key(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
             conn.executemany(
@@ -1213,7 +1544,12 @@ class DuckDBTableBackend(TableBackend):
                 rows = conn.execute(sql, params).fetchall()
             finally:
                 conn.close()
-            return [_json_loads(row[0]) for row in rows]
+            documents = [_json_loads(row[0]) for row in rows]
+            return _postfilter_id_candidates(
+                documents,
+                filter_doc,
+                lambda: self._all_docs_unfiltered(collection),
+            )
         except Exception:
             return [
                 doc
@@ -1235,20 +1571,28 @@ class DuckDBTableBackend(TableBackend):
     @_write_locked
     def replace_one(self, collection, doc_id, replacement):
         self.create_collection(collection)
+        target_id = _physical_id_key(doc_id)
         self.validate_unique_post_image(
             collection,
             [
-                replacement if doc.get("_id") == doc_id else doc
+                replacement if _physical_id_key(doc.get("_id")) == target_id else doc
                 for doc in self.find(collection, {})
             ],
         )
         conn = self._connect()
         try:
+            stored_id = _local_matching_physical_row_id(
+                conn,
+                _quote_identifier(collection),
+                doc_id,
+            )
+            if stored_id is None:
+                return
             conn.execute(
                 "UPDATE {0} SET data = ? WHERE _id = ?".format(
                     _quote_identifier(collection)
                 ),
-                (_json_dumps(replacement), str(doc_id)),
+                (_json_dumps(replacement), stored_id),
             )
         finally:
             conn.close()
@@ -1260,9 +1604,17 @@ class DuckDBTableBackend(TableBackend):
         self.create_collection(collection)
         conn = self._connect()
         try:
+            stored_ids = [
+                _local_matching_physical_row_id(
+                    conn,
+                    _quote_identifier(collection),
+                    doc_id,
+                )
+                for doc_id in ids
+            ]
             conn.executemany(
                 "DELETE FROM {0} WHERE _id = ?".format(_quote_identifier(collection)),
-                [(str(doc_id),) for doc_id in ids],
+                [(stored_id,) for stored_id in stored_ids if stored_id is not None],
             )
         finally:
             conn.close()
@@ -1492,10 +1844,11 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
             rows = self._read_all_rows(collection)
             existing_docs = [_json_loads(row[1]) for row in rows]
             self.validate_unique_post_image(collection, existing_docs + docs)
+            _validate_physical_ids(existing_docs, docs)
             existing = {row[0] for row in rows}
             new_rows = []
             for doc in docs:
-                doc_id = str(doc["_id"])
+                doc_id = _physical_id_key(doc["_id"])
                 if doc_id in existing:
                     raise DuplicateKeyError("_id:{0} already exists".format(doc["_id"]))
                 new_rows.append((doc_id, _json_dumps(doc)))
@@ -1523,7 +1876,14 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
                 ).fetchall()
             finally:
                 conn.close()
-            return [_json_loads(row[0]) for row in rows]
+            documents = [_json_loads(row[0]) for row in rows]
+            return _postfilter_id_candidates(
+                documents,
+                filter_doc,
+                lambda: [
+                    _json_loads(row[1]) for row in self._read_all_rows(collection)
+                ],
+            )
         except Exception:
             return [
                 _json_loads(row[1])
@@ -1534,24 +1894,27 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
     def replace_one(self, collection, doc_id, replacement):
         with self._write_lock():
             current_rows = self._read_all_rows(collection)
+            stored_id = _matching_physical_row_id(current_rows, doc_id)
             self.validate_unique_post_image(
                 collection,
                 [
-                    replacement if row_id == str(doc_id) else _json_loads(data)
+                    replacement if row_id == stored_id else _json_loads(data)
                     for row_id, data in current_rows
                 ],
             )
             rows = [
-                (row_id, _json_dumps(replacement) if row_id == str(doc_id) else data)
+                (row_id, _json_dumps(replacement) if row_id == stored_id else data)
                 for row_id, data in current_rows
             ]
             self._write_rows(collection, rows)
 
     def delete_ids(self, collection, ids):
         with self._write_lock():
-            id_set = {str(doc_id) for doc_id in ids}
+            id_set = {_physical_id_key(doc_id) for doc_id in ids}
             rows = [
-                row for row in self._read_all_rows(collection) if row[0] not in id_set
+                row
+                for row in self._read_all_rows(collection)
+                if _physical_id_key(_json_loads(row[1])["_id"]) not in id_set
             ]
             self._write_rows(collection, rows)
 
@@ -1605,6 +1968,7 @@ class RemoteSQLTableBackend(TableBackend):
 
     placeholder = "%s"
     json_type = "TEXT"
+    ordered_data_type = "TEXT"
     metadata_table = "__tinymongo_collections"
     index_catalog_table = "__tinymongo_indexes"
 
@@ -1618,6 +1982,7 @@ class RemoteSQLTableBackend(TableBackend):
     ):
         if not dsn:
             raise ValueError("{0} backend requires a DSN".format(self.dialect))
+        self._ordered_data_collections = set()
         super(RemoteSQLTableBackend, self).__init__(
             path,
             threads=threads,
@@ -1665,10 +2030,7 @@ class RemoteSQLTableBackend(TableBackend):
             raise
 
     def _commit(self, conn):
-        try:
-            conn.commit()
-        except Exception:
-            pass
+        conn.commit()
 
     def _close_cursor(self, cursor):
         try:
@@ -1803,17 +2165,35 @@ class RemoteSQLTableBackend(TableBackend):
     def create_collection(self, collection):
         conn = self._connect()
         try:
+            table = self._quote(self._table_name(collection))
             self._execute(
                 conn,
                 "CREATE TABLE IF NOT EXISTS {0} "
-                "(_id VARCHAR(255) PRIMARY KEY, data {1} NOT NULL)".format(
-                    self._quote(self._table_name(collection)), self.json_type
+                "(_id VARCHAR(255) PRIMARY KEY, data {1} NOT NULL, "
+                "data_ordered {2} NULL)".format(
+                    table,
+                    self.json_type,
+                    self.ordered_data_type,
                 ),
             )
+            needs_ordered_data = collection not in self._ordered_data_collections
+            if needs_ordered_data:
+                self._ensure_ordered_data_column(conn, collection, table)
             self._record_collection(conn, collection)
             self._commit(conn)
+            if needs_ordered_data:
+                self._ordered_data_collections.add(collection)
         finally:
             conn.close()
+
+    def _ensure_ordered_data_column(self, conn, collection, table):
+        """Upgrade a legacy remote table without disturbing its JSON indexes."""
+
+        self._execute(
+            conn,
+            "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS "
+            "data_ordered {1} NULL".format(table, self.ordered_data_type),
+        )
 
     def drop_collection(self, collection):
         existed = collection in self.list_collections()
@@ -1841,6 +2221,7 @@ class RemoteSQLTableBackend(TableBackend):
                 (self.database, collection),
             )
             self._commit(conn)
+            self._ordered_data_collections.discard(collection)
             return existed
         finally:
             conn.close()
@@ -1849,7 +2230,8 @@ class RemoteSQLTableBackend(TableBackend):
         self.create_collection(collection)
         current = self._all_docs_unfiltered(collection)
         self.validate_unique_post_image(collection, current + docs)
-        rows = [(str(doc["_id"]), _json_dumps(doc)) for doc in docs]
+        _validate_physical_ids(current, docs)
+        rows = [(_physical_id_key(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
             self._insert_rows(conn, collection, rows, bypass_document_validation)
@@ -1868,11 +2250,25 @@ class RemoteSQLTableBackend(TableBackend):
     def _data_placeholder(self):
         return self.placeholder
 
+    def _decode_data_value(self, data, ordered_data=None):
+        """Read ordered text when present and legacy JSON otherwise."""
+
+        document = _json_loads(ordered_data if ordered_data is not None else data)
+        # Tolerate the short-lived wrapped representation used by pre-release
+        # development builds as well as released legacy object rows.
+        if isinstance(document, str):
+            document = _json_loads(document)
+        return document
+
     def find(self, collection, filter_doc=None, sort=None, skip=None, limit=None):
         self.create_collection(collection)
         if not filter_doc:
             return self._all_docs_unfiltered(collection)
-        if isinstance(filter_doc, dict) and set(filter_doc.keys()) == {"_id"}:
+        if (
+            isinstance(filter_doc, dict)
+            and set(filter_doc.keys()) == {"_id"}
+            and not isinstance(filter_doc["_id"], dict)
+        ):
             doc = self._find_by_id(collection, filter_doc["_id"])
             return [doc] if doc else []
         return [
@@ -1882,20 +2278,70 @@ class RemoteSQLTableBackend(TableBackend):
         ]
 
     def _find_by_id(self, collection, doc_id):
+        _stored_id, document = self._stored_row_by_id(collection, doc_id)
+        return document
+
+    def _stored_row_by_id(self, collection, doc_id):
         conn = self._connect()
         try:
+            expected = _physical_id_key(doc_id)
+            for candidate in _physical_id_candidates(doc_id):
+                cursor = self._execute(
+                    conn,
+                    "SELECT data_ordered, data FROM {0} WHERE _id = {1}".format(
+                        self._quote(self._table_name(collection)), self.placeholder
+                    ),
+                    (candidate,),
+                )
+                try:
+                    row = cursor.fetchone()
+                finally:
+                    self._close_cursor(cursor)
+                if row is None:
+                    continue
+                document = self._decode_data_value(
+                    row[-1],
+                    ordered_data=row[0] if len(row) > 1 else None,
+                )
+                document = _restore_legacy_document_id(
+                    candidate,
+                    document,
+                    requested_id=doc_id,
+                )
+                if _physical_id_key(document["_id"]) == expected:
+                    return candidate, document
+
+            if not _requires_legacy_id_scan(doc_id):
+                return None, None
+
+            # See the local fallback: container IDs and equivalent datetime
+            # representations can have legacy strings that cannot be enumerated.
             cursor = self._execute(
                 conn,
-                "SELECT data FROM {0} WHERE _id = {1}".format(
-                    self._quote(self._table_name(collection)), self.placeholder
+                "SELECT _id, data_ordered, data FROM {0}".format(
+                    self._quote(self._table_name(collection))
                 ),
-                (str(doc_id),),
             )
             try:
-                row = cursor.fetchone()
-                return _json_loads(row[0]) if row else None
+                rows = cursor.fetchall()
             finally:
                 self._close_cursor(cursor)
+            for row in rows:
+                document = self._decode_data_value(
+                    row[-1],
+                    ordered_data=row[1] if len(row) > 2 else None,
+                )
+                document = _restore_legacy_document_id(
+                    row[0],
+                    document,
+                    requested_id=doc_id,
+                )
+                try:
+                    if _physical_id_key(document["_id"]) == expected:
+                        return row[0], document
+                except (KeyError, TypeError, ValueError):
+                    continue
+            return None, None
         finally:
             conn.close()
 
@@ -1904,12 +2350,21 @@ class RemoteSQLTableBackend(TableBackend):
         try:
             cursor = self._execute(
                 conn,
-                "SELECT data FROM {0}".format(
+                "SELECT _id, data_ordered, data FROM {0}".format(
                     self._quote(self._table_name(collection))
                 ),
             )
             try:
-                return [_json_loads(row[0]) for row in cursor.fetchall()]
+                return [
+                    _restore_legacy_document_id(
+                        row[0],
+                        self._decode_data_value(
+                            row[-1],
+                            ordered_data=row[1] if len(row) > 2 else None,
+                        ),
+                    )
+                    for row in cursor.fetchall()
+                ]
             finally:
                 self._close_cursor(cursor)
         finally:
@@ -1917,24 +2372,33 @@ class RemoteSQLTableBackend(TableBackend):
 
     def replace_one(self, collection, doc_id, replacement):
         self.create_collection(collection)
+        target_id = _physical_id_key(doc_id)
         self.validate_unique_post_image(
             collection,
             [
-                replacement if str(doc.get("_id")) == str(doc_id) else doc
+                replacement if _physical_id_key(doc.get("_id")) == target_id else doc
                 for doc in self._all_docs_unfiltered(collection)
             ],
         )
+        stored_id, _document = self._stored_row_by_id(collection, doc_id)
+        if stored_id is None:
+            return
         conn = self._connect()
         try:
             try:
                 self._execute(
                     conn,
-                    "UPDATE {0} SET data = {1} WHERE _id = {2}".format(
+                    "UPDATE {0} SET data = {1}, data_ordered = {2} "
+                    "WHERE _id = {2}".format(
                         self._quote(self._table_name(collection)),
                         self._data_placeholder(),
                         self.placeholder,
                     ),
-                    (_json_dumps(replacement), str(doc_id)),
+                    (
+                        _json_dumps(replacement),
+                        _json_dumps(replacement),
+                        stored_id,
+                    ),
                 )
                 self._commit(conn)
             except Exception as exc:
@@ -1948,6 +2412,7 @@ class RemoteSQLTableBackend(TableBackend):
         if not ids:
             return
         self.create_collection(collection)
+        stored_ids = [self._stored_row_by_id(collection, doc_id)[0] for doc_id in ids]
         conn = self._connect()
         try:
             self._executemany(
@@ -1955,7 +2420,7 @@ class RemoteSQLTableBackend(TableBackend):
                 "DELETE FROM {0} WHERE _id = {1}".format(
                     self._quote(self._table_name(collection)), self.placeholder
                 ),
-                [(str(doc_id),) for doc_id in ids],
+                [(stored_id,) for stored_id in stored_ids if stored_id is not None],
             )
             self._commit(conn)
         finally:
@@ -2084,17 +2549,24 @@ class PostgresTableBackend(RemoteSQLTableBackend):
         )
 
     def _insert_rows(self, conn, collection, rows, bypass_document_validation):
-        sql = "INSERT INTO {0} (_id, data) VALUES ({1}, {2})".format(
+        sql = (
+            "INSERT INTO {0} (_id, data, data_ordered) " "VALUES ({1}, {2}, {1})"
+        ).format(
             self._quote(self._table_name(collection)),
             self.placeholder,
             self._data_placeholder(),
         )
-        self._executemany(conn, sql, rows)
+        self._executemany(
+            conn,
+            sql,
+            [(doc_id, data, data) for doc_id, data in rows],
+        )
 
 
 class MySQLTableBackend(RemoteSQLTableBackend):
     dialect = "mysql"
     json_type = "JSON"
+    ordered_data_type = "LONGTEXT"
 
     def __init__(self, path, threads=None, duckdb_config=None, database=None, dsn=None):
         pymysql = _import_optional_driver(
@@ -2131,6 +2603,35 @@ class MySQLTableBackend(RemoteSQLTableBackend):
 
     def _generated_index_column(self, collection, spec):
         return self._physical_index_name(collection, spec).replace("_idx_", "_key_")
+
+    def _ensure_ordered_data_column(self, conn, collection, table):
+        # MySQL 8 does not accept ADD COLUMN IF NOT EXISTS. Querying the active
+        # schema also avoids needless ALTER TABLE operations for new tables.
+        cursor = self._execute(
+            conn,
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = {0} "
+            "AND column_name = 'data_ordered' LIMIT 1".format(self.placeholder),
+            (self._table_name(collection),),
+        )
+        try:
+            exists = cursor.fetchone() is not None
+        finally:
+            self._close_cursor(cursor)
+        if exists:
+            return
+
+        try:
+            self._execute(
+                conn,
+                "ALTER TABLE {0} ADD COLUMN data_ordered {1} NULL".format(
+                    table, self.ordered_data_type
+                ),
+            )
+        except Exception as exc:
+            code = exc.args[0] if getattr(exc, "args", ()) else None
+            if code != 1060 and "duplicate column" not in str(exc).lower():
+                raise
 
     def _create_native_index(self, conn, collection, spec):
         json_path = "$" + "".join(
@@ -2197,7 +2698,11 @@ class MySQLTableBackend(RemoteSQLTableBackend):
         )
 
     def _insert_rows(self, conn, collection, rows, bypass_document_validation):
-        sql = "INSERT INTO {0} (_id, data) VALUES ({1}, {1})".format(
-            self._quote(self._table_name(collection)), self.placeholder
+        sql = (
+            "INSERT INTO {0} (_id, data, data_ordered) " "VALUES ({1}, {1}, {1})"
+        ).format(self._quote(self._table_name(collection)), self.placeholder)
+        self._executemany(
+            conn,
+            sql,
+            [(doc_id, data, data) for doc_id, data in rows],
         )
-        self._executemany(conn, sql, rows)

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -5,14 +5,17 @@
 from __future__ import absolute_import
 
 import copy
+from collections.abc import Iterable, Mapping, MutableMapping
 from functools import reduce, wraps
 import logging
 import os
 import shutil
+import warnings
 from uuid import uuid4
 
 from tinydb import Query, TinyDB, where  # type: ignore[attr-defined]
 from .bson_codec import bson_available
+from .bson_types import bson_identity_key, bson_scalar_sort_key, bson_values_equal
 from .storage_backends import (
     clear_memory_database,
     clear_memory_namespace,
@@ -29,6 +32,7 @@ from .storage_backends import (
 # from .errors import DuplicateKeyError
 from .results import InsertOneResult, InsertManyResult, UpdateResult, DeleteResult
 from .errors import (
+    BulkWriteError,
     DuplicateKeyError,
     InvalidOperation,
     OperationFailure,
@@ -37,6 +41,7 @@ from .errors import (
 from .indexes import (
     INDEX_CATALOG_TABLE,
     IndexSpec,
+    TinyMongoUnsupportedWarning,
     emit_index_plan_warnings,
     index_catalog_id,
     parse_index_spec,
@@ -44,7 +49,12 @@ from .indexes import (
     validate_unique_documents,
 )
 from .projection import normalize_projection, project_document
-from .table_backends import matches_filter, requires_python_filter
+from .table_backends import (
+    _filter_references_id,
+    _value_matches,
+    matches_filter,
+    requires_python_filter,
+)
 
 basestring = str
 
@@ -71,10 +81,154 @@ _MISSING = object()
 def _get_nested(doc, path, default=_MISSING):
     current = doc
     for key in path.split("."):
-        if not isinstance(current, dict) or key not in current:
+        if not isinstance(current, Mapping) or key not in current:
             return default
         current = current[key]
     return current
+
+
+def _bulk_write_details(n_inserted, write_errors):
+    """Return the result document exposed by PyMongo's ``BulkWriteError``."""
+    return {
+        "writeErrors": write_errors,
+        "writeConcernErrors": [],
+        "nInserted": n_inserted,
+        "nUpserted": 0,
+        "nMatched": 0,
+        "nModified": 0,
+        "nRemoved": 0,
+        "upserted": [],
+    }
+
+
+def _duplicate_write_error(collection, index, document, spec=None, error=None):
+    """Describe one duplicate insert using PyMongo's bulk error shape."""
+    field = "_id" if spec is None else spec.field
+    index_name = "_id_" if spec is None else spec.name
+    value = _get_nested(document, field)
+    if value is _MISSING:
+        value = None
+    message = (
+        "E11000 duplicate key error collection: {0} index: {1} "
+        "dup key: {{ {2}: {3!r} }}"
+    ).format(collection.full_name, index_name, field, value)
+    if error is not None and str(error):
+        message = "{0}: {1}".format(message, error)
+    return {
+        "index": index,
+        "code": 11000,
+        "errmsg": message,
+        "keyPattern": {field: 1 if spec is None else spec.direction},
+        "keyValue": {field: value},
+        "op": document,
+    }
+
+
+def _first_unique_conflict(existing_documents, document, specs):
+    """Return the first unique index violated by ``document``, if any."""
+    for spec in specs:
+        if not spec.unique:
+            continue
+        try:
+            validate_unique_documents(existing_documents + [document], [spec])
+        except DuplicateKeyError as error:
+            return spec, error
+    return None, None
+
+
+def _plan_insert_many(collection, documents, existing_documents, specs, ordered):
+    """Split a batch into inserts and duplicate-key write errors."""
+    existing_ids = [document["_id"] for document in existing_documents]
+    accepted = []
+    write_errors = []
+
+    for index, document in enumerate(documents):
+        duplicate_error = None
+        if any(bson_values_equal(document["_id"], value) for value in existing_ids):
+            duplicate_error = _duplicate_write_error(collection, index, document)
+        else:
+            spec, error = _first_unique_conflict(existing_documents, document, specs)
+            if spec is not None:
+                duplicate_error = _duplicate_write_error(
+                    collection,
+                    index,
+                    document,
+                    spec=spec,
+                    error=error,
+                )
+
+        if duplicate_error is not None:
+            write_errors.append(duplicate_error)
+            if ordered:
+                break
+        else:
+            accepted.append(document)
+            existing_documents.append(document)
+            existing_ids.append(document["_id"])
+
+    return accepted, write_errors
+
+
+def _execute_engine_insert_many(
+    collection,
+    documents,
+    ordered,
+    bypass_document_validation,
+):
+    """Plan and execute a table-backend batch, retrying native races."""
+
+    engine = collection.parent.engine
+    last_error = None
+    accepted = []
+    write_errors = []
+
+    # Remote SQL constraints are the final cross-process authority. If another
+    # writer commits after our preflight, the native insert fails atomically;
+    # re-read and re-plan so the public error still identifies the original
+    # operation and preserves ordered/unordered semantics.
+    for _attempt in range(3):
+        existing_documents = engine.find(collection.tablename, {})
+        accepted, write_errors = _plan_insert_many(
+            collection,
+            documents,
+            existing_documents,
+            engine.get_index_specs(collection.tablename),
+            ordered,
+        )
+        if not accepted:
+            return [], accepted, write_errors
+        try:
+            results = engine.insert_many(
+                collection.tablename,
+                accepted,
+                bypass_document_validation=bypass_document_validation is True,
+            )
+        except DuplicateKeyError as error:
+            last_error = error
+            continue
+        return list(results), accepted, write_errors
+
+    # A native constraint continued to reject the batch without exposing a
+    # newly committed conflicting row. Preserve the batch exception contract
+    # with the earliest operation that reached the backend.
+    conflict_document = accepted[0]
+    conflict_index = next(
+        index
+        for index, document in enumerate(documents)
+        if document is conflict_document
+    )
+    write_errors.append(
+        _duplicate_write_error(
+            collection,
+            conflict_index,
+            conflict_document,
+            error=last_error,
+        )
+    )
+    write_errors.sort(key=lambda item: item["index"])
+    if ordered:
+        write_errors = write_errors[:1]
+    return [], [], write_errors
 
 
 def _set_nested(doc, path, value):
@@ -153,6 +307,35 @@ def _apply_update_document(item, update_doc):
     return updated
 
 
+def _tinydb_replace_document(replacement):
+    """Return a TinyDB transform that writes an exact document post-image."""
+
+    def replace(document):
+        document.clear()
+        document.update(copy.deepcopy(replacement))
+
+    return replace
+
+
+def _tinydb_id_condition(value):
+    """Return a TinyDB condition with BSON-aware ``_id`` equality."""
+
+    return where("_id").test(bson_values_equal, value)
+
+
+def _direct_id_equality(filter_doc):
+    """Return the operand for a direct exact ``_id`` query, if present."""
+
+    if not isinstance(filter_doc, dict) or set(filter_doc) != {"_id"}:
+        return _MISSING
+    expected = filter_doc["_id"]
+    if isinstance(expected, dict) and any(str(key).startswith("$") for key in expected):
+        if set(expected) != {"$eq"}:
+            return _MISSING
+        return expected["$eq"]
+    return expected
+
+
 def _validate_update_document(update_doc):
     if (
         not isinstance(update_doc, dict)
@@ -191,6 +374,12 @@ def _simple_equality_filter(_filter):
     if field.startswith("$") or isinstance(value, (dict, list)):
         return None
     return field, value
+
+
+def _cached_value_matches(actual, expected, _cache_identity):
+    """Match a TinyDB value while keeping BSON-distinct query-cache keys."""
+
+    return _value_matches(actual, expected)
 
 
 def _looks_like_network_target(host, port=None):
@@ -262,20 +451,37 @@ class TinyMongoClient(object):
         """Initialize container folder and choose a storage backend."""
         self._foldername = foldername
         self._backend = backend or "tinydb"
+        # Reject unknown names at construction instead of waiting for the first
+        # database access, when the configuration error is harder to diagnose.
+        get_storage_class(self._backend)
+        backend_name = str(self._backend).lower()
         self._memory_namespace = None
         self._shared_memory = False
-        if str(self._backend).lower() == "memory":
+        if backend_name == "memory":
             self._memory_namespace, self._shared_memory = _memory_namespace(foldername)
             self._foldername = self._memory_namespace
         self._threads = kwargs.get("threads")
-        self._storage_uri = kwargs.get("storage_uri") or os.environ.get(
-            "TINYMONGO_STORAGE_URI"
-        )
+        storage_uri = kwargs.get("storage_uri")
+        if backend_name in ("parquet", "parquetv2"):
+            if storage_uri is None:
+                storage_uri = os.environ.get("TINYMONGO_STORAGE_URI")
+            self._storage_uri = storage_uri or None
+        else:
+            self._storage_uri = None
         self._duckdb_config = kwargs.get("duckdb_config")
-        self._dsn = kwargs.get("dsn") or self._dsn_from_env(self._backend)
+        dsn = kwargs.get("dsn")
+        if is_remote_sql_backend(backend_name):
+            if dsn is None:
+                dsn = self._dsn_from_env(backend_name)
+            self._dsn = dsn or None
+        else:
+            self._dsn = None
         self._databases = {}
         self._closed = False
-        if self._memory_namespace is None:
+        storage_is_nonlocal = is_remote_sql_backend(backend_name) or bool(
+            self._storage_uri and backend_name in ("parquet", "parquetv2")
+        )
+        if self._memory_namespace is None and not storage_is_nonlocal:
             try:
                 os.makedirs(foldername, exist_ok=True)
             except OSError as x:
@@ -323,8 +529,7 @@ class TinyMongoClient(object):
         return os.path.join(self._foldername, key + storage_extension(self._backend))
 
     def _get_db(self, key):
-        if self._closed:
-            raise InvalidOperation("Cannot use a closed TinyMongoClient")
+        self._ensure_open()
         if key in self._databases:
             return self._databases[key]
         path = self._get_db_path(key)
@@ -347,6 +552,12 @@ class TinyMongoClient(object):
         self._databases[key] = database
         return database
 
+    def _ensure_open(self):
+        """Reject operations that would use a client after it was closed."""
+
+        if self._closed:
+            raise InvalidOperation("Cannot use a closed TinyMongoClient")
+
     def close(self):
         """Close databases opened by this client."""
         if self._closed:
@@ -366,6 +577,7 @@ class TinyMongoClient(object):
 
     def server_info(self):
         """Return local TinyMongo metadata in the shape of PyMongo's call."""
+        self._ensure_open()
         return {
             "version": "tinymongo",
             "storage": self._backend,
@@ -377,6 +589,7 @@ class TinyMongoClient(object):
 
     def capabilities(self):
         """Describe behavior that the configured backend can honor."""
+        self._ensure_open()
         backend = str(self._backend or "tinydb").lower()
         remote = is_remote_sql_backend(backend)
         object_storage = bool(self._storage_uri and backend in ("parquet", "parquetv2"))
@@ -417,6 +630,7 @@ class TinyMongoClient(object):
 
     def list_database_names(self):
         """Return database names found in the configured local storage folder."""
+        self._ensure_open()
         if self._memory_namespace is not None:
             return list_memory_databases(self._memory_namespace)
         extension = storage_extension(self._backend)
@@ -597,6 +811,10 @@ class TinyMongoDatabase(object):
 
     def __getattr__(self, name):
         """Gets a new or existing collection"""
+        if name.startswith("_"):
+            raise AttributeError(
+                "{} object has no attribute {}".format(type(self).__name__, name)
+            )
         return TinyMongoCollection(name, self)
 
     def __getitem__(self, name):
@@ -629,11 +847,15 @@ class TinyMongoDatabase(object):
             names = self.engine.list_collections()
         else:
             names = list(self.tinydb.tables())
-        return [name for name in names if not name.startswith("__tinymongo_")]
+        return [
+            name
+            for name in names
+            if name != "_default" and not name.startswith("__tinymongo_")
+        ]
 
     def list_collection_names(self):
         """Compatibility alias for modern PyMongo."""
-        return [name for name in self.collection_names() if name != "_default"]
+        return self.collection_names()
 
     def close(self):
         """Close this database's storage resources."""
@@ -722,16 +944,45 @@ class TinyMongoCollection(object):
         )
 
     def __getattr__(self, name):
-        """
-        If attr is not found return self
-        :param name:
-        :return:
-        """
-        # if self.table is None:
-        #     self.tablename += u"." + name
-        if self.table is None:
-            self.build_table()
-        return self
+        """Return a dotted child collection selected by attribute."""
+        if name.startswith("_"):
+            full_name = "{0}.{1}".format(self.tablename, name)
+            raise AttributeError(
+                "{0} has no attribute {1!r}. To access the {2} collection, "
+                "use database[{2!r}].".format(
+                    type(self).__name__,
+                    name,
+                    full_name,
+                )
+            )
+        return self[name]
+
+    def __getitem__(self, name):
+        """Return a dotted child collection selected by subscription."""
+        return TinyMongoCollection(
+            "{0}.{1}".format(self.tablename, name),
+            self.parent,
+        )
+
+    def __call__(self, *args, **kwargs):
+        """Explain method typos that resolved to a child collection."""
+        if "." not in self.tablename:
+            raise TypeError(
+                "'{0}' object is not callable. If you meant to call the "
+                "'{1}' method on a 'TinyMongoDatabase' object it is failing "
+                "because no such method exists.".format(
+                    type(self).__name__,
+                    self.tablename,
+                )
+            )
+        raise TypeError(
+            "'{0}' object is not callable. If you meant to call the '{1}' "
+            "method on a '{0}' object it is failing because no such method "
+            "exists.".format(
+                type(self).__name__,
+                self.tablename.rsplit(".", 1)[-1],
+            )
+        )
 
     def build_table(self):
         """
@@ -933,10 +1184,16 @@ class TinyMongoCollection(object):
             seen = set()
             for item in values:
                 try:
-                    if item in seen:
+                    identity = bson_identity_key(item)
+                    cache_key = (
+                        ("__tinymongo_bson_identity__", identity)
+                        if identity is not None
+                        else item
+                    )
+                    if cache_key in seen:
                         continue
-                    seen.add(item)
-                    index.setdefault(item, []).append(doc)
+                    seen.add(cache_key)
+                    index.setdefault(cache_key, []).append(doc)
                 except TypeError:
                     continue
         self._index_cache[key] = index
@@ -1065,8 +1322,8 @@ class TinyMongoCollection(object):
         if self.parent.engine is not None:
             if not isinstance(doc, dict):
                 raise ValueError('"doc" must be a dict')
-            if "_id" in doc and doc["_id"] is not None:
-                _id = doc["_id"] = doc["_id"]
+            if "_id" in doc:
+                _id = doc["_id"]
             else:
                 _id = doc["_id"] = generate_id()
             self.parent.engine.validate_unique_post_image(
@@ -1089,10 +1346,10 @@ class TinyMongoCollection(object):
             if not isinstance(doc, dict):
                 raise ValueError('"doc" must be a dict')
 
-            # Respect explicit falsy ids (0, False) — only generate when _id
-            # is missing or None.
-            if "_id" in doc and doc["_id"] is not None:
-                _id = doc["_id"] = doc["_id"]
+            # PyMongo generates an ID only when the field is absent. Explicit
+            # values such as 0, False, and None remain user-controlled IDs.
+            if "_id" in doc:
+                _id = doc["_id"]
             else:
                 _id = doc["_id"] = generate_id()
 
@@ -1113,75 +1370,90 @@ class TinyMongoCollection(object):
             self._release_collection_lock(rlock, portalocker_lock)
 
     @_engine_write_locked
-    def insert_many(self, docs, *args, **kwargs):
+    def insert_many(
+        self,
+        docs,
+        ordered=True,
+        bypass_document_validation=None,
+        session=None,
+        comment=None,
+    ):
         """
-        Inserts several documents into the collection
-        :param docs: a list of documents
+        Insert several documents with PyMongo-style partial failure semantics.
+
+        Duplicate-key failures stop an ordered batch at the first failed
+        operation. Unordered batches continue with every valid operation. Any
+        client-side serialization failure is detected before storage is
+        changed. This whole-list preflight is a stronger TinyMongo guarantee;
+        PyMongo may split a very large input across multiple wire batches.
+
+        :param docs: an iterable of documents
         :return: InsertManyResult
         """
-        _reject_session(kwargs)
-        if self.parent.engine is not None:
-            if not isinstance(docs, list):
-                raise ValueError('"insert_many" requires a list input')
-            _ids = []
-            for doc in docs:
-                if "_id" in doc and doc["_id"] is not None:
-                    _id = doc["_id"] = doc["_id"]
-                else:
-                    _id = doc["_id"] = generate_id()
-                _ids.append(_id)
-            self.parent.engine.validate_unique_post_image(
-                self.tablename,
-                self.parent.engine.find(self.tablename, {}) + docs,
-            )
-            results = self.parent.engine.insert_many(
-                self.tablename,
+        _reject_session({"session": session})
+        if not isinstance(docs, Iterable) or isinstance(
+            docs, (Mapping, str, bytes, bytearray)
+        ):
+            raise TypeError("documents must be a non-empty iterable")
+        docs = list(docs)
+        if not docs:
+            raise TypeError("documents must be a non-empty list")
+        if not isinstance(ordered, bool):
+            raise TypeError("ordered must be True or False")
+
+        _ids = []
+        for doc in docs:
+            if not isinstance(doc, MutableMapping):
+                raise TypeError("each document must be a mutable mapping")
+            if "_id" in doc:
+                _id = doc["_id"]
+            else:
+                _id = doc["_id"] = generate_id()
+            _ids.append(_id)
+
+        # Validate TinyMongo's one storage batch at the JSON boundary before
+        # changing storage. PyMongo can split very large inputs across multiple
+        # wire batches, so TinyMongo intentionally provides a stronger
+        # whole-list guarantee here.
+        from .bson_codec import dumps as encode_storage_payload
+
+        encode_storage_payload(docs, ensure_ascii=False)
+
+        engine = self.parent.engine
+        if engine is not None:
+            results, accepted, write_errors = _execute_engine_insert_many(
+                self,
                 docs,
-                bypass_document_validation=kwargs.get("bypass_document_validation")
-                is True,
+                ordered,
+                bypass_document_validation,
             )
-            return InsertManyResult(eids=results, inserted_ids=_ids)
+            if write_errors:
+                raise BulkWriteError(_bulk_write_details(len(accepted), write_errors))
+            return InsertManyResult(eids=results, inserted_ids=list(_ids))
 
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             if self.table is None:
                 self.build_table()
             self._refresh_table()
-            if not isinstance(docs, list):
-                raise ValueError('"insert_many" requires a list input')
-
-            # Get all _id values once to reduce I/O. Document-validation bypass
-            # never bypasses MongoDB's built-in unique _id constraint.
-            existing = [doc["_id"] for doc in self.find({})]
-
-            _ids = list()
-            for doc in docs:
-
-                # Respect explicit falsy ids (0, False) — only generate when
-                # _id is missing or None.
-                if "_id" in doc and doc["_id"] is not None:
-                    _id = doc["_id"] = doc["_id"]
-                else:
-                    _id = doc["_id"] = generate_id()
-
-                if _id in existing:
-                    raise DuplicateKeyError(
-                        "_id:{0} already exists in collection:{1}".format(
-                            _id, self.tablename
-                        )
-                    )
-                existing.append(_id)
-
-                _ids.append(_id)
-
-            self._validate_unique_post_image(self.table.all() + docs)
-            results = self.table.insert_multiple(docs)
-            self._invalidate_indexes()
-
-            return InsertManyResult(
-                eids=[eid for eid in results],
-                inserted_ids=[inserted_id for inserted_id in _ids],
+            accepted, write_errors = _plan_insert_many(
+                self,
+                docs,
+                self.table.all(),
+                list(self._index_specs.values()),
+                ordered,
             )
+
+            if accepted:
+                results = self.table.insert_multiple(accepted)
+                self._invalidate_indexes()
+            else:
+                results = []
+
+            if write_errors:
+                raise BulkWriteError(_bulk_write_details(len(accepted), write_errors))
+
+            return InsertManyResult(eids=list(results), inserted_ids=list(_ids))
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
@@ -1335,14 +1607,13 @@ class TinyMongoCollection(object):
                 # don't want to use the previous key if this is a secondary key
                 # (fixes multiple item query that includes $ codes)
                 if not isinstance(value, dict) and not isinstance(value, list):
-                    conditions = (
-                        ((Q(q, key) == value) | (Q(q, key).any([value])))
-                        if not conditions
-                        else (
-                            conditions
-                            & ((Q(q, key) == value) | (Q(q, key).any([value])))
-                        )
+                    cache_identity = bson_identity_key(value)
+                    equality = Q(q, key).test(
+                        _cached_value_matches,
+                        value,
+                        ("__tinymongo_bson_identity__", cache_identity),
                     )
+                    conditions = equality if not conditions else (conditions & equality)
                     prev_key = key
 
             logger.debug("c: {}".format(conditions))
@@ -1445,7 +1716,11 @@ class TinyMongoCollection(object):
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
                 [
-                    updated if item.get("_id") == matches[0].get("_id") else item
+                    (
+                        updated
+                        if bson_values_equal(item.get("_id"), matches[0].get("_id"))
+                        else item
+                    )
                     for item in self.parent.engine.find(self.tablename, {})
                 ],
             )
@@ -1466,7 +1741,17 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            if requires_python_filter(query):
+            direct_id = _direct_id_equality(query)
+            if direct_id is not _MISSING:
+                item = next(
+                    (
+                        candidate
+                        for candidate in self.table.all()
+                        if bson_values_equal(candidate.get("_id"), direct_id)
+                    ),
+                    None,
+                )
+            elif _filter_references_id(query) or requires_python_filter(query):
                 item = next(
                     (
                         candidate
@@ -1497,11 +1782,18 @@ class TinyMongoCollection(object):
             modified = updated != item
             if modified:
                 post_image = [
-                    updated if current.get("_id") == item.get("_id") else current
+                    (
+                        updated
+                        if bson_values_equal(current.get("_id"), item.get("_id"))
+                        else current
+                    )
                     for current in self.table.all()
                 ]
                 self._validate_unique_post_image(post_image)
-                self.table.update(updated, where("_id") == item["_id"])
+                self.table.update(
+                    _tinydb_replace_document(updated),
+                    _tinydb_id_condition(item["_id"]),
+                )
                 self._invalidate_indexes()
 
             return UpdateResult(
@@ -1555,7 +1847,10 @@ class TinyMongoCollection(object):
                         (
                             updated
                             for original, updated in updates
-                            if original.get("_id") == item.get("_id")
+                            if bson_values_equal(
+                                original.get("_id"),
+                                item.get("_id"),
+                            )
                         ),
                         item,
                     )
@@ -1577,7 +1872,14 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            if requires_python_filter(query):
+            direct_id = _direct_id_equality(query)
+            if direct_id is not _MISSING:
+                items = [
+                    candidate
+                    for candidate in self.table.all()
+                    if bson_values_equal(candidate.get("_id"), direct_id)
+                ]
+            elif _filter_references_id(query) or requires_python_filter(query):
                 items = [
                     candidate
                     for candidate in self.table.all()
@@ -1604,7 +1906,10 @@ class TinyMongoCollection(object):
                         (
                             updated
                             for original, updated in updates
-                            if original.get("_id") == item.get("_id")
+                            if bson_values_equal(
+                                original.get("_id"),
+                                item.get("_id"),
+                            )
                         ),
                         item,
                     )
@@ -1617,7 +1922,10 @@ class TinyMongoCollection(object):
                 if updated != item:
                     modified_count += 1
                     result.extend(
-                        self.table.update(updated, where("_id") == item["_id"])
+                        self.table.update(
+                            _tinydb_replace_document(updated),
+                            _tinydb_id_condition(item["_id"]),
+                        )
                     )
             if modified_count:
                 self._invalidate_indexes()
@@ -1661,7 +1969,11 @@ class TinyMongoCollection(object):
                 self.parent.engine.validate_unique_post_image(
                     self.tablename,
                     [
-                        updated if current.get("_id") == item.get("_id") else current
+                        (
+                            updated
+                            if bson_values_equal(current.get("_id"), item.get("_id"))
+                            else current
+                        )
                         for current in self.parent.engine.find(self.tablename, {})
                     ],
                 )
@@ -1678,7 +1990,17 @@ class TinyMongoCollection(object):
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             self._refresh_table()
-            if requires_python_filter(query):
+            direct_id = _direct_id_equality(query)
+            if direct_id is not _MISSING:
+                item = next(
+                    (
+                        candidate
+                        for candidate in self.table.all()
+                        if bson_values_equal(candidate.get("_id"), direct_id)
+                    ),
+                    None,
+                )
+            elif _filter_references_id(query) or requires_python_filter(query):
                 item = next(
                     (
                         candidate
@@ -1710,11 +2032,15 @@ class TinyMongoCollection(object):
             modified = updated != item
             if modified:
                 post_image = [
-                    updated if current.get("_id") == item.get("_id") else current
+                    (
+                        updated
+                        if bson_values_equal(current.get("_id"), item.get("_id"))
+                        else current
+                    )
                     for current in self.table.all()
                 ]
                 self._validate_unique_post_image(post_image)
-                self.table.remove(where("_id") == item["_id"])
+                self.table.remove(_tinydb_id_condition(item["_id"]))
                 self.table.insert(updated)
                 self._invalidate_indexes()
                 result = [item["_id"]]
@@ -1857,13 +2183,35 @@ class TinyMongoCollection(object):
             if _filter is None:
                 result = self.table.all()
             else:
+                direct_id = _direct_id_equality(_filter)
+                if direct_id is not _MISSING:
+                    result = [
+                        document
+                        for document in self.table.all()
+                        if bson_values_equal(document.get("_id"), direct_id)
+                    ]
+                    return TinyMongoCursor(
+                        result,
+                        sort=sort,
+                        skip=skip,
+                        limit=limit,
+                        collection=self,
+                        projection=projection,
+                        query=_filter,
+                    )
                 simple = _simple_equality_filter(_filter)
                 if simple is not None:
                     key, value = simple
                     index = self._get_index(key)
                     if index is not None:
+                        identity = bson_identity_key(value)
+                        cache_key = (
+                            ("__tinymongo_bson_identity__", identity)
+                            if identity is not None
+                            else value
+                        )
                         return TinyMongoCursor(
-                            list(index.get(value, [])),
+                            list(index.get(cache_key, [])),
                             sort=sort,
                             skip=skip,
                             limit=limit,
@@ -1871,7 +2219,7 @@ class TinyMongoCollection(object):
                             projection=projection,
                             query=_filter,
                         )
-                if requires_python_filter(_filter):
+                if _filter_references_id(_filter) or requires_python_filter(_filter):
                     result = [
                         document
                         for document in self.table.all()
@@ -1962,7 +2310,7 @@ class TinyMongoCollection(object):
                 return DeleteResult(raw_result=[])
             self._set_storage_merge_writes(False)
             try:
-                result = self.table.remove(where("_id") == item["_id"])
+                result = self.table.remove(_tinydb_id_condition(item["_id"]))
                 self._invalidate_indexes()
             finally:
                 self._set_storage_merge_writes(True)
@@ -1990,7 +2338,8 @@ class TinyMongoCollection(object):
             self._set_storage_merge_writes(False)
             try:
                 result = [
-                    self.table.remove(where("_id") == item["_id"]) for item in items
+                    self.table.remove(_tinydb_id_condition(item["_id"]))
+                    for item in items
                 ]
                 self._invalidate_indexes()
 
@@ -2028,6 +2377,7 @@ class TinyMongoCursor(object):
         self._skip = 0
         self._limit = 0
         self._closed = False
+        self._unsupported_sort_warnings = set()
         self.cursorpos = -1
         self.currentrec = None
 
@@ -2076,7 +2426,23 @@ class TinyMongoCursor(object):
         self.cursorpos = -1
         self.currentrec = self.cursordat[-1] if self.cursordat else None
 
-    def _order(self, value, is_reverse=None):
+    def _warn_unsupported_sort_value(self, field, value):
+        """Warn once when a sort field contains an unsupported value type."""
+        warning_key = (field, type(value))
+        if warning_key in self._unsupported_sort_warnings:
+            return
+        self._unsupported_sort_warnings.add(warning_key)
+        warnings.warn(
+            "Sorting field '{0}' encountered unsupported value type '{1}'; "
+            "values of this type compare as null.".format(
+                field,
+                type(value).__name__,
+            ),
+            TinyMongoUnsupportedWarning,
+            stacklevel=4,
+        )
+
+    def _order(self, value, is_reverse=None, sort_field=None):
         """Parsing data to a sortable form
         By giving each data type an ID(int), and assemble with the value
         into a sortable tuple.
@@ -2088,7 +2454,7 @@ class TinyMongoCursor(object):
             """
             result = list()
             for key in dict_doc:
-                data = self._order(dict_doc[key])
+                data = self._order(dict_doc[key], sort_field=sort_field)
                 res = (data[0], key, data[1])
                 result.append(res)
             return tuple(result)
@@ -2097,30 +2463,10 @@ class TinyMongoCursor(object):
             """list will iter members to compare"""
             result = list()
             for member in list_doc:
-                result.append(self._order(member))
+                result.append(self._order(member, sort_field=sort_field))
             return result
 
-        # (TODO) include more data type
-        if value is None or not isinstance(
-            # value, (dict, list, basestring, bool, float, int)
-            value,
-            (dict, list, str, bool, float, int),
-        ):
-            # not support/sortable value type
-            value = (0, None)
-
-        elif isinstance(value, bool):
-            value = (5, value)
-
-        elif isinstance(value, (int, float)):
-            value = (1, value)
-
-        # elif isinstance(value, basestring):
-        elif isinstance(value, str):
-
-            value = (2, value)
-
-        elif isinstance(value, dict):
+        if isinstance(value, dict):
             value = (3, _dict_parser(value))
 
         elif isinstance(value, list):  # pragma: no branch - type chain is exhaustive
@@ -2138,6 +2484,15 @@ class TinyMongoCursor(object):
                 # if the smallest or largest member is a list
                 # then compaer with it's sub-member in list index order
                 value = (4, tuple(value))
+
+        else:
+            scalar_key = bson_scalar_sort_key(value)
+            if scalar_key is None:
+                if sort_field is not None:
+                    self._warn_unsupported_sort_value(sort_field, value)
+                value = (0, None)
+            else:
+                value = scalar_key
 
         return value
 
@@ -2242,7 +2597,7 @@ class TinyMongoCursor(object):
                     # treat no match as None
                     data = None
 
-                value = self._order(data, is_reverse)
+                value = self._order(data, is_reverse, pair[0])
 
                 # read previous section
                 pre_sect = pre_sect_stack[index] if pre_sect_stack else 0


### PR DESCRIPTION
## Why

Mike Kennedy's first Talk Python acceptance pass reached the asynchronous application initializer, opened all four database handles, and initialized all 16 collections. That run exposed a connected group of compatibility gaps around BSON values, embedded-document identity, batch-write failures, sort behavior, CLI migration safety, and sync/async parity.

This PR turns those findings into backend-independent contracts and implements the supported behavior across TinyDB, memory, SQLite, DuckDB, Parquet, PostgreSQL, and MariaDB/MySQL. The immediate goal is to make the real Talk Python application runnable through TinyMongo without rewriting its PyMongo call sites, while keeping unsupported behavior explicit. It also prepares the forthcoming 1.2.1 release line.

## What changed

### BSON persistence, equality, sorting, and identity

- Adds a shared BSON scalar registry used by persistence, equality, sorting, and physical `_id` generation.
- Adds tagged, strict-JSON-safe round trips for `datetime`, `ObjectId`, `Binary`, `bytes`, `bytearray`, `NaN`, and positive/negative infinity.
- Preserves nonzero Binary subtypes; native bytes, bytearray, and generic Binary subtype 0 intentionally share equality and `_id` identity.
- Keeps booleans distinct from numbers while treating equivalent numeric forms such as `1` and `1.0` as the same BSON identity.
- Makes embedded-document order significant for exact equality and `_id` identity, including nested mappings and mapping subclasses.
- Adds MongoDB-shaped sorting for supported BSON families, including mixed naive/aware datetimes, ObjectIds, BinData, booleans, and deterministic NaN placement.
- Emits one bounded `TinyMongoUnsupportedWarning` per unsupported sort field/type instead of silently leaving insertion order unchanged.

### Typed physical IDs and storage compatibility

- SQL, DuckDB, and Parquet backends now store compact BSON-aware physical `_id` keys for new rows.
- Existing stringified physical IDs remain readable, replaceable, and deletable, including numeric and datetime equivalents.
- Legacy PostgreSQL JSONB mapping IDs recover original literal field order from their physical row key where possible.
- Remote SQL keeps `data` as a normal JSON/JSONB object so pre-existing native indexes continue to work.
- Adds a nullable ordered sidecar (`TEXT` on PostgreSQL, `LONGTEXT` on MariaDB/MySQL) to preserve document order and large encoded values.
- Existing remote tables are upgraded automatically on first access; legacy rows without the sidecar remain readable and gain it when rewritten.
- The MySQL upgrade path uses `information_schema` rather than unsupported `ADD COLUMN IF NOT EXISTS` syntax and handles duplicate-column races safely.
- Commit failures and native duplicate errors now propagate with the correct TinyMongo/PyMongo-shaped exception.

### `insert_many()` parity

- Accepts any iterable of mutable mapping documents rather than requiring a list.
- Implements PyMongo's `ordered=True` default: successful documents before the first duplicate stay written, then a `BulkWriteError` is raised.
- Implements `ordered=False`: valid documents continue and every duplicate-key failure is reported with its original input index and operation.
- Produces PyMongo-shaped `BulkWriteError.details`, including `nInserted`, `writeErrors`, key pattern/value, and write-concern fields.
- Applies the same behavior to `_id` and user-defined unique-index conflicts across synchronous and asynchronous APIs.
- Preflights the complete TinyMongo input for client-side serialization failures so an unencodable document leaves the whole input unwritten. This intentionally provides a stronger whole-input guarantee than PyMongo can provide after splitting very large inputs into wire batches.
- Preserves an explicitly supplied `_id: None` and enforces its uniqueness.

### Query, update, and collection behavior

- Applies BSON-aware equality to direct queries and the `$in`, `$nin`, and `$all` query operators.
- Routes compound/logical filters that reference `_id` through exact identity matching on TinyDB/memory instead of Python's bool/numeric aliases.
- Persists exact update post-images so top-level `$unset` truly removes a field rather than allowing TinyDB's merge behavior to restore it.
- Matches PyMongo dotted child-collection access and private-attribute guards for synchronous and asynchronous database/collection handles.
- Keeps async storage and lock waits off the event loop while preserving synchronous result and error semantics.
- Rejects invalid async backends without opening storage or creating paths.

### CLI and backend safety

- Makes CLI export/import use the same BSON-aware codec as storage.
- Preserves embedded-document field order during export, including document-valued IDs.
- Filters TinyDB's internal `_default` table from API/CLI collection listings, inspection, and migration.
- Preflights replace imports and migrations against destination index rules before deleting existing data.
- Restores the previous collection if a destructive replacement fails after preflight.
- Makes environment-only object-storage URIs and remote SQL DSNs participate in CLI discovery and migration summaries.
- Stops remote SQL and object-storage Parquet from creating unused local fallback paths.

### Documentation, CI, and release preparation

- Adds a dedicated Mike Kennedy/Talk Python follow-up checklist to `ROADMAP.md`, separating completed compatibility work from the post-merge real-application rerun and remaining operator work.
- Updates README, migration, remote SQL, object-storage, and Talk Python acceptance documentation with behavior and upgrade guidance.
- Bumps project metadata to 1.2.1 and adds a detailed unreleased changelog.
- Adds a dependency-free Python 3.9 CI job, a PyMongo 4.9 floor job, real MongoDB contracts, and PostgreSQL/MariaDB integration coverage.
- Hardens PyPI publishing so a release tag must match the package version, point to `master`, have successful CI, contain dated release notes, remove unpublished wording, and pass strict Twine validation.

## Migration and compatibility notes

- PyMongo remains optional for core TinyMongo use. It is an optional runtime dependency for ObjectId/non-generic Binary values, patching, and conditional PyMongo exception inheritance.
- Existing plain JSON and legacy physical IDs remain supported. Before a bulk rewrite, users should check old data for newly recognized BSON-equivalent ID pairs such as `1`/`1.0` or bytes/generic Binary subtype 0.
- Opening a pre-1.2.1 remote SQL collection may add `data_ordered`; the database role needs `ALTER TABLE` permission during that one-time upgrade.
- PostgreSQL JSONB may already have normalized ordinary embedded-document key order in legacy rows. Rewriting captures the order PostgreSQL returns; it cannot reconstruct unknown original application order except where a literal legacy `_id` row key provides it.
- UUID, Decimal128, regular-expression round trips, broader BSON range comparisons, `$pull`/`$addToSet`/`distinct()` identity reuse, and the complete real Talk Python rerun remain tracked follow-up work.

## Validation

Validated on the exact pushed worktree:

- Full local suite: **1,108 passed, 125 deselected**.
- Coverage: **4,804/4,804 statements and 1,746/1,746 branches — 100% with no partial branches**.
- Real MongoDB 8 contract matrix: **456 passed**.
- PostgreSQL 16 + MariaDB 11.4 remote SQL integration suite: **10 passed**.
- Oracle MySQL 8.4 was also exercised during implementation for its schema-upgrade and ordered-sidecar path.
- PyMongo-focused compatibility selection passed.
- Ruff, Black, mypy, `git diff --check`, and workflow YAML parsing passed.
- Fresh 1.2.1 wheel and source distribution built successfully; `twine check --strict` passed for both.

## Follow-up after merge

1. Update Mike's TinyMongo agent guide against the merge SHA or `v1.2.1` tag, correcting the documented signatures, defaults, dependency boundaries, `_id: None`, `_default`, async patching caveats, error shapes, and binary normalization.
2. Rerun Mike's focused reproductions and the real Talk Python async application suite, then publish the MongoDB/memory/SQLite baseline.
3. Continue the separately tracked unsupported-operator, BSON range-comparison, distinct/update identity, and extended BSON-index work.

Closes #140.

Progresses #75, #94, #103, and #136.
