### PR TITLE
Fix Talk Python generated IDs, null negation, and invalid documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,17 @@
   schema upgrades leave existing native JSON indexes in place.
 - Explicit null `_id` values are preserved, and exact recursive `_id` identity
   prevents scalar/container aliases and codec-normalized tuple/list duplicates.
+- Implicit IDs now use native `ObjectId` values when optional BSON support is
+  installed, including insert batches and upserts, so their string form can be
+  reconstructed with `ObjectId(...)`. Dependency-free writes and the explicit
+  `generate_id()` helper retain portable UUID-string IDs.
+- `$ne: None` and `$nin` lists containing `None` now exclude missing fields,
+  matching MongoDB without changing the missing-field behavior of non-null
+  negation.
+- Unsupported document values now raise `InvalidDocument` before storage is
+  changed, with the original document and nested path context. When PyMongo is
+  installed, the error is catchable through both BSON's `InvalidDocument` and
+  `PyMongoError`; dependency-free callers retain the TinyMongo error hierarchy.
 - Remote SQL duplicate races are reread and replanned so ordered and unordered
   batches retain their documented partial-write behavior; database commit
   failures now propagate instead of being reported as successful writes.

--- a/README.md
+++ b/README.md
@@ -414,6 +414,12 @@ members), nested document paths, `$gt`, `$gte`, `$lt`, `$lte`, `$ne`,
 `$nin`, `$in`, `$all`, `$and`, `$or`, `$nor`, `$not`, `$regex`,
 case-insensitive `$options`, and `$exists`.
 
+MongoDB treats missing fields differently depending on the negated value.
+`{"field": {"$ne": None}}` and `$nin` lists containing `None` exclude
+documents where `field` is missing, while `$ne` and `$nin` with only non-null
+values continue to include missing fields. The same rule applies to dotted
+paths and array members across TinyMongo backends.
+
 Update support includes `$set`, `$unset`, `$inc`, `$push`, `$pull`, and
 `$addToSet`, including `upsert=True`. As in PyMongo, `update_one()` and
 `update_many()` require update operators; use `replace_one()` for full-document
@@ -487,6 +493,14 @@ core dependency:
 pip install "tinymongo[bson]"
 ```
 
+When BSON support is installed, TinyMongo gives writes that omit `_id` a native
+`ObjectId`, including `insert_many()` and upsert paths. The returned value can
+be reconstructed with `ObjectId(str(result.inserted_id))`. A dependency-free
+installation falls back to a 32-character UUID string. The public
+`tinymongo.generate_id()` helper always returns that portable UUID string for
+callers, such as MongoEngine models, that explicitly want string IDs. Existing
+string and integer IDs remain readable and are never rewritten.
+
 ```python
 from datetime import datetime
 from bson import Binary, ObjectId
@@ -541,6 +555,13 @@ a client-side serialization failure leaves the entire TinyMongo input
 unwritten. This is a stronger whole-list guarantee than PyMongo provides for
 very large inputs, which it may split across multiple wire batches.
 
+An unsupported value raises `tinymongo.InvalidDocument` before storage is
+changed. The exception retains the rejected document in its `document`
+attribute, and its message identifies the collection and nested value path
+(plus the batch index for `insert_many()`). With PyMongo installed, it can be
+caught as either `bson.errors.InvalidDocument` or `pymongo.errors.PyMongoError`;
+dependency-free callers can catch `tinymongo.errors.TinyMongoError`.
+
 TinyMongo includes PyMongo-shaped contract tests that run application code with
 `import pymongo` redirected to TinyMongo:
 
@@ -582,7 +603,9 @@ PyMongo remains optional. It is needed for these comparisons,
 it is not required for normal TinyMongo clients, `datetime` storage, or native
 subtype-0 byte values. When it is installed, TinyMongo error classes also
 inherit the matching `pymongo.errors` classes, so existing `PyMongoError`
-handlers continue to work.
+handlers continue to work. `InvalidDocument` additionally preserves BSON's
+standard error identity while remaining inside TinyMongo's portable error
+hierarchy.
 
 PyMongo's full upstream driver test suite targets a real MongoDB server and
 driver internals, so it is not expected to pass against TinyMongo. The contract

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,15 @@ with the follow-up audit of his
   numbers, and equivalent numeric representations share one key.
 - [x] Use typed physical `_id` keys on SQL, DuckDB, and Parquet backends without
   breaking reads, replacements, or deletes for existing stringified keys.
+- [x] Generate native `ObjectId` values for implicit IDs when optional BSON
+  support is installed across inserts and upserts, while keeping dependency-free
+  UUID fallback IDs and the explicit string-returning `generate_id()` helper.
+- [x] Match MongoDB's null-negation boundary: `$ne: None` and `$nin` lists
+  containing `None` exclude missing fields, while non-null negation continues
+  to include them.
+- [x] Raise `InvalidDocument` before writes containing unsupported values, with
+  original-document and nested-path context plus BSON, PyMongo, and
+  dependency-free TinyMongo catch compatibility.
 - [x] Preserve embedded-document field order and strict-JSON non-finite floats
   in remote SQL rows while continuing to read legacy rows without an ordered
   copy.
@@ -87,8 +96,11 @@ with the follow-up audit of his
   collection filtering, current error/result shapes, and `bytearray`
   normalization. Also distinguish PyMongo from a core dependency: it is an
   optional runtime dependency for ObjectId and nonzero Binary values, patching,
-  and conditional exception inheritance. Correct the remaining constructor,
-  sync-laziness, validation, sort, locking, environment-variable,
+  and conditional exception inheritance. Document the native automatic
+  `ObjectId` versus explicit string `generate_id()` behavior, null-negation
+  handling for missing fields, and the contextual `InvalidDocument` hierarchy.
+  Correct the remaining constructor, sync-laziness, validation, sort,
+  locking, environment-variable,
   capabilities-detection, portable-error-catching, index-migration wording,
   and the contradictory async `db.name` collection example identified by the
   guide audit.
@@ -102,10 +114,13 @@ with the follow-up audit of his
 - [ ] Extend unique-index tokens to supported BSON values through
   [#75](https://github.com/schapman1974/tinymongo/issues/75) and
   [#76](https://github.com/schapman1974/tinymongo/issues/76).
-- [ ] Rerun Mike's two focused reproductions, resume the real Talk Python
-  acceptance run, and publish the MongoDB, memory, and SQLite baseline through
-  [#72](https://github.com/schapman1974/tinymongo/issues/72) and
-  [#136](https://github.com/schapman1974/tinymongo/issues/136).
+- [x] Run the real Talk Python acceptance suite against MongoDB and TinyMongo
+  SQLite: both passed all 590 tests, and the 81,017-document application
+  database migrated with zero rejections.
+- [ ] Rerun Mike's TM-009 and TM-010 reproductions plus the invalid-document
+  write path after these fixes merge, then publish the MongoDB, memory, and
+  SQLite baseline through [#72](https://github.com/schapman1974/tinymongo/issues/72)
+  and [#136](https://github.com/schapman1974/tinymongo/issues/136).
 
 Application-compatibility work:
 
@@ -114,7 +129,9 @@ Application-compatibility work:
     off-thread storage calls, async cleanup, and sync-result parity.
   - [x] Run the application-derived compatibility contracts through both the
     synchronous and asynchronous APIs.
-  - [ ] Run the complete async application contract against Talk Python and
+  - [x] Run the complete application suite through the async acceptance path:
+    MongoDB and TinyMongo SQLite each passed 590 tests.
+  - [ ] Complete the write-heavy admin and multi-worker SQLite follow-up, and
     record any remaining differences.
 - [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
 - [ ] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
@@ -122,7 +139,8 @@ Application-compatibility work:
   - [ ] Add UUID, Decimal128, and regular-expression round trips.
 - [ ] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
   - [x] Talk Python query slice: scalar-to-array equality, combined `$nin`,
-    `$not`, `$regex`, case-insensitive `$options`, and missing fields.
+    `$not`, `$regex`, case-insensitive `$options`, and Mongo-correct
+    null-versus-missing negation.
   - [ ] Prioritize the remaining query and update candidates from measured
     application failures.
 - [ ] [#102: Optional PyMongo-version adaptation](https://github.com/schapman1974/tinymongo/issues/102)
@@ -133,8 +151,10 @@ Application-compatibility work:
     sync/async backend and MongoDB contract matrix.
   - [x] Provide an external pytest runner that patches both PyMongo client
     classes before application tests are imported.
-  - [ ] Run the real Talk Python suite through the runner and publish its
-    reference, memory, and SQLite baseline.
+  - [x] Run the real Talk Python suite through the runner against the MongoDB
+    reference and TinyMongo SQLite, with 590 passing tests on each.
+  - [ ] Rerun the new focused cases and publish the reference, memory, and
+    SQLite report artifacts.
 - [ ] [#87: Differential compatibility fuzzing](https://github.com/schapman1974/tinymongo/issues/87)
 
 Exit criteria:
@@ -323,7 +343,8 @@ Exit criteria:
    contract, and publish the baseline compatibility score.
    - [x] Exercise the Talk-Python-derived contract slice through sync and async.
    - [x] Add deterministic reporting and an external application test runner.
-   - [ ] Complete the real application run with Mike and record every difference.
+   - [x] Complete the real application run with Mike and record every difference.
+   - [ ] Rerun the three follow-up cases and publish the dimensioned baseline.
 5. [ ] Build aggregation core after the real-application acceptance path works.
 6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
    compatibility gaps.

--- a/docs/TALKPYTHON_ACCEPTANCE.md
+++ b/docs/TALKPYTHON_ACCEPTANCE.md
@@ -10,9 +10,10 @@ contains two layers that make that handoff practical:
    `pymongo.MongoClient` and `pymongo.AsyncMongoClient` are patched to use a
    selected TinyMongo backend.
 
-The second layer still needs to be run in the Talk Python repository. Until that
-real application run happens, the roadmap's application-acceptance item remains
-open.
+Mike Kennedy has now run the second layer in the Talk Python repository against
+both MongoDB and TinyMongo SQLite. The remaining acceptance work is to rerun
+the focused follow-up cases, exercise the write-heavy admin and concurrency
+paths, and publish the complete dimensioned report.
 
 ## Prepare the application environment
 
@@ -94,7 +95,7 @@ The report is publishable only when every expected target cell was executed,
 the matching MongoDB reference behavior passed, and no result is unattributed.
 A partial run is still rendered, but it is labeled incomplete.
 
-## First application findings and rerun gate
+## Application result and rerun gate
 
 Mike Kennedy's first real Talk Python pass reached the asynchronous application
 initializer on SQLite, opened all four database handles, and accepted the index
@@ -112,28 +113,58 @@ to reusable contracts:
 - synchronous and asynchronous code must preserve the same behavior across
   memory, JSON, SQLite, DuckDB, and Parquet.
 
-The Mongo-compatible portions of these behaviors now run through the shared
+After those fixes, Mike migrated all 81,017 source documents with zero
+rejections and ran the real application suite through this repository's
+acceptance runner. MongoDB and TinyMongo SQLite both passed all 590 tests; the
+public site rendered from TinyMongo without MongoDB running. The recorded
+TinyMongo baseline was `master` at `6615f8b`, Python 3.14.6, PyMongo 4.17, and
+the SQLite backend. A fresh-memory run initially exposed four sitemap failures,
+which Mike confirmed and fixed as empty-data assumptions in the application
+rather than TinyMongo differences.
+
+The Mongo-compatible behaviors also run through TinyMongo's shared
 synchronous/asynchronous matrix and real MongoDB contracts. TinyMongo's
 stronger whole-input serialization preflight is covered locally because
-PyMongo may split a very large input across wire batches. Before publishing
-the Talk Python baseline, rerun the two reduced reproductions and the
-application suite, and record the exact Talk Python commit, Python and PyMongo
-versions, selected test inventory, and configuration. The runner's `--api`
-value labels results; the application configuration must actually exercise
-the corresponding client path.
+PyMongo may split a very large input across wire batches. Before publishing the
+final dimensioned report, record the exact Talk Python commit, selected test
+inventory, and configuration for each rerun. The runner's `--api` value labels
+results; the application configuration must actually exercise the
+corresponding client path.
+
+### Follow-up compatibility fixes
+
+Mike's next focused pass identified three more PyMongo-facing differences:
+
+- omitted `_id` values needed to be native `ObjectId` instances so the
+  application could reconstruct them from their string form;
+- `$ne: None` and `$nin` lists containing `None` needed to exclude missing
+  fields; and
+- unsupported document values needed to raise `InvalidDocument` instead of a
+  bare serialization `TypeError`.
+
+These cases now run through the shared synchronous/asynchronous contract
+matrix. TinyMongo creates native automatic IDs when optional BSON support is
+available, while dependency-free writes and the explicit `generate_id()`
+helper retain UUID strings. Invalid-document failures happen before storage,
+retain the rejected document and nested path context, and are catchable through
+both BSON's `InvalidDocument` and `PyMongoError` when PyMongo is installed.
+The main application goal is achieved; these three follow-up cases remain open
+until they are rerun in Talk Python's write paths.
 
 Mike's separate TinyMongo agent reference currently describes unreleased
 `master` behavior as version 1.2.0. After the compatibility branch merges,
 update that guide against the merge SHA or the `v1.2.1` tag, including the
 Binary codec, BSON-aware `_id` identity, `insert_many()` partial failures,
-bounded sort diagnostics, exact `$unset`, BSON-aware CLI, and dotted child
-collections. Also correct the stale list-only `insert_many()` signature and
-defaults, `BulkWriteError` details, blanket session claim, conditional
-`AsyncMongoClient` patch/import caveat, numeric-versus-bool identity wording,
-explicit null `_id` handling, `_default` collection filtering, current
-error/result shapes, and `bytearray` normalization. It should call PyMongo an
-optional runtime dependency—not a core dependency—for ObjectId and nonzero
-Binary values, patching, and conditional exception inheritance.
+bounded sort diagnostics, exact `$unset`, BSON-aware CLI, dotted child
+collections, native automatic `ObjectId` values, null-negation behavior, and
+contextual `InvalidDocument` errors. Also correct the stale list-only
+`insert_many()` signature and defaults, `BulkWriteError` details, blanket
+session claim, conditional `AsyncMongoClient` patch/import caveat,
+numeric-versus-bool identity wording, explicit null `_id` handling, `_default`
+collection filtering, current error/result shapes, and `bytearray`
+normalization. It should call PyMongo an optional runtime dependency—not a core
+dependency—for ObjectId and nonzero Binary values, patching, and conditional
+exception inheritance.
 The same guide update should correct constructor and sync-laziness wording,
 document validation as a no-op, empty-array and sort-error details,
 backend-specific locking and durability, the full object-storage environment

--- a/tests/contracts/test_talkpython_contract.py
+++ b/tests/contracts/test_talkpython_contract.py
@@ -165,6 +165,33 @@ def test_nin_excludes_values_and_includes_missing_fields(contract_target):
     assert sorted(_ids(documents)) == [1, 4]
 
 
+def test_null_negation_distinguishes_missing_and_non_null_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": "real"},
+            {"_id": 2, "value": ""},
+            {"_id": 3, "value": None},
+            {"_id": 4},
+            {"_id": 5, "value": "other"},
+        ]
+    )
+
+    expectations = [
+        ({"value": {"$nin": [None, ""]}}, [1, 5]),
+        ({"value": {"$nin": (None, "")}}, [1, 5]),
+        ({"value": {"$ne": None}}, [1, 2, 5]),
+        ({"value": {"$ne": ""}}, [1, 3, 4, 5]),
+        ({"value": {"$nin": ["real"]}}, [2, 3, 4, 5]),
+        ({"value": {"$not": {"$regex": "^r"}}}, [2, 3, 4, 5]),
+        ({"value": {"$exists": True}}, [1, 2, 3, 5]),
+        ({"value": {"$exists": False}}, [4]),
+    ]
+
+    for query, expected_ids in expectations:
+        assert sorted(_ids(collection.find(query))) == expected_ids
+
+
 def test_nin_and_negated_regex_share_one_field_specification(contract_target):
     collection = contract_target.collection
     collection.insert_many(
@@ -333,6 +360,43 @@ def test_object_id_and_datetime_round_trip_and_range_query(contract_target):
     assert document["created_date"] == created_date
     assert isinstance(document["created_date"], datetime)
     assert _ids(in_range) == [episode_id]
+
+
+def test_generated_id_uses_the_standard_object_id_round_trip(contract_target):
+    bson = pytest.importorskip("bson")
+    collection = contract_target.collection
+    document = {"title": "A newly-created episode"}
+
+    result = collection.insert_one(document)
+    reconstructed = bson.ObjectId(str(result.inserted_id))
+    found = collection.find_one({"_id": reconstructed})
+
+    assert isinstance(result.inserted_id, bson.ObjectId)
+    assert document["_id"] == result.inserted_id
+    assert len(str(result.inserted_id)) == 24
+    assert reconstructed == result.inserted_id
+    assert found["title"] == document["title"]
+
+
+def test_invalid_document_has_a_bson_compatible_error(contract_target):
+    bson_errors = pytest.importorskip("bson.errors")
+    pymongo_errors = pytest.importorskip("pymongo.errors")
+    collection = contract_target.collection
+    document = {"payload": {"tags": {1, 2, 3}}}
+
+    with pytest.raises(bson_errors.InvalidDocument) as caught:
+        collection.insert_one(document)
+
+    if contract_target.name != "mongodb" and contract_target.api == "sync":
+        assert collection.name not in collection.database.list_collection_names()
+    assert collection.count_documents({}) == 0
+    if contract_target.name != "mongodb":
+        assert isinstance(caught.value, pymongo_errors.PyMongoError)
+        assert caught.value.document is document
+        assert collection.full_name in str(caught.value)
+        assert "payload" in str(caught.value)
+        assert "tags" in str(caught.value)
+        assert "set" in str(caught.value)
 
 
 def test_binary_round_trip_query_and_mongodb_sort_order(contract_target):

--- a/tests/test_bson_codec.py
+++ b/tests/test_bson_codec.py
@@ -6,11 +6,67 @@ import pytest
 
 import tinymongo as tm
 from tinymongo import bson_codec, bson_types
+from tinymongo.errors import InvalidDocument, TinyMongoError
 
 
 bson = pytest.importorskip("bson")
 ObjectId = bson.ObjectId
 Binary = bson.Binary
+
+
+def test_invalid_document_matches_tinymongo_bson_and_pymongo_hierarchies():
+    from bson.errors import InvalidDocument as BsonInvalidDocument
+    from pymongo.errors import InvalidDocument as PyMongoInvalidDocument
+    from pymongo.errors import PyMongoError
+
+    document = {"value": {1, 2}}
+
+    with pytest.raises(InvalidDocument) as caught:
+        bson_codec.dumps(document)
+
+    error = caught.value
+    assert isinstance(error, TinyMongoError)
+    assert isinstance(error, BsonInvalidDocument)
+    assert isinstance(error, PyMongoInvalidDocument)
+    assert isinstance(error, PyMongoError)
+    assert not isinstance(error, TypeError)
+    assert error.document is document
+
+
+def test_invalid_document_reports_nested_path_and_write_context():
+    document = {
+        "_id": "broken",
+        "outer": {"items": [{"valid": 1}, {"unsupported": {1, 2}}]},
+    }
+
+    with pytest.raises(InvalidDocument) as caught:
+        bson_codec.dumps(
+            document,
+            document_context="collection 'app.items', document index 4",
+        )
+
+    message = str(caught.value)
+    assert caught.value.document is document
+    assert "collection 'app.items', document index 4" in message
+    assert "$['outer']['items'][1]['unsupported']" in message
+    assert "cannot encode object" in message
+    assert "<class 'set'>" in message
+
+
+def test_invalid_document_bounds_the_offending_value_representation():
+    class VerboseUnsupportedValue:
+        def __repr__(self):
+            return "unsupported-" + ("x" * 500)
+
+    document = {"value": VerboseUnsupportedValue()}
+
+    with pytest.raises(InvalidDocument) as caught:
+        bson_codec.dumps(document)
+
+    message = str(caught.value)
+    assert "unsupported-" in message
+    assert "..." in message
+    assert "x" * 200 not in message
 
 
 def _extended_document():

--- a/tests/test_bson_registry_hardening.py
+++ b/tests/test_bson_registry_hardening.py
@@ -262,7 +262,9 @@ def test_fresh_process_without_pymongo_keeps_core_codec_available():
 
         builtins.__import__ = without_pymongo
 
+        import tinymongo
         from tinymongo import bson_codec, bson_types
+        from tinymongo.errors import InvalidDocument, TinyMongoError
 
         assert bson_types.bson_capabilities() == {
             "objectid": False,
@@ -272,6 +274,37 @@ def test_fresh_process_without_pymongo_keeps_core_codec_available():
         assert bson_codec.object_id_available() is False
         assert bson_codec.binary_available() is False
         assert bson_codec.loads(bson_codec.dumps(b"core")) == b"core"
+        assert issubclass(InvalidDocument, TinyMongoError)
+
+        explicit_id = tinymongo.generate_id()
+        assert type(explicit_id) is str
+        assert len(explicit_id) == 32
+
+        client = tinymongo.TinyMongoClient(backend="memory")
+        result = client.core.items.insert_one({"kind": "implicit-id"})
+        assert type(result.inserted_id) is str
+        assert len(result.inserted_id) == 32
+        assert client.core.items.find_one({"_id": result.inserted_id}) is not None
+        client.close()
+
+        invalid_document = {
+            "_id": "invalid",
+            "nested": [{"unsupported": {1, 2}}],
+        }
+        try:
+            bson_codec.dumps(
+                invalid_document,
+                document_context="collection 'core.items'",
+            )
+        except TinyMongoError as error:
+            assert isinstance(error, InvalidDocument)
+            assert not isinstance(error, TypeError)
+            assert error.document is invalid_document
+            assert "collection 'core.items'" in str(error)
+            assert "$['nested'][0]['unsupported']" in str(error)
+            assert "<class 'set'>" in str(error)
+        else:
+            raise AssertionError("unsupported set encoded without an error")
 
         moment = datetime(2026, 7, 29, 12, 30)
         assert bson_codec.loads(bson_codec.dumps(moment)) == moment

--- a/tests/test_insert_many_semantics.py
+++ b/tests/test_insert_many_semantics.py
@@ -11,7 +11,7 @@ import pytest
 
 import tinymongo
 from tinymongo.asyncio import AsyncTinyMongoClient
-from tinymongo.errors import BulkWriteError, DuplicateKeyError
+from tinymongo.errors import BulkWriteError, DuplicateKeyError, InvalidDocument
 from tinymongo.tinymongo import TinyMongoCollection
 
 
@@ -126,14 +126,21 @@ def test_insert_many_serialization_preflight_is_all_or_nothing(
     collection = client.app.items
     documents = [
         {"name": "first"},
-        {"name": "invalid", "value": object()},
+        {"name": "invalid", "value": {1, 2}},
         {"name": "last"},
     ]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(InvalidDocument) as caught:
         collection.insert_many(documents, ordered=ordered)
 
+    message = str(caught.value)
+    assert caught.value.document is documents[1]
+    assert "collection 'app.items'" in message
+    assert "document index 1" in message
+    assert "['value']" in message
+    assert "<class 'set'>" in message
     assert all("_id" in document for document in documents)
+    assert collection.name not in collection.database.list_collection_names()
     assert collection.count_documents({}) == 0
     client.close()
 

--- a/tests/test_memory_backend.py
+++ b/tests/test_memory_backend.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import pytest
 import tinymongo as tm
-from tinymongo.errors import DuplicateKeyError
+from tinymongo.errors import DuplicateKeyError, InvalidDocument
 from tinymongo import storage_backends
 from tinymongo.storage_backends import storage_extension
 
@@ -174,8 +174,10 @@ def test_memory_storage_uses_the_same_json_value_rules_as_default_storage():
         client.app.items.insert_one({"_id": "tuple", "values": (1, 2)})
         assert client.app.items.find_one({"_id": "tuple"})["values"] == [1, 2]
 
-        with pytest.raises(TypeError):
-            client.app.items.insert_one({"_id": "unsupported", "value": object()})
+        unsupported = {"_id": "unsupported", "value": {1, 2}}
+        with pytest.raises(InvalidDocument) as caught:
+            client.app.items.insert_one(unsupported)
+        assert caught.value.document is unsupported
         assert client.app.items.find_one({"_id": "unsupported"}) is None
     finally:
         client.close()

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -326,6 +326,41 @@ def test_matches_filter_operator_edges():
     assert not matches_filter(doc, {"name": {"$unknown": "Ada"}})
 
 
+@pytest.mark.parametrize(
+    ("document", "expected"),
+    [
+        ({}, (False, False, False, True, True)),
+        ({"value": None}, (False, False, False, True, True)),
+        ({"value": 0}, (True, True, False, False, False)),
+        ({"value": 1}, (True, True, True, True, True)),
+        ({"value": []}, (True, True, True, True, True)),
+        ({"value": [None]}, (False, False, False, True, True)),
+        ({"value": [0]}, (True, True, False, False, False)),
+        ({"value": [None, 0]}, (False, False, False, False, False)),
+    ],
+)
+def test_null_negation_matches_mongodb_missing_and_array_semantics(document, expected):
+    queries = [
+        {"value": {"$ne": None}},
+        {"value": {"$nin": [None]}},
+        {"value": {"$nin": [None, 0]}},
+        {"value": {"$ne": 0}},
+        {"value": {"$nin": [0]}},
+    ]
+
+    assert tuple(matches_filter(document, query) for query in queries) == expected
+    if not document:
+        assert not matches_filter({"nested": {}}, {"nested.value": {"$ne": None}})
+        assert not matches_filter(
+            {"nested": {}},
+            {"nested.value": {"$nin": [None, "blocked"]}},
+        )
+        assert not matches_filter(
+            {"nested": {}},
+            {"nested.value": {"$nin": (None, "blocked")}},
+        )
+
+
 def test_array_equality_supports_exact_arrays_and_scalar_membership():
     document = {"items": [1, 2], "nested": [["a", "b"], ["c"]]}
 

--- a/tests/test_talkpython_regressions.py
+++ b/tests/test_talkpython_regressions.py
@@ -5,6 +5,8 @@ from datetime import date, datetime, timedelta, timezone
 import pytest
 
 import tinymongo as tm
+from tinymongo import bson_types
+from tinymongo.errors import InvalidDocument
 from tinymongo.indexes import TinyMongoUnsupportedWarning
 
 
@@ -32,6 +34,80 @@ def talkpython_collection(request, tmp_path):
 
 def _labels(cursor):
     return [document["label"] for document in cursor]
+
+
+def test_implicit_ids_are_objectids_across_every_write_path(talkpython_collection):
+    collection = talkpython_collection
+    single = collection.insert_one({"kind": "single"})
+    many = collection.insert_many([{"kind": "many-a"}, {"kind": "many-b"}])
+    updated = collection.update_one(
+        {"kind": "update-one"},
+        {"$set": {"created": True}},
+        upsert=True,
+    )
+    updated_many = collection.update_many(
+        {"kind": "update-many"},
+        {"$set": {"created": True}},
+        upsert=True,
+    )
+    replaced = collection.replace_one(
+        {"kind": "replacement"},
+        {"kind": "replacement", "created": True},
+        upsert=True,
+    )
+    generated_ids = [
+        single.inserted_id,
+        *many.inserted_ids,
+        updated.upserted_id,
+        updated_many.upserted_id,
+        replaced.upserted_id,
+    ]
+
+    assert all(isinstance(document_id, ObjectId) for document_id in generated_ids)
+    for document_id in generated_ids:
+        reconstructed = ObjectId(str(document_id))
+        assert collection.find_one({"_id": reconstructed})["_id"] == document_id
+
+
+def test_explicit_string_generator_and_core_fallback_remain_available(monkeypatch):
+    explicit = tm.generate_id()
+
+    assert type(explicit) is str
+    assert len(explicit) == 32
+    int(explicit, 16)
+
+    monkeypatch.setattr(bson_types, "_ObjectId", None)
+    client = tm.TinyMongoClient(backend="memory")
+    try:
+        result = client.app.items.insert_one({"kind": "core-only"})
+
+        assert type(result.inserted_id) is str
+        assert len(result.inserted_id) == 32
+        assert client.app.items.find_one({"_id": result.inserted_id}) is not None
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("operation", ["update_one", "update_many", "replace_one"])
+def test_invalid_write_payload_fails_even_without_a_matching_document(
+    talkpython_collection, operation
+):
+    collection = talkpython_collection
+
+    with pytest.raises(InvalidDocument) as caught:
+        if operation == "replace_one":
+            collection.replace_one(
+                {"_id": "missing"},
+                {"value": {1, 2}},
+            )
+        else:
+            getattr(collection, operation)(
+                {"_id": "missing"},
+                {"$unset": {"value": {1, 2}}},
+            )
+
+    assert "set" in str(caught.value)
+    assert collection.count_documents({}) == 0
 
 
 def test_datetime_and_object_id_sort_in_both_directions(talkpython_collection):

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -19,6 +19,7 @@ import json
 import math
 
 from . import bson_types
+from .errors import InvalidDocument
 
 
 # Compatibility aliases remain patchable for dependency-error tests and older
@@ -35,6 +36,7 @@ _BINARY_VALUE = "binary"
 _BINARY_DATA = "base64"
 _BINARY_SUBTYPE = "subtype"
 _NONFINITE_FLOAT = "float"
+_ROOT_UNSET = object()
 
 
 def bson_available():
@@ -54,8 +56,23 @@ def binary_available():
     return _Binary is not None
 
 
-def encode_value(value):
+def _nested_path(path, key):
+    if isinstance(key, int):
+        return "{0}[{1}]".format(path, key)
+    return "{0}[{1!r}]".format(path, key)
+
+
+def _bounded_repr(value, limit=160):
+    rendered = repr(value)
+    if len(rendered) <= limit:
+        return rendered
+    return rendered[: limit - 3] + "..."
+
+
+def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
     """Recursively convert supported non-JSON values into tagged JSON data."""
+    if _root is _ROOT_UNSET:
+        _root = value
     spec = bson_types.bson_type_spec(value)
     storage_tag = spec.storage_tag if spec is not None else None
     if storage_tag == "objectid":
@@ -81,13 +98,51 @@ def encode_value(value):
             return {
                 _TYPE_MARKER: _ESCAPED_MAPPING,
                 _VALUE_MARKER: [
-                    [str(key), encode_value(item)] for key, item in value.items()
+                    [
+                        str(key),
+                        encode_value(
+                            item,
+                            _path=_nested_path(_path, key),
+                            _root=_root,
+                            _context=_context,
+                        ),
+                    ]
+                    for key, item in value.items()
                 ],
             }
-        return {str(key): encode_value(item) for key, item in value.items()}
+        return {
+            str(key): encode_value(
+                item,
+                _path=_nested_path(_path, key),
+                _root=_root,
+                _context=_context,
+            )
+            for key, item in value.items()
+        }
     if isinstance(value, (list, tuple)):
-        return [encode_value(item) for item in value]
-    return value
+        return [
+            encode_value(
+                item,
+                _path=_nested_path(_path, index),
+                _root=_root,
+                _context=_context,
+            )
+            for index, item in enumerate(value)
+        ]
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+
+    context = " for {0}".format(_context) if _context else ""
+    raise InvalidDocument(
+        "Invalid document{0} at {1!r}: cannot encode object {2}, "
+        "of type {3!r}".format(
+            context,
+            _path,
+            _bounded_repr(value),
+            type(value),
+        ),
+        document=_root,
+    )
 
 
 def _encode_binary(value, subtype):
@@ -178,10 +233,10 @@ def decode_value(value):
     return value
 
 
-def dumps(value, **kwargs):
+def dumps(value, document_context=None, **kwargs):
     """Serialize a TinyMongo value as JSON with BSON-compatible tagging."""
     kwargs.setdefault("allow_nan", False)
-    return json.dumps(encode_value(value), **kwargs)
+    return json.dumps(encode_value(value, _context=document_context), **kwargs)
 
 
 def loads(value):

--- a/tinymongo/errors.py
+++ b/tinymongo/errors.py
@@ -60,6 +60,9 @@ except ImportError:  # pragma: no cover - exercised in dependency-free installs
     class _InvalidOperation(_PyMongoError):
         pass
 
+    class _InvalidDocument(_PyMongoError):
+        pass
+
 else:
     _PyMongoError = _pymongo_errors.PyMongoError  # type: ignore[misc,assignment]
     _ConnectionFailure = _pymongo_errors.ConnectionFailure  # type: ignore[misc,assignment]
@@ -70,6 +73,7 @@ else:
     _DuplicateKeyError = _pymongo_errors.DuplicateKeyError  # type: ignore[misc,assignment]
     _BulkWriteError = _pymongo_errors.BulkWriteError  # type: ignore[misc,assignment]
     _InvalidOperation = _pymongo_errors.InvalidOperation  # type: ignore[misc,assignment]
+    _InvalidDocument = _pymongo_errors.InvalidDocument  # type: ignore[misc,assignment]
 
 
 class TinyMongoError(_PyMongoError):
@@ -106,6 +110,25 @@ class BulkWriteError(_BulkWriteError, OperationFailure):
 
 class InvalidOperation(_InvalidOperation, TinyMongoError):
     """Raised when a client attempts an invalid operation."""
+
+
+class InvalidDocument(_InvalidDocument, TinyMongoError):
+    """Raised when a document contains a value TinyMongo cannot encode.
+
+    PyMongo exposes :class:`bson.errors.InvalidDocument`, which is not itself a
+    ``PyMongoError``. TinyMongo intentionally inherits from both compatibility
+    families so existing application handlers can catch either one.
+    """
+
+    def __init__(self, message, document=None):
+        super(InvalidDocument, self).__init__(message)
+        self._document = document
+
+    @property
+    def document(self):
+        """Return the original document rejected by the encoder."""
+
+        return self._document
 
 
 class TinyMongoNotSupportedError(TinyMongoError, NotImplementedError):

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -509,15 +509,19 @@ def _field_matches(actual, expected, exact=False):
             ):
                 return False
         elif operator == "$ne":
-            if exists and equality(actual, operand):
+            if (not exists and operand is None) or (
+                exists and equality(actual, operand)
+            ):
                 return False
         elif operator == "$in":
-            values = operand if isinstance(operand, list) else [operand]
+            values = operand if isinstance(operand, (list, tuple)) else [operand]
             if not exists or not any(equality(actual, item) for item in values):
                 return False
         elif operator == "$nin":
-            values = operand if isinstance(operand, list) else [operand]
-            if exists and any(equality(actual, item) for item in values):
+            values = operand if isinstance(operand, (list, tuple)) else [operand]
+            if (not exists and any(item is None for item in values)) or (
+                exists and any(equality(actual, item) for item in values)
+            ):
                 return False
         elif operator == "$all":
             if not isinstance(actual, list) or not all(

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -16,7 +16,12 @@ from uuid import uuid4
 
 from tinydb import Query, TinyDB, where  # type: ignore[attr-defined]
 from .bson_codec import bson_available
-from .bson_types import bson_identity_key, bson_scalar_sort_key, bson_values_equal
+from .bson_types import (
+    bson_identity_key,
+    bson_scalar_sort_key,
+    bson_values_equal,
+    object_id_type,
+)
 from .storage_backends import (
     clear_memory_database,
     clear_memory_namespace,
@@ -35,6 +40,7 @@ from .results import InsertOneResult, InsertManyResult, UpdateResult, DeleteResu
 from .errors import (
     BulkWriteError,
     DuplicateKeyError,
+    InvalidDocument as InvalidDocument,
     InvalidOperation,
     OperationFailure,
     TinyMongoNotSupportedError,
@@ -78,6 +84,15 @@ def Q(query, key):
 
 
 _MISSING = object()
+
+
+def _generate_document_id():
+    """Return a PyMongo-shaped automatic ID when optional BSON is available."""
+
+    object_id_class = object_id_type()
+    if object_id_class is not None:
+        return object_id_class()
+    return generate_id()
 
 
 def _get_nested(doc, path, default=_MISSING):
@@ -365,7 +380,8 @@ def _document_for_upsert(query, update_doc):
             else:
                 continue  # pragma: no cover - continue has no trace event on Python 3.9
         _set_nested(document, key, copy.deepcopy(value))
-    document.setdefault("_id", generate_id())
+    if "_id" not in document:
+        document["_id"] = _generate_document_id()
     return _apply_update_document(document, update_doc)
 
 
@@ -918,6 +934,22 @@ class TinyMongoCollection(object):
         """Return the dotted database and collection name."""
         return "{0}.{1}".format(self.parent.name, self.tablename)
 
+    def _validate_storage_document(self, document, index=None):
+        """Reject unencodable values before a backend observes the write."""
+
+        from .bson_codec import dumps as encode_storage_payload
+
+        context = "collection {0!r}".format(self.full_name)
+        if index is not None:
+            context += ", document index {0}".format(index)
+        if "_id" in document:
+            context += ", document _id={0!r}".format(document["_id"])
+        encode_storage_payload(
+            document,
+            document_context=context,
+            ensure_ascii=False,
+        )
+
     @property
     def write_concern(self):
         return _CompatibilityConcern()
@@ -1326,13 +1358,18 @@ class TinyMongoCollection(object):
         :return: InsertOneResult
         """
         _reject_session(kwargs)
+        if not isinstance(doc, dict):
+            raise ValueError('"doc" must be a dict')
+
+        # PyMongo generates an ID only when the field is absent. Explicit
+        # values such as 0, False, and None remain user-controlled IDs.
+        if "_id" in doc:
+            _id = doc["_id"]
+        else:
+            _id = doc["_id"] = _generate_document_id()
+        self._validate_storage_document(doc)
+
         if self.parent.engine is not None:
-            if not isinstance(doc, dict):
-                raise ValueError('"doc" must be a dict')
-            if "_id" in doc:
-                _id = doc["_id"]
-            else:
-                _id = doc["_id"] = generate_id()
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
                 self.parent.engine.find(self.tablename, {}) + [doc],
@@ -1350,15 +1387,6 @@ class TinyMongoCollection(object):
             if self.table is None:
                 self.build_table()
             self._refresh_table()
-            if not isinstance(doc, dict):
-                raise ValueError('"doc" must be a dict')
-
-            # PyMongo generates an ID only when the field is absent. Explicit
-            # values such as 0, False, and None remain user-controlled IDs.
-            if "_id" in doc:
-                _id = doc["_id"]
-            else:
-                _id = doc["_id"] = generate_id()
 
             existing = self.find_one({"_id": _id})
             if existing is None:
@@ -1415,16 +1443,15 @@ class TinyMongoCollection(object):
             if "_id" in doc:
                 _id = doc["_id"]
             else:
-                _id = doc["_id"] = generate_id()
+                _id = doc["_id"] = _generate_document_id()
             _ids.append(_id)
 
         # Validate TinyMongo's one storage batch at the JSON boundary before
         # changing storage. PyMongo can split very large inputs across multiple
         # wire batches, so TinyMongo intentionally provides a stronger
         # whole-list guarantee here.
-        from .bson_codec import dumps as encode_storage_payload
-
-        encode_storage_payload(docs, ensure_ascii=False)
+        for index, doc in enumerate(docs):
+            self._validate_storage_document(doc, index=index)
 
         engine = self.parent.engine
         if engine is not None:
@@ -1699,6 +1726,7 @@ class TinyMongoCollection(object):
         """
         _reject_session(kwargs)
         _validate_update_document(doc)
+        self._validate_storage_document(doc)
         upsert = kwargs.get("upsert") is True
 
         if self.parent.engine is not None:
@@ -1706,6 +1734,7 @@ class TinyMongoCollection(object):
             if not matches:
                 if upsert:
                     inserted = _document_for_upsert(query, doc)
+                    self._validate_storage_document(inserted)
                     self.parent.engine.validate_unique_post_image(
                         self.tablename,
                         self.parent.engine.find(self.tablename, {}) + [inserted],
@@ -1719,6 +1748,7 @@ class TinyMongoCollection(object):
                     )
                 return UpdateResult(raw_result=[], matched_count=0, modified_count=0)
             updated = self.parent.engine.apply_update(matches[0], doc)
+            self._validate_storage_document(updated)
             modified = updated != matches[0]
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
@@ -1773,6 +1803,7 @@ class TinyMongoCollection(object):
             if item is None:
                 if upsert:
                     inserted = _document_for_upsert(query, doc)
+                    self._validate_storage_document(inserted)
                     self._validate_unique_post_image(self.table.all() + [inserted])
                     self.table.insert(inserted)
                     self._invalidate_indexes()
@@ -1785,6 +1816,7 @@ class TinyMongoCollection(object):
                 return UpdateResult(raw_result=[])
 
             updated = _apply_update_document(item, doc)
+            self._validate_storage_document(updated)
             modified = updated != item
             if modified:
                 post_image = [
@@ -1825,12 +1857,14 @@ class TinyMongoCollection(object):
         """
         _reject_session(kwargs)
         _validate_update_document(doc)
+        self._validate_storage_document(doc)
         upsert = kwargs.get("upsert") is True
 
         if self.parent.engine is not None:
             matches = self.parent.engine.find(self.tablename, query)
             if not matches and upsert:
                 inserted = _document_for_upsert(query, doc)
+                self._validate_storage_document(inserted)
                 self.parent.engine.validate_unique_post_image(
                     self.tablename,
                     self.parent.engine.find(self.tablename, {}) + [inserted],
@@ -1845,6 +1879,8 @@ class TinyMongoCollection(object):
             updates = [
                 (item, self.parent.engine.apply_update(item, doc)) for item in matches
             ]
+            for _original, updated in updates:
+                self._validate_storage_document(updated)
             modified_count = sum(updated != item for item, updated in updates)
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
@@ -1895,6 +1931,7 @@ class TinyMongoCollection(object):
                 items = list(self.table.search(allcond))
             if not items and upsert:
                 inserted = _document_for_upsert(query, doc)
+                self._validate_storage_document(inserted)
                 self._validate_unique_post_image(self.table.all() + [inserted])
                 self.table.insert(inserted)
                 self._invalidate_indexes()
@@ -1905,6 +1942,8 @@ class TinyMongoCollection(object):
                     upserted_id=inserted["_id"],
                 )
             updates = [(item, _apply_update_document(item, doc)) for item in items]
+            for _original, updated in updates:
+                self._validate_storage_document(updated)
             self._validate_unique_post_image(
                 [
                     next(
@@ -1949,12 +1988,17 @@ class TinyMongoCollection(object):
         Replaces one document matching the query with the replacement document.
         """
         _reject_session(kwargs)
+        if not isinstance(replacement, dict):
+            raise TypeError('"replacement" must be a dict')
+        self._validate_storage_document(replacement)
         if self.parent.engine is not None:
             item = self.parent.engine.find_one(self.tablename, query)
             if item is None:
                 if kwargs.get("upsert") is True:
                     inserted = copy.deepcopy(replacement)
-                    inserted.setdefault("_id", generate_id())
+                    if "_id" not in inserted:
+                        inserted["_id"] = _generate_document_id()
+                    self._validate_storage_document(inserted)
                     self.parent.engine.validate_unique_post_image(
                         self.tablename,
                         self.parent.engine.find(self.tablename, {}) + [inserted],
@@ -1969,6 +2013,7 @@ class TinyMongoCollection(object):
                 return UpdateResult(raw_result=[])
             updated = copy.deepcopy(replacement)
             updated["_id"] = item["_id"]
+            self._validate_storage_document(updated)
             modified = updated != item
             if modified:
                 self.parent.engine.validate_unique_post_image(
@@ -2019,7 +2064,9 @@ class TinyMongoCollection(object):
             if item is None:
                 if kwargs.get("upsert") is True:
                     inserted = copy.deepcopy(replacement)
-                    inserted.setdefault("_id", generate_id())
+                    if "_id" not in inserted:
+                        inserted["_id"] = _generate_document_id()
+                    self._validate_storage_document(inserted)
                     self._validate_unique_post_image(self.table.all() + [inserted])
                     self.table.insert(inserted)
                     self._invalidate_indexes()
@@ -2033,6 +2080,7 @@ class TinyMongoCollection(object):
 
             updated = copy.deepcopy(replacement)
             updated["_id"] = item["_id"]
+            self._validate_storage_document(updated)
             modified = updated != item
             if modified:
                 post_image = [
@@ -2782,9 +2830,8 @@ class TinyGridFS(object):
 
 
 def generate_id():
-    """Generate new UUID"""
-    # TODO: Use six.string_type to Py3 compat
-    return str(uuid4()).replace("-", "")
+    """Generate a portable UUID string for callers that explicitly want one."""
+    return uuid4().hex
 
 
 # def generate_id():


### PR DESCRIPTION
## Summary

This follows Mike Kennedy's second Talk Python acceptance report in #136 and fixes all three newly reduced compatibility gaps:

1. implicit IDs now support the standard `ObjectId(str(inserted_id))` round trip;
2. `$ne: None` and `$nin` values containing `None` now distinguish missing fields the same way MongoDB does; and
3. unsupported document values now raise a contextual, BSON-compatible `InvalidDocument` before storage changes.

The fixes apply to the synchronous and asynchronous APIs and to every TinyMongo storage family.

## Context

Mike's latest run established that the real Talk Python site already runs on TinyMongo SQLite: 81,017 of 81,017 documents migrated, the public site rendered without MongoDB, and MongoDB and TinyMongo each passed all 590 application tests. These three findings came from the focused write/query follow-up that followed that successful baseline.

Related report: https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5135871616

## What changed

### Native automatic IDs

- Added a private automatic document-ID factory that returns a native `ObjectId` when PyMongo's complete BSON capability is available.
- Routed every implicit-ID path through it: `insert_one`, `insert_many`, update upserts, update-many upserts, and replacement upserts.
- Kept caller-supplied IDs exactly as supplied, including strings, integers, `None`, and existing ObjectIds.
- Kept public `tinymongo.generate_id()` as the existing 32-character UUID-string helper. This preserves MongoEngine `StringField(default=tinymongo.generate_id)` and other explicit string-ID callers.
- Kept a dependency-free UUID-string fallback when PyMongo/BSON is unavailable.
- Added contracts proving the returned ID is a native ObjectId, has a 24-character string form, can be reconstructed, and finds the stored document.

This does not rewrite or coerce existing UUID-string IDs. Old string IDs and new ObjectIds can coexist.

### Mongo-correct null negation

- `$ne: None` now excludes both explicit nulls and missing fields.
- `$nin` containing a top-level `None` now excludes explicit nulls and missing fields.
- Non-null `$ne` and `$nin` still include missing fields, preserving MongoDB's inverse rule.
- Applied the same behavior to dotted paths, arrays, list operands, and tuple operands (which PyMongo serializes as BSON arrays).
- Added Mike's complete query matrix to the shared sync/async contract suite and a lower-level table covering missing, null, scalar, empty-array, and array-member cases.

### Contextual `InvalidDocument`

- Added `tinymongo.InvalidDocument` / `tinymongo.errors.InvalidDocument`.
- With PyMongo installed, the error is catchable as:
  - `bson.errors.InvalidDocument`
  - `pymongo.errors.InvalidDocument`
  - `pymongo.errors.PyMongoError`
  - `tinymongo.errors.TinyMongoError`
- Without PyMongo, it remains available through TinyMongo's dependency-free error hierarchy.
- Centralized unsupported-value detection in the BSON/JSON codec so nested failures retain:
  - the original document in `.document`;
  - the collection name;
  - the insert-many document index;
  - the nested value path; and
  - a bounded representation and offending type.
- Preflight now occurs before any backend read, table/collection creation, or write for inserts, updates, and replacements.
- `insert_many` keeps its documented whole-input serialization guarantee: every missing ID is assigned, then the full batch is validated, and no documents are written on an encoding failure.

## Documentation and roadmap

- Documented automatic ObjectIds versus the explicit/core UUID-string behavior.
- Documented null-versus-missing negation and `InvalidDocument` handling.
- Recorded Mike's 590/590 MongoDB/SQLite result and zero-rejection 81,017-document migration.
- Checked off these three fixes and left the focused rerun, admin-write pass, concurrency pass, and report publication as follow-up work.

## Verification

- Full local suite: **1,167 passed**, 131 opt-in tests deselected.
- Coverage: **100% statements and 100% branches** across `tinymongo/*`.
- Shared live MongoDB 8.0 contracts on CPython 3.14.6t with the GIL disabled: **82 passed**.
- Full live PostgreSQL 16 / MariaDB 11.4 integration suite on CPython 3.14.6t: **10 passed**.
- Direct live PostgreSQL and MariaDB probes: all three fixes passed on both backends, including no table creation on invalid input.
- PyMongo 4.9 floor suite: **127 passed**.
- Stable CPython 3.14.6t targeted sync/async compatibility selection: passed with the GIL disabled.
- Ruff, Black, mypy, and `git diff --check`: passed.
- Source distribution and wheel built successfully; Twine metadata checks passed.

## Follow-up

After merge, Mike can rerun TM-009, TM-010, and the invalid-document write path against the real Talk Python application. Issue #136 remains open for the write-heavy admin surfaces, multi-worker SQLite pass, and final published compatibility artifacts.
