### PR TITLE
Add Python 3.14 and free-threaded 3.14t support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.9', '3.11', '3.13']
+        python-version: ['3.9', '3.11', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4
@@ -66,14 +67,88 @@ jobs:
           coverage report --include='tinymongo/*' --fail-under=100
 
       - name: Lint
+        if: matrix.python-version == '3.14'
         run: |
           ruff check .
           black --check .
           mypy --ignore-missing-imports tinymongo
 
+  free-threaded:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up free-threaded Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14t'
+          check-latest: true
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-free-threaded.txt
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libexpat1-dev libpq-dev
+
+      - name: Install free-threaded dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-free-threaded.txt
+          pip install ".[free-threaded]"
+
+      - name: Verify dependencies preserve free-threaded execution
+        run: |
+          python - <<'PY'
+          import sys
+          import sysconfig
+
+          assert sysconfig.get_config_var("Py_GIL_DISABLED") == 1
+          assert sys._is_gil_enabled() is False
+
+          import coverage.tracer
+          import mongoengine
+          import mypy.main
+          import portalocker
+          import psycopg
+          import pyarrow
+          import pymongo
+          import pymysql
+          import tinydb_serialization
+          import tinymongo
+
+          assert psycopg.pq.__impl__ == "python"
+          assert sys._is_gil_enabled() is False
+          PY
+
+      - name: Force GIL-disabled test execution
+        run: echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
+
+      - name: Run supported free-threaded suite
+        run: |
+          coverage run --branch -m pytest \
+            --ignore=tests/test_table_backends.py \
+            -k 'not duckdb and not parquet'
+          coverage report --include='tinymongo/*' --fail-under=85
+
   mongodb-contracts:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: '3.11'
+            free-threaded: false
+            artifact-suffix: py311
+          - python-version: '3.14'
+            free-threaded: false
+            artifact-suffix: py314
+          - python-version: '3.14t'
+            free-threaded: true
+            artifact-suffix: py314t
     services:
       mongodb:
         image: mongo:8.0
@@ -94,18 +169,53 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
           cache: pip
 
-      - name: Install dependencies
+      - name: Install standard contract dependencies
+        if: ${{ !matrix.free-threaded }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           pip install ".[all]"
 
+      - name: Install free-threaded MongoDB dependencies
+        if: matrix.free-threaded
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest "pymongo>=4.15.2" .
+
+      - name: Verify free-threaded MongoDB dependencies
+        if: matrix.free-threaded
+        run: |
+          python - <<'PY'
+          import sys
+          import sysconfig
+
+          assert sysconfig.get_config_var("Py_GIL_DISABLED") == 1
+          assert sys._is_gil_enabled() is False
+
+          import pymongo
+          import tinymongo
+
+          assert sys._is_gil_enabled() is False
+          PY
+
+      - name: Force GIL-disabled contract execution
+        if: matrix.free-threaded
+        run: echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
+
       - name: Run real MongoDB compatibility contracts
+        if: ${{ !matrix.free-threaded }}
         run: >-
           pytest -o addopts='' -q -m contract tests/contracts
+          --junitxml=contract-results.xml
+
+      - name: Run free-threaded MongoDB compatibility contracts
+        if: matrix.free-threaded
+        run: >-
+          pytest -o addopts='' -q -m 'contract and mongodb' tests/contracts
           --junitxml=contract-results.xml
 
       - name: Generate compatibility reports
@@ -124,7 +234,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mongodb-compatibility-results
+          name: mongodb-compatibility-results-${{ matrix.artifact-suffix }}
           path: |
             contract-results.xml
             compatibility-report.json
@@ -134,6 +244,16 @@ jobs:
   remote-sql-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: '3.11'
+            free-threaded: false
+          - python-version: '3.14'
+            free-threaded: false
+          - python-version: '3.14t'
+            free-threaded: true
     services:
       postgres:
         image: postgres:16
@@ -169,16 +289,103 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
           cache: pip
 
-      - name: Install remote SQL test dependencies
+      - name: Install libpq for pure Psycopg
+        if: matrix.free-threaded
+        run: sudo apt-get update && sudo apt-get install -y libpq5
+
+      - name: Install standard remote SQL test dependencies
+        if: ${{ !matrix.free-threaded }}
         run: |
           python -m pip install --upgrade pip
           pip install pytest ".[remote-sql,bson]"
 
+      - name: Install free-threaded remote SQL test dependencies
+        if: matrix.free-threaded
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest ".[free-threaded]"
+
+      - name: Verify free-threaded remote SQL dependencies
+        if: matrix.free-threaded
+        run: |
+          python - <<'PY'
+          import sys
+          import sysconfig
+
+          assert sysconfig.get_config_var("Py_GIL_DISABLED") == 1
+          assert sys._is_gil_enabled() is False
+
+          import psycopg
+          import pymysql
+          import tinymongo
+
+          assert psycopg.pq.__impl__ == "python"
+          assert sys._is_gil_enabled() is False
+          PY
+
+      - name: Force GIL-disabled integration execution
+        if: matrix.free-threaded
+        run: echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
+
       - name: Run PostgreSQL and MariaDB integration tests
         run: pytest -o addopts='' -q -m integration tests/integration/test_remote_sql.py
+
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: '3.14'
+            artifact-name: tinymongo-dist-py314
+          - python-version: '3.14t'
+            artifact-name: tinymongo-dist-py314t
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
+
+      - name: Install package tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install "build>=1.3" "twine>=7"
+
+      - name: Build and verify distributions
+        run: |
+          python -m build
+          python -m twine check --strict dist/*
+
+      - name: Install the built wheel
+        run: pip install --force-reinstall dist/*.whl
+
+      - name: Smoke-test installed package
+        working-directory: ${{ runner.temp }}
+        run: |
+          python - <<'PY'
+          import sys
+          import sysconfig
+          import tinymongo
+
+          if sysconfig.get_config_var("Py_GIL_DISABLED"):
+              assert sys._is_gil_enabled() is False
+          PY
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: dist/*
+          if-no-files-found: error
 
   pymongo-floor:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [1.2.1] - Unreleased
 
 ### Added
+- Required CPython 3.14 CI coverage and beta-level CPython 3.14t coverage with
+  GIL-disabled unit, concurrency, live-database, and package-install checks,
+  plus a dedicated free-threaded dependency profile.
 - Process-local `memory` backend for isolated tests and temporary data, with
   explicit same-process sharing through named `memory://NAME` namespaces.
 - The memory backend now participates in the shared MongoDB compatibility
@@ -58,6 +61,10 @@
   with private attribute access guarded like PyMongo in both APIs.
 
 ### Fixed
+- Concurrent first access now creates one cached database handle per client,
+  compatibility concern documents are no longer shared between instances, and
+  lazy table creation for retained collection handles occurs under the write
+  lock.
 - `bypass_document_validation` remains a compatibility no-op: TinyMongo has no
   user-configurable validator layer, and the flag cannot bypass built-in `_id`
   or declared unique-index constraints.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include requirements-dev.txt
+include requirements-free-threaded.txt
 include README.md
 recursive-include examples *.py
 recursive-include tests *.py *.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Parquet, PostgreSQL, and MariaDB/MySQL backends.
 # Status
 
 TinyMongo supports Python 3.9 and newer and is tested in GitHub Actions on
-Python 3.9, 3.11, and 3.13.
+Python 3.9, 3.11, 3.13, and 3.14. CPython 3.14's free-threaded build is
+supported at the beta level for the backends described below.
 
 # Installation
 
@@ -232,6 +233,31 @@ dependency. It is selected at runtime for `ObjectId`, non-generic `Binary`
 subtypes, patching, and conditional PyMongo exception inheritance, and is also
 used by development compatibility tests. Install `tinymongo[bson]` for BSON
 values or `tinymongo[pymongo]` for patching and installed-version compatibility.
+
+## Free-threaded Python 3.14
+
+For CPython 3.14t, install the dependency profile that has been verified while
+the GIL is disabled:
+
+```bash
+python3.14t -m pip install "tinymongo[free-threaded]"
+```
+
+This profile covers the core API, memory, TinyDB/JSON, SQLite, BSON/PyMongo,
+MySQL/MariaDB, and PostgreSQL through pure Psycopg. Pure Psycopg requires the
+system `libpq` library. DuckDB and Parquet are not yet available in this
+profile because DuckDB does not publish a `cp314t` wheel; `psycopg-binary`
+likewise has no `cp314t` distribution. The required 3.14t CI lanes verify that
+the GIL remains disabled and exercise in-process concurrency, MongoDB
+contracts, remote SQL, and built-package installation. Contributors using
+3.14t should install `requirements-free-threaded.txt` instead of
+`requirements-dev.txt`.
+
+Free-threaded support does not make every object safe for simultaneous
+mutation. Shared client, database, and collection handles support independent
+operations, but applications should coordinate lifecycle calls such as
+`close()` and `drop_database()` and should not consume one cursor or iterator
+from multiple threads.
 
 | Backend | Dependency | Best fit | Notes |
 | --- | --- | --- | --- |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -187,6 +187,17 @@ Exit criteria:
 
 [View milestone](https://github.com/schapman1974/tinymongo/milestone/4)
 
+### Python 3.14 runtime coverage
+
+- [x] Add required Python 3.14 unit, 100%-coverage, live MongoDB, remote SQL,
+  and built-package CI lanes.
+- [x] Add beta-level CPython 3.14t coverage with the GIL disabled for core,
+  concurrency, BSON/PyMongo, live MongoDB, pure-Psycopg PostgreSQL,
+  MariaDB/MySQL, and package installation.
+- [ ] Add DuckDB and Parquet to the 3.14t lane when DuckDB publishes a
+  compatible free-threaded distribution; switch PostgreSQL back to the binary
+  Psycopg profile there when `psycopg-binary` publishes one.
+
 - [ ] [#79: Backend benchmarks and compatibility reports](https://github.com/schapman1974/tinymongo/issues/79)
 - [ ] [#55: ODM integration](https://github.com/schapman1974/tinymongo/issues/55)
 - [ ] [#81: MongoDB document and key validation](https://github.com/schapman1974/tinymongo/issues/81)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Database",
 ]
 
@@ -71,6 +73,14 @@ postgres = ["psycopg[binary]>=3.1"]
 mysql = ["PyMySQL>=1.1"]
 mariadb = ["PyMySQL>=1.1"]
 remote-sql = ["psycopg[binary]>=3.1", "PyMySQL>=1.1"]
+# PEP 508 has no free-threaded ABI marker. This profile uses pure Psycopg and
+# omits DuckDB/Parquet until those projects publish compatible distributions.
+free-threaded = [
+  "tinydb-serialization>=1.0.4,<2",
+  "pymongo>=4.15.2",
+  "psycopg>=3.3.4",
+  "PyMySQL>=1.1",
+]
 all = [
   "tinydb-serialization>=1.0.4,<2",
   "pymongo>=4.9",

--- a/requirements-free-threaded.txt
+++ b/requirements-free-threaded.txt
@@ -1,0 +1,14 @@
+# Development tools and compiled packages verified on CPython 3.14t.
+# DuckDB and psycopg-binary are intentionally absent because neither publishes
+# a compatible free-threaded distribution. Runtime dependencies come from
+# tinymongo[free-threaded].
+pytest>=8.4
+coverage>=7.10
+pyarrow>=22
+pymongo>=4.15.2
+mongoengine>=0.29.1,<1
+black>=25,<26
+ruff>=0.15,<0.16
+mypy>=1.20,<2
+build>=1.3
+twine>=7

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,100 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+
+import pytest
+import tinymongo as tm
+from tinymongo import tinymongo as implementation
+
+
+def test_concurrent_first_database_access_reuses_one_cached_handle(
+    tmp_path, monkeypatch
+):
+    original_database = implementation.TinyMongoDatabase
+    constructor_calls = 0
+    constructor_lock = threading.Lock()
+    workers = 8
+    start = threading.Barrier(workers)
+
+    def slow_database(*args, **kwargs):
+        nonlocal constructor_calls
+        with constructor_lock:
+            constructor_calls += 1
+        time.sleep(0.05)
+        return original_database(*args, **kwargs)
+
+    monkeypatch.setattr(implementation, "TinyMongoDatabase", slow_database)
+    client = tm.TinyMongoClient(str(tmp_path))
+
+    def select_database(_worker):
+        start.wait()
+        return client.app
+
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            databases = list(executor.map(select_database, range(workers)))
+
+        assert constructor_calls == 1
+        assert len({id(database) for database in databases}) == 1
+        assert client._databases == {"app": databases[0]}
+    finally:
+        client.close()
+
+
+def test_compatibility_concern_documents_are_not_shared(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path))
+    try:
+        collection = client.app.items
+        first = collection.write_concern
+        second = collection.write_concern
+
+        first.document["w"] = "majority"
+
+        assert second.document == {}
+        assert collection.read_concern.document == {}
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("operation", ["update_one", "update_many", "replace_one"])
+def test_shared_collection_builds_its_table_inside_the_write_lock(
+    tmp_path, monkeypatch, operation
+):
+    client = tm.TinyMongoClient(str(tmp_path))
+    client.app.items.insert_one({"_id": 1, "count": 0})
+    collection = client.app.items
+    original_build_table = collection.build_table
+    build_calls = 0
+    build_calls_lock = threading.Lock()
+    workers = 2
+    start = threading.Barrier(workers)
+
+    def slow_build_table():
+        nonlocal build_calls
+        with build_calls_lock:
+            build_calls += 1
+        time.sleep(0.05)
+        original_build_table()
+
+    monkeypatch.setattr(collection, "build_table", slow_build_table)
+
+    def write(worker):
+        start.wait()
+        if operation == "replace_one":
+            return collection.replace_one(
+                {"_id": 1},
+                {"_id": 1, "count": worker},
+            )
+        return getattr(collection, operation)(
+            {"_id": 1},
+            {"$inc": {"count": 1}},
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            results = list(executor.map(write, range(workers)))
+
+        assert build_calls == 1
+        assert all(result.matched_count == 1 for result in results)
+    finally:
+        client.close()

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -10,6 +10,7 @@ from functools import reduce, wraps
 import logging
 import os
 import shutil
+import threading
 import warnings
 from uuid import uuid4
 
@@ -66,7 +67,8 @@ DESCENDING = -1
 
 
 class _CompatibilityConcern(object):
-    document: dict = {}
+    def __init__(self):
+        self.document = {}
 
 
 def Q(query, key):
@@ -477,6 +479,7 @@ class TinyMongoClient(object):
         else:
             self._dsn = None
         self._databases = {}
+        self._databases_lock = threading.RLock()
         self._closed = False
         storage_is_nonlocal = is_remote_sql_backend(backend_name) or bool(
             self._storage_uri and backend_name in ("parquet", "parquetv2")
@@ -529,28 +532,29 @@ class TinyMongoClient(object):
         return os.path.join(self._foldername, key + storage_extension(self._backend))
 
     def _get_db(self, key):
-        self._ensure_open()
-        if key in self._databases:
-            return self._databases[key]
-        path = self._get_db_path(key)
-        if is_table_backend(self._backend):
-            engine_class = get_table_backend(self._backend)
-            database = TinyMongoDatabase(
-                key,
-                path,
-                self._storage,
-                engine=engine_class(
+        with self._databases_lock:
+            self._ensure_open()
+            if key in self._databases:
+                return self._databases[key]
+            path = self._get_db_path(key)
+            if is_table_backend(self._backend):
+                engine_class = get_table_backend(self._backend)
+                database = TinyMongoDatabase(
+                    key,
                     path,
-                    threads=self._threads,
-                    duckdb_config=self._duckdb_config,
-                    database=key,
-                    dsn=self._dsn,
-                ),
-            )
-        else:
-            database = TinyMongoDatabase(key, path, self._storage)
-        self._databases[key] = database
-        return database
+                    self._storage,
+                    engine=engine_class(
+                        path,
+                        threads=self._threads,
+                        duckdb_config=self._duckdb_config,
+                        database=key,
+                        dsn=self._dsn,
+                    ),
+                )
+            else:
+                database = TinyMongoDatabase(key, path, self._storage)
+            self._databases[key] = database
+            return database
 
     def _ensure_open(self):
         """Reject operations that would use a client after it was closed."""
@@ -560,14 +564,15 @@ class TinyMongoClient(object):
 
     def close(self):
         """Close databases opened by this client."""
-        if self._closed:
-            return
-        for database in self._databases.values():
-            database.close()
-        self._databases.clear()
-        if self._memory_namespace is not None and not self._shared_memory:
-            clear_memory_namespace(self._memory_namespace)
-        self._closed = True
+        with self._databases_lock:
+            if self._closed:
+                return
+            for database in self._databases.values():
+                database.close()
+            self._databases.clear()
+            if self._memory_namespace is not None and not self._shared_memory:
+                clear_memory_namespace(self._memory_namespace)
+            self._closed = True
 
     def __enter__(self):
         return self
@@ -691,25 +696,27 @@ class TinyMongoClient(object):
         name = getattr(name_or_database, "database", name_or_database)
         if not isinstance(name, str):
             raise TypeError("database name must be a string or TinyMongoDatabase")
-        if name not in self.list_database_names() and name not in self._databases:
-            return None
+        with self._databases_lock:
+            self._ensure_open()
+            if name not in self.list_database_names() and name not in self._databases:
+                return None
 
-        database = self._databases.pop(name, None)
-        if database is None:
-            database = self[name]
-            self._databases.pop(name, None)
-        for collection_name in list(database.list_collection_names()):
-            database.drop_collection(collection_name)
-        database.close()
+            database = self._databases.pop(name, None)
+            if database is None:
+                database = self[name]
+                self._databases.pop(name, None)
+            for collection_name in list(database.list_collection_names()):
+                database.drop_collection(collection_name)
+            database.close()
 
-        path = self._get_db_path(name)
-        if self._memory_namespace is not None:
-            clear_memory_database(path)
-        elif not is_remote_sql_backend(self._backend) and not self._storage_uri:
-            if os.path.isfile(path):
-                os.remove(path)
-            elif os.path.isdir(path):
-                shutil.rmtree(path)
+            path = self._get_db_path(name)
+            if self._memory_namespace is not None:
+                clear_memory_database(path)
+            elif not is_remote_sql_backend(self._backend) and not self._storage_uri:
+                if os.path.isfile(path):
+                    os.remove(path)
+                elif os.path.isdir(path):
+                    shutil.rmtree(path)
         return None
 
     def database_names(self):
@@ -1735,11 +1742,10 @@ class TinyMongoCollection(object):
                 modified_count=int(modified),
             )
 
-        if self.table is None:
-            self.build_table()
-
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
+            if self.table is None:
+                self.build_table()
             self._refresh_table()
             direct_id = _direct_id_equality(query)
             if direct_id is not _MISSING:
@@ -1866,11 +1872,10 @@ class TinyMongoCollection(object):
                 modified_count=modified_count,
             )
 
-        if self.table is None:
-            self.build_table()
-
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
+            if self.table is None:
+                self.build_table()
             self._refresh_table()
             direct_id = _direct_id_equality(query)
             if direct_id is not _MISSING:
@@ -1984,11 +1989,10 @@ class TinyMongoCollection(object):
                 modified_count=int(modified),
             )
 
-        if self.table is None:
-            self.build_table()
-
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
+            if self.table is None:
+                self.build_table()
             self._refresh_table()
             direct_id = _direct_id_equality(query)
             if direct_id is not _MISSING:


### PR DESCRIPTION
## Summary

This adds required CPython 3.14 coverage and beta-level support for CPython
3.14t running with the GIL disabled. It includes a dedicated dependency
profile, new CI lanes, concurrency fixes discovered during the audit,
packaging checks, and documentation of the supported backend boundary.

## Why

Installing the existing development or `all` dependency profiles on 3.14t is
not currently reliable because DuckDB and `psycopg-binary` do not publish
compatible `cp314t` distributions. Free-threaded execution also exposed races
that normal GIL-backed execution had hidden: concurrent first access could
construct multiple database handles, compatibility concern instances shared
one mutable document, and retained collection handles could lazily construct a
table outside their write lock.

## What changed

- Add regular Python 3.14 to the full unit and coverage matrix.
- Add a required `3.14t` job that verifies `Py_GIL_DISABLED`, confirms the GIL
  remains off after importing every supported compiled dependency, and runs the
  compatible sync and async suite with `PYTHON_GIL=0`.
- Add 3.14 and 3.14t live MongoDB, PostgreSQL, and MariaDB/MySQL lanes.
- Add 3.14 and 3.14t build, Twine, wheel-install, and import smoke tests.
- Add the `tinymongo[free-threaded]` profile and
  `requirements-free-threaded.txt`.
- Use pure Psycopg 3.3.4+ with system `libpq` in the free-threaded profile.
- Add Python 3.14 and beta free-threading package classifiers.
- Serialize client database-handle creation, close, and database removal with
  a reentrant lock.
- Move retained collection table creation inside the existing write lock.
- Give each compatibility concern its own document.
- Add deterministic concurrency regression tests.
- Document installation, thread-sharing boundaries, supported backends,
  upstream exclusions, and roadmap status.

## Supported 3.14t scope

The beta profile covers the core API, memory, TinyDB/JSON, SQLite,
BSON/PyMongo, MongoDB contracts, MySQL/MariaDB, PostgreSQL through pure
Psycopg, and package installation. DuckDB and Parquet remain outside the
3.14t lane until DuckDB publishes a free-threaded distribution. PostgreSQL can
return to `psycopg-binary` when that project publishes a compatible
distribution.

Regular Python 3.14 continues to run the complete dependency and backend suite,
including DuckDB and Parquet.

## Validation

Local verification used stable CPython 3.14.6t with `PYTHON_GIL=0`:

- 812 supported tests passed; whole-package coverage was 86%, with an enforced
  85% floor for this intentionally reduced dependency set.
- The regular Python 3.14 suite passed 1,113 tests at 100% statement and branch
  coverage.
- MongoDB 8: 76 compatibility contracts passed.
- PostgreSQL 16 and MariaDB 11.4: all 10 integration tests passed.
- The GIL remained disabled before and after importing Coverage, MongoEngine,
  mypy, Portalocker, pure Psycopg, PyArrow, PyMongo, PyMySQL, TinyDB
  serialization, and TinyMongo.
- The concurrency regression tests also passed 25 repeated GIL-disabled runs.
- Ruff, Black, mypy, Actionlint, `git diff --check`, package builds, strict
  Twine checks, isolated wheel installation, and GIL-disabled wheel smoke tests
  passed.
