### PR TITLE
Prepare TinyMongo 1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.1] - Unreleased
+## [1.2.1] - 2026-07-31
 
 ### Added
 - Required CPython 3.14 CI coverage and beta-level CPython 3.14t coverage with

--- a/README.md
+++ b/README.md
@@ -17,17 +17,15 @@ supported at the beta level for the backends described below.
 
 # Installation
 
-The latest stable release can be installed via `pip install tinymongo`.
-This checkout is the forthcoming 1.2.1 release line. Until 1.2.1 is published
-on PyPI, install the Git branch directly to use the APIs documented below:
+The latest stable release is 1.2.1 and can be installed from PyPI:
 
 ```bash
-pip install "tinymongo @ git+https://github.com/schapman1974/tinymongo.git@master"
+pip install "tinymongo==1.2.1"
 ```
 
 For development, clone this repository and run `pip install -e .` from its
-root. Use the `v1.2.0` tag when you need documentation that matches the current
-stable package exactly; use the `v1.2.1` tag after that release is published.
+root. Use the `v1.2.1` tag when you need source and documentation that match
+the current stable package exactly; `master` may contain unreleased changes.
 
 The default JSON backend has a small dependency set. Optional database backends
 may install native binary wheels supplied by DuckDB, PyArrow, or SQL drivers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,10 +85,8 @@ with the follow-up audit of his
   migration reports, avoid unused nonlocal-storage directories, reject invalid
   backends eagerly with the complete alias list, and guard client metadata and
   listing methods after close.
-- [ ] After this work merges, update Mike's agent guide against the merge SHA
-  or the `v1.2.1` tag. Until 1.2.1 is published, label it as the forthcoming
-  1.2.1 release, use the Git install command, and do not describe the expanded
-  API as available from PyPI.
+- [ ] Update Mike's agent guide against the `v1.2.1` tag and describe the
+  expanded API as available from PyPI.
   Correct its list-only `insert_many()` signature
   and defaults, `BulkWriteError` details, blanket session-rejection claim,
   conditional `AsyncMongoClient` patch/import caveat, numeric-equivalence
@@ -115,12 +113,13 @@ with the follow-up audit of his
   [#75](https://github.com/schapman1974/tinymongo/issues/75) and
   [#76](https://github.com/schapman1974/tinymongo/issues/76).
 - [x] Run the real Talk Python acceptance suite against MongoDB and TinyMongo
-  SQLite: both passed all 590 tests, and the 81,017-document application
+  SQLite: both passed all 597 tests, and the 81,017-document application
   database migrated with zero rejections.
-- [ ] Rerun Mike's TM-009 and TM-010 reproductions plus the invalid-document
-  write path after these fixes merge, then publish the MongoDB, memory, and
-  SQLite baseline through [#72](https://github.com/schapman1974/tinymongo/issues/72)
-  and [#136](https://github.com/schapman1974/tinymongo/issues/136).
+- [x] Rerun Mike's TM-009 and TM-010 reproductions plus the invalid-document
+  write path after the fixes merged; all pass against the real application.
+- [ ] Publish the MongoDB, memory, and SQLite report artifacts through
+  [#72](https://github.com/schapman1974/tinymongo/issues/72) and
+  [#136](https://github.com/schapman1974/tinymongo/issues/136).
 
 Application-compatibility work:
 
@@ -130,9 +129,9 @@ Application-compatibility work:
   - [x] Run the application-derived compatibility contracts through both the
     synchronous and asynchronous APIs.
   - [x] Run the complete application suite through the async acceptance path:
-    MongoDB and TinyMongo SQLite each passed 590 tests.
-  - [ ] Complete the write-heavy admin and multi-worker SQLite follow-up, and
-    record any remaining differences.
+    MongoDB and TinyMongo SQLite each passed 597 tests.
+  - [x] Complete the write-heavy admin and multi-worker SQLite follow-up: all
+    21 admin checks passed with no errors, lost writes, or torn reads.
 - [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
 - [ ] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
   - [x] Milestone 1 ObjectId, datetime, and Binary storage/query support.
@@ -152,9 +151,8 @@ Application-compatibility work:
   - [x] Provide an external pytest runner that patches both PyMongo client
     classes before application tests are imported.
   - [x] Run the real Talk Python suite through the runner against the MongoDB
-    reference and TinyMongo SQLite, with 590 passing tests on each.
-  - [ ] Rerun the new focused cases and publish the reference, memory, and
-    SQLite report artifacts.
+    reference and TinyMongo SQLite, with 597 passing tests on each.
+  - [ ] Publish the reference, memory, and SQLite report artifacts.
 - [ ] [#87: Differential compatibility fuzzing](https://github.com/schapman1974/tinymongo/issues/87)
 
 Exit criteria:

--- a/docs/TALKPYTHON_ACCEPTANCE.md
+++ b/docs/TALKPYTHON_ACCEPTANCE.md
@@ -115,12 +115,13 @@ to reusable contracts:
 
 After those fixes, Mike migrated all 81,017 source documents with zero
 rejections and ran the real application suite through this repository's
-acceptance runner. MongoDB and TinyMongo SQLite both passed all 590 tests; the
-public site rendered from TinyMongo without MongoDB running. The recorded
-TinyMongo baseline was `master` at `6615f8b`, Python 3.14.6, PyMongo 4.17, and
-the SQLite backend. A fresh-memory run initially exposed four sitemap failures,
-which Mike confirmed and fixed as empty-data assumptions in the application
-rather than TinyMongo differences.
+acceptance runner. After the final follow-up in #143, MongoDB and TinyMongo
+SQLite both passed all 597 tests; all nine application surfaces and all 21
+admin-write checks passed. The public site rendered from TinyMongo without
+MongoDB running. The final recorded TinyMongo baseline was `master` at
+`07e9b40`, Python 3.14.6, PyMongo 4.17, and the SQLite backend. A fresh-memory
+run initially exposed four sitemap failures, which Mike confirmed and fixed as
+empty-data assumptions in the application rather than TinyMongo differences.
 
 The Mongo-compatible behaviors also run through TinyMongo's shared
 synchronous/asynchronous matrix and real MongoDB contracts. TinyMongo's
@@ -148,13 +149,13 @@ available, while dependency-free writes and the explicit `generate_id()`
 helper retain UUID strings. Invalid-document failures happen before storage,
 retain the rejected document and nested path context, and are catchable through
 both BSON's `InvalidDocument` and `PyMongoError` when PyMongo is installed.
-The main application goal is achieved; these three follow-up cases remain open
-until they are rerun in Talk Python's write paths.
+Mike reran these cases unchanged against `07e9b40`; all passed in the focused
+reproductions and the real Talk Python write paths. The main application goal
+is complete with no known correctness defect in Talk Python's TinyMongo path.
 
-Mike's separate TinyMongo agent reference currently describes unreleased
-`master` behavior as version 1.2.0. After the compatibility branch merges,
-update that guide against the merge SHA or the `v1.2.1` tag, including the
-Binary codec, BSON-aware `_id` identity, `insert_many()` partial failures,
+Mike's separate TinyMongo agent reference should now be updated against the
+`v1.2.1` tag, including the Binary codec, BSON-aware `_id` identity,
+`insert_many()` partial failures,
 bounded sort diagnostics, exact `$unset`, BSON-aware CLI, dotted child
 collections, native automatic `ObjectId` values, null-negation behavior, and
 contextual `InvalidDocument` errors. Also correct the stale list-only


### PR DESCRIPTION
## Summary

Prepare the repository metadata and public documentation for the TinyMongo 1.2.1 PyPI release.

This PR intentionally contains release-preparation changes only. The implementation being released is already on `master`; after this PR is merged and GitHub CI succeeds on the exact merge commit, that commit will be tagged `v1.2.1`. The tag will trigger the guarded `Publish to PyPI` workflow.

## Changes

- date the 1.2.1 changelog entry for July 31, 2026
- update README installation examples and release wording to 1.2.1
- record Mike Kennedy's final Talk Python acceptance result: 597/597 tests passing on both SQLite and MongoDB
- mark the completed Talk Python follow-up checks in the roadmap while leaving report-artifact publication open
- align the acceptance notes with the final tested baseline (`07e9b40`)

## Release safety

The publish workflow verifies all of the following before it uploads anything:

- the ref is an annotated release tag
- the tag is exactly `v1.2.1`, matching `pyproject.toml`
- the tagged commit is on `master`
- GitHub CI passed for that exact commit
- the changelog contains one dated 1.2.1 section
- the README no longer contains pre-release wording

## Validation completed locally

- release workflow metadata gate reproduced successfully for `v1.2.1`
- Ruff passed
- Black check passed
- mypy passed
- `git diff --check` passed
- wheel and source distribution built successfully
- `twine check --strict` passed for both artifacts
- wheel metadata reports version 1.2.1, Python >=3.9, and the expected optional extras (`bson`, `pymongo`, `all`, storage backends, and free-threaded support)

## Post-merge sequence

1. Wait for CI on the exact merge commit.
2. Create and push annotated tag `v1.2.1`.
3. Monitor the PyPI workflow to completion.
4. Confirm both the wheel and source distribution are available from PyPI.
