### PR TITLE
Implement MongoDB array update modifiers and safe query-aware $pull

### DIFF
--- a/tests/contracts/test_array_update_contract.py
+++ b/tests/contracts/test_array_update_contract.py
@@ -1,0 +1,238 @@
+"""Array-update contracts shared by every backend and both APIs."""
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def test_push_each_slice_keeps_a_bounded_array(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "capped", "pages": ["p1"]})
+
+    result = collection.update_one(
+        {"_id": "capped"},
+        {"$push": {"pages": {"$each": ["p2", "p3"], "$slice": -2}}},
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "capped"})["pages"] == ["p2", "p3"]
+
+    for number in range(4, 10):
+        collection.update_one(
+            {"_id": "capped"},
+            {
+                "$push": {
+                    "pages": {
+                        "$each": ["p{0}".format(number)],
+                        "$slice": -2,
+                    }
+                }
+            },
+        )
+
+    pages = collection.find_one({"_id": "capped"})["pages"]
+    assert pages == ["p8", "p9"]
+    assert len(pages) == 2
+
+
+def test_push_modifiers_follow_mongodb_order_and_boundaries(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "position-positive", "values": [50, 60, 70, 100]},
+            {
+                "_id": "position-negative",
+                "values": [50, 60, 20, 30, 70, 100],
+            },
+            {"_id": "position-high", "values": [2, 3]},
+            {"_id": "position-low", "values": [2, 3]},
+            {"_id": "sort-ascending", "values": [3, 1]},
+            {"_id": "sort-descending", "values": [1, 3]},
+            {"_id": "sort-bson-distinct", "values": [True, 1]},
+            {
+                "_id": "sort-document",
+                "values": [
+                    {"meta": {"score": 3}},
+                    {"meta": {"score": 1}},
+                ],
+            },
+            {
+                "_id": "sort-compound",
+                "values": [
+                    {"group": "b", "score": 1},
+                    {"group": "a", "score": 1},
+                ],
+            },
+            {"_id": "slice-positive", "values": [1, 2, 3]},
+            {"_id": "slice-negative", "values": [1, 2, 3]},
+            {"_id": "slice-zero", "values": [1, 2, 3]},
+            {"_id": "combined", "values": [3, 1]},
+        ]
+    )
+
+    updates = {
+        "position-positive": {"$each": [20, 30], "$position": 2},
+        "position-negative": {"$each": [90, 80], "$position": -2},
+        "position-high": {"$each": [4], "$position": 99},
+        "position-low": {"$each": [0, 1], "$position": -99},
+        "sort-ascending": {"$each": [2], "$sort": 1},
+        "sort-descending": {"$each": [2], "$sort": -1},
+        "sort-bson-distinct": {"$each": [], "$sort": 1},
+        "sort-document": {
+            "$each": [{"meta": {"score": 2}}],
+            "$sort": {"meta.score": 1},
+        },
+        "sort-compound": {
+            "$each": [{"group": "a", "score": 2}],
+            "$sort": {"group": 1, "score": -1},
+        },
+        "slice-positive": {"$each": [4], "$slice": 2},
+        "slice-negative": {"$each": [4], "$slice": -2},
+        "slice-zero": {"$each": [4], "$slice": 0},
+        # The deliberately scrambled keys prove semantic processing order.
+        "combined": {"$slice": 3, "$sort": 1, "$each": [2, 0], "$position": 1},
+    }
+    results = {}
+    for document_id, modifier in updates.items():
+        results[document_id] = collection.update_one(
+            {"_id": document_id}, {"$push": {"values": modifier}}
+        )
+
+    expected = {
+        "position-positive": [50, 60, 20, 30, 70, 100],
+        "position-negative": [50, 60, 20, 30, 90, 80, 70, 100],
+        "position-high": [2, 3, 4],
+        "position-low": [0, 1, 2, 3],
+        "sort-ascending": [1, 2, 3],
+        "sort-descending": [3, 2, 1],
+        "sort-bson-distinct": [1, True],
+        "sort-document": [
+            {"meta": {"score": 1}},
+            {"meta": {"score": 2}},
+            {"meta": {"score": 3}},
+        ],
+        "sort-compound": [
+            {"group": "a", "score": 2},
+            {"group": "a", "score": 1},
+            {"group": "b", "score": 1},
+        ],
+        "slice-positive": [1, 2],
+        "slice-negative": [3, 4],
+        "slice-zero": [],
+        "combined": [0, 1, 2],
+    }
+    for document_id, values in expected.items():
+        assert collection.find_one({"_id": document_id})["values"] == values
+    assert results["sort-bson-distinct"].modified_count == 1
+
+
+def test_plain_push_and_add_to_set_each_regressions(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "push", "values": []},
+            {
+                "_id": "set",
+                "values": [1, {"a": 1, "b": 2}],
+            },
+        ]
+    )
+
+    collection.update_one({"_id": "push"}, {"$push": {"values": "plain"}})
+    collection.update_one({"_id": "push"}, {"$push": {"values": {"name": "document"}}})
+    collection.update_one({"_id": "push"}, {"$push": {"values": ["nested"]}})
+
+    modifier = {
+        "$each": [
+            1.0,
+            True,
+            2,
+            2,
+            {"a": 1, "b": 2},
+            {"b": 2, "a": 1},
+        ]
+    }
+    changed = collection.update_one({"_id": "set"}, {"$addToSet": {"values": modifier}})
+    unchanged = collection.update_one(
+        {"_id": "set"}, {"$addToSet": {"values": modifier}}
+    )
+
+    assert collection.find_one({"_id": "push"})["values"] == [
+        "plain",
+        {"name": "document"},
+        ["nested"],
+    ]
+    values = collection.find_one({"_id": "set"})["values"]
+    assert values[:4] == [1, {"a": 1, "b": 2}, True, 2]
+    assert list(values[4].items()) == [("b", 2), ("a", 1)]
+    assert (changed.modified_count, unchanged.modified_count) == (1, 0)
+
+
+def test_invalid_array_modifiers_fail_atomically(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "invalid", "values": [1], "status": "original"}
+    collection.insert_one(original)
+
+    malformed_each = observe(
+        lambda: collection.update_one(
+            {"_id": "invalid"},
+            {"$push": {"values": {"$each": "not-an-array"}}},
+        )
+    )
+    unknown_modifier = observe(
+        lambda: collection.update_one(
+            {"_id": "invalid"},
+            {
+                "$set": {"status": "changed"},
+                "$push": {"values": {"$each": [], "$unknown": 1}},
+            },
+        )
+    )
+    unknown_operator = observe(
+        lambda: collection.update_one({"_id": "invalid"}, {"$unknown": {"values": 1}})
+    )
+
+    assert malformed_each.error is not None
+    assert unknown_modifier.error is not None
+    assert unknown_operator.error is not None
+    assert collection.find_one({"_id": "invalid"}) == original
+
+
+def test_pull_accepts_literal_and_query_operands(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "range", "values": [5, 8, 10]},
+            {"_id": "literal", "values": [1, [1, 2], [2, 3]]},
+            {
+                "_id": "documents",
+                "values": [
+                    {"kind": "x", "meta": {"score": 5}},
+                    {"kind": "x", "meta": {"score": 9}},
+                    {"kind": "y", "meta": {"score": 10}},
+                    7,
+                ],
+            },
+        ]
+    )
+
+    collection.update_one({"_id": "range"}, {"$pull": {"values": {"$gte": 8}}})
+    collection.update_one({"_id": "literal"}, {"$pull": {"values": 1}})
+    collection.update_one(
+        {"_id": "documents"},
+        {"$pull": {"values": {"kind": "x", "meta.score": {"$gte": 8}}}},
+    )
+
+    assert collection.find_one({"_id": "range"})["values"] == [5]
+    assert collection.find_one({"_id": "literal"})["values"] == [
+        [1, 2],
+        [2, 3],
+    ]
+    assert collection.find_one({"_id": "documents"})["values"] == [
+        {"kind": "x", "meta": {"score": 5}},
+        {"kind": "y", "meta": {"score": 10}},
+        7,
+    ]

--- a/tests/test_array_update_modifiers.py
+++ b/tests/test_array_update_modifiers.py
@@ -1,0 +1,271 @@
+"""Focused edge and error tests for MongoDB-style array updates."""
+
+import pytest
+
+from tinymongo import TinyMongoClient
+from tinymongo import tinymongo as core
+from tinymongo.errors import TinyMongoError, TinyMongoNotSupportedError, WriteError
+
+
+@pytest.mark.parametrize(
+    "operand, message",
+    [
+        ({"$each": "value"}, r"\$each requires an array"),
+        ({"$slice": 2}, "modifiers require \\$each"),
+        ({"$each": [], "$unknown": 1}, "does not support modifier"),
+        ({"$each": [], "$position": True}, r"\$position requires an integer"),
+        ({"$each": [], "$position": 1.5}, r"\$position requires an integer"),
+        ({"$each": [], "$slice": False}, r"\$slice requires an integer"),
+        ({"$each": [], "$slice": 1.5}, r"\$slice requires an integer"),
+        ({"$each": [], "$sort": 0}, r"\$sort requires"),
+        ({"$each": [], "$sort": True}, r"\$sort requires"),
+        ({"$each": [], "$sort": {}}, r"\$sort requires"),
+        ({"$each": [], "$sort": {"score": 0}}, "invalid sort specification"),
+        ({"$each": [], "$sort": {1: 1}}, "invalid sort specification"),
+    ],
+)
+def test_push_rejects_malformed_modifier_documents(operand, message):
+    original = {"_id": 1, "values": [1]}
+
+    with pytest.raises(WriteError, match=message) as caught:
+        core._apply_update_document(original, {"$push": {"values": operand}})
+
+    assert isinstance(caught.value, TinyMongoError)
+    assert caught.value.code == 2
+    assert original == {"_id": 1, "values": [1]}
+
+
+@pytest.mark.parametrize(
+    "operand, message",
+    [
+        ({"$each": "value"}, r"\$each requires an array"),
+        ({"$unknown": []}, "modifiers require \\$each|does not support modifier"),
+        ({"$each": [], "$slice": 1}, "does not support modifier"),
+    ],
+)
+def test_add_to_set_rejects_malformed_modifier_documents(operand, message):
+    with pytest.raises(WriteError, match=message):
+        core._apply_update_document(
+            {"_id": 1, "values": []}, {"$addToSet": {"values": operand}}
+        )
+
+
+def test_push_sort_uses_recursive_whole_value_bson_order():
+    updated = core._apply_update_document(
+        {"_id": 1, "values": [[3, 0], "text", [], None]},
+        {"$push": {"values": {"$each": [[1]], "$sort": 1.0}}},
+    )
+    descending = core._apply_update_document(
+        {"_id": 1, "values": [{"score": 1}, {}, {"score": None}]},
+        {
+            "$push": {
+                "values": {
+                    "$each": [{"score": 2}],
+                    "$sort": {"score": -1.0},
+                }
+            }
+        },
+    )
+
+    assert updated["values"] == [None, "text", [], [1], [3, 0]]
+    assert descending["values"][0] == {"score": 2}
+    assert descending["values"][1] == {"score": 1}
+    assert {tuple(value) for value in descending["values"][2:]} == {
+        (),
+        ("score",),
+    }
+
+
+def test_add_to_set_uses_bson_equality_and_creates_missing_empty_array():
+    original = {
+        "_id": 1,
+        "values": [1, {"a": 1, "b": 2}, "duplicate", "duplicate"],
+    }
+    updated = core._apply_update_document(
+        original,
+        {
+            "$addToSet": {
+                "values": {
+                    "$each": [1.0, True, {"b": 2, "a": 1}, True],
+                }
+            }
+        },
+    )
+    missing = core._apply_update_document(
+        {"_id": 2}, {"$addToSet": {"values": {"$each": []}}}
+    )
+
+    assert len(updated["values"]) == 6
+    assert updated["values"][-2] is True
+    assert list(updated["values"][-1]) == ["b", "a"]
+    assert updated["values"].count("duplicate") == 2
+    assert missing["values"] == []
+
+
+def test_pull_supports_query_operators_documents_logical_queries_and_exact_arrays():
+    original = {
+        "_id": 1,
+        "values": [
+            [1, 2],
+            [2, 1],
+            {"kind": "keep", "score": 1},
+            {"kind": "drop", "score": 8},
+            {"kind": "also-drop", "score": 9},
+            1,
+        ],
+    }
+
+    exact = core._apply_update_document(original, {"$pull": {"values": [1, 2]}})
+    queried = core._apply_update_document(
+        exact,
+        {
+            "$pull": {
+                "values": {
+                    "$or": [
+                        {"kind": "drop"},
+                        {"score": {"$gte": 9}},
+                    ]
+                }
+            }
+        },
+    )
+    empty_query = core._apply_update_document(queried, {"$pull": {"values": {}}})
+    explicit_equality = core._apply_update_document(
+        {"_id": 2, "values": [[1, 2], [2, 3], 1]},
+        {"$pull": {"values": {"$eq": 1}}},
+    )
+    type_bracketed = core._apply_update_document(
+        {"_id": 3, "values": [True, 1, 2, "3"]},
+        {"$pull": {"values": {"$gte": 1}}},
+    )
+    conjunction = core._apply_update_document(
+        {
+            "_id": 4,
+            "values": [
+                {"kind": "keep", "score": 9},
+                {"kind": "keep", "score": 1},
+                {"kind": "keep"},
+                {"kind": "other", "score": 9},
+            ],
+        },
+        {
+            "$pull": {
+                "values": {
+                    "$and": [
+                        {"kind": "keep"},
+                        {"score": {"$gte": 8}},
+                    ]
+                }
+            }
+        },
+    )
+    negated_disjunction = core._apply_update_document(
+        {
+            "_id": 5,
+            "values": [
+                {"kind": "keep", "score": 1},
+                {"kind": "other", "score": 9},
+                {"kind": "other", "score": 1},
+            ],
+        },
+        {
+            "$pull": {
+                "values": {
+                    "$nor": [
+                        {"kind": "keep"},
+                        {"score": {"$gte": 8}},
+                    ]
+                }
+            }
+        },
+    )
+    nested_literal = core._apply_update_document(
+        {
+            "_id": 6,
+            "values": [
+                {"meta": {"score": 1}},
+                {"meta": {"score": 2}},
+            ],
+        },
+        {"$pull": {"values": {"meta": {"score": 1}}}},
+    )
+
+    assert exact["values"][0] == [2, 1]
+    assert queried["values"] == [[2, 1], {"kind": "keep", "score": 1}, 1]
+    assert empty_query["values"] == [[2, 1], 1]
+    assert explicit_equality["values"] == [[2, 3]]
+    assert type_bracketed["values"] == [True, "3"]
+    assert conjunction["values"] == [
+        {"kind": "keep", "score": 1},
+        {"kind": "keep"},
+        {"kind": "other", "score": 9},
+    ]
+    assert negated_disjunction["values"] == [
+        {"kind": "keep", "score": 1},
+        {"kind": "other", "score": 9},
+    ]
+    assert nested_literal["values"] == [{"meta": {"score": 2}}]
+
+
+@pytest.mark.parametrize(
+    "condition, message",
+    [
+        ({"$unknown": 1}, "does not support query operator"),
+        ({"score": {"$unknown": 1}}, "does not support query operator"),
+        ({"$or": {"score": 1}}, "requires an array of documents"),
+        ({"$and": [1]}, "requires an array of documents"),
+        ({"$or": []}, "requires an array of documents"),
+        ({"$not": {"$unknown": 1}}, "does not support query operator"),
+        ({"$all": [2]}, "does not support query operator"),
+        ({"$not": {"$eq": 2}}, "does not support query operator"),
+        ({"$options": "i"}, "does not support query operator"),
+        ({"$regex": "["}, "does not support query operator"),
+        ({"$gte": {}}, "requires a supported scalar value"),
+        (
+            {"$gte": 1, "$or": [{"score": 1}]},
+            "document query operator",
+        ),
+        (
+            {"$and": [{"$gte": 1}, {"$lte": 2}]},
+            "document query operator",
+        ),
+        (
+            {"$or": [{"$eq": 1}, {"$eq": 2}]},
+            "document query operator",
+        ),
+        (
+            {"a": {"$or": [{"b": 1}, {"b": 2}]}},
+            "does not support query operator",
+        ),
+        (
+            {"score": {"$gte": 1, "plain": 2}},
+            "cannot mix field and document query operators",
+        ),
+    ],
+)
+def test_pull_rejects_unsupported_or_malformed_queries(condition, message):
+    with pytest.raises(WriteError, match=message):
+        core._apply_update_document(
+            {"_id": 1, "values": [1]}, {"$pull": {"values": condition}}
+        )
+
+
+def test_invalid_updates_are_preflighted_and_atomic_even_without_a_match(tmp_path):
+    client = TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.db.items
+    original = {"_id": 1, "status": "original", "values": [1]}
+    collection.insert_one(original)
+
+    with pytest.raises(WriteError):
+        collection.update_many(
+            {},
+            {
+                "$set": {"status": "changed"},
+                "$push": {"values": {"$each": [], "$unknown": 1}},
+            },
+        )
+    with pytest.raises(TinyMongoNotSupportedError, match="Unsupported update operator"):
+        collection.update_one({"_id": "missing"}, {"$unknown": {"value": 1}})
+
+    assert collection.find_one({"_id": 1}) == original
+    client.close()

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -14,7 +14,12 @@ from tinymongo import cli
 from tinymongo import tinymongo as core
 from tinymongo import parquet_storage as ps
 from tinymongo import storage_backends as sb
-from tinymongo.errors import BulkWriteError, DuplicateKeyError, OperationFailure
+from tinymongo.errors import (
+    BulkWriteError,
+    DuplicateKeyError,
+    OperationFailure,
+    TinyMongoNotSupportedError,
+)
 from tinymongo.results import (
     DeleteResult,
     InsertManyResult,
@@ -728,7 +733,7 @@ def test_update_operator_error_edges(tmp_path):
     c = client.db.collection
     c.insert_one({"_id": 1, "count": "one"})
 
-    with pytest.raises(ValueError, match="Unsupported update operator"):
+    with pytest.raises(TinyMongoNotSupportedError, match="Unsupported update operator"):
         c.update_one({"_id": 1}, {"$unknown": {"x": 1}})
     with pytest.raises(ValueError, match="update only works with \\$ operators"):
         c.update_one({"_id": 1}, {})

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -906,7 +906,7 @@ class TableBackend(object):
         updated_ids = []
         for doc in matches:
             updated = self.apply_update(doc, update_doc)
-            if updated != doc:
+            if not bson_values_equal(updated, doc):
                 self.replace_one(collection, doc["_id"], updated)
                 updated_ids.append(doc["_id"])
         return updated_ids

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -8,6 +8,7 @@ import copy
 from collections.abc import Iterable, Mapping, MutableMapping
 from functools import reduce, wraps
 import logging
+import operator as comparison_operator
 import os
 import shutil
 import threading
@@ -44,6 +45,7 @@ from .errors import (
     InvalidOperation,
     OperationFailure,
     TinyMongoNotSupportedError,
+    WriteError,
 )
 from .indexes import (
     INDEX_CATALOG_TABLE,
@@ -270,6 +272,292 @@ def _unset_nested(doc, path):
     current.pop(parts[-1], None)
 
 
+_UPDATE_OPERATORS = frozenset(("$set", "$unset", "$inc", "$push", "$pull", "$addToSet"))
+_PUSH_MODIFIERS = frozenset(("$each", "$position", "$sort", "$slice"))
+_ADD_TO_SET_MODIFIERS = frozenset(("$each",))
+_PULL_COMPARISON_OPERATORS = {
+    "$gt": comparison_operator.gt,
+    "$gte": comparison_operator.ge,
+    "$lt": comparison_operator.lt,
+    "$lte": comparison_operator.le,
+}
+_PULL_FIELD_OPERATORS = frozenset(("$eq",) + tuple(_PULL_COMPARISON_OPERATORS))
+_PULL_LOGICAL_OPERATORS = frozenset(("$and", "$or", "$nor"))
+
+
+def _raise_write_error(message):
+    """Raise a Mongo-shaped write error that remains a TinyMongoError."""
+
+    raise WriteError(message, code=2)
+
+
+def _is_modifier_document(value):
+    return isinstance(value, Mapping) and any(
+        isinstance(key, str) and key.startswith("$") for key in value
+    )
+
+
+def _is_modifier_integer(value):
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_sort_direction(value):
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and value in (-1, 1)
+    )
+
+
+def _validate_each_modifier(value, operator, allowed_modifiers):
+    """Validate an array modifier document and return whether one was used."""
+
+    if not _is_modifier_document(value):
+        return False
+
+    unsupported = [key for key in value if key not in allowed_modifiers]
+    if unsupported:
+        _raise_write_error(
+            "{0} does not support modifier {1}".format(operator, repr(unsupported[0]))
+        )
+    if "$each" not in value:
+        _raise_write_error("{0} modifiers require $each".format(operator))
+    if not isinstance(value["$each"], (list, tuple)):
+        _raise_write_error("{0} $each requires an array".format(operator))
+    return True
+
+
+def _validate_push_operand(value):
+    if not _validate_each_modifier(value, "$push", _PUSH_MODIFIERS):
+        return False
+
+    if "$position" in value and not _is_modifier_integer(value["$position"]):
+        _raise_write_error("$push $position requires an integer")
+    if "$slice" in value and not _is_modifier_integer(value["$slice"]):
+        _raise_write_error("$push $slice requires an integer")
+    if "$sort" in value:
+        sort_spec = value["$sort"]
+        if _is_sort_direction(sort_spec):
+            return True
+        if not isinstance(sort_spec, Mapping) or not sort_spec:
+            _raise_write_error("$push $sort requires 1, -1, or a non-empty document")
+        if not all(
+            isinstance(field, str) and _is_sort_direction(direction)
+            for field, direction in sort_spec.items()
+        ):
+            _raise_write_error("$push $sort contains an invalid sort specification")
+    return True
+
+
+def _validate_add_to_set_operand(value):
+    return _validate_each_modifier(value, "$addToSet", _ADD_TO_SET_MODIFIERS)
+
+
+def _validate_pull_field_condition(condition):
+    """Validate the operators applied to one array element or document field."""
+
+    if not isinstance(condition, Mapping):
+        return
+
+    operator_keys = [
+        key for key in condition if isinstance(key, str) and key.startswith("$")
+    ]
+    if not operator_keys:
+        return
+    if len(operator_keys) != len(condition):
+        _raise_write_error("$pull cannot mix field and document query operators")
+
+    for key, operand in condition.items():
+        if key not in _PULL_FIELD_OPERATORS:
+            _raise_write_error("$pull does not support query operator {0}".format(key))
+        if key in _PULL_COMPARISON_OPERATORS and (
+            operand is None or bson_scalar_sort_key(operand) is None
+        ):
+            _raise_write_error(
+                "$pull {0} requires a supported scalar value".format(key)
+            )
+
+
+def _validate_pull_document_condition(condition):
+    """Validate a query applied to each embedded document in the array."""
+
+    for key, operand in condition.items():
+        if key in _PULL_LOGICAL_OPERATORS:
+            if (
+                not isinstance(operand, (list, tuple))
+                or not operand
+                or not all(isinstance(clause, Mapping) for clause in operand)
+            ):
+                _raise_write_error(
+                    "$pull {0} requires an array of documents".format(key)
+                )
+            for clause in operand:
+                _validate_pull_document_condition(clause)
+        elif isinstance(key, str) and key.startswith("$"):
+            _raise_write_error(
+                "$pull does not support document query operator {0}".format(key)
+            )
+        else:
+            _validate_pull_field_condition(operand)
+
+
+def _validate_pull_condition(condition):
+    """Reject unsupported query operators instead of silently matching nothing."""
+
+    if not isinstance(condition, Mapping):
+        return
+
+    operator_keys = [
+        key for key in condition if isinstance(key, str) and key.startswith("$")
+    ]
+    if any(key in _PULL_LOGICAL_OPERATORS for key in operator_keys):
+        _validate_pull_document_condition(condition)
+    elif operator_keys:
+        _validate_pull_field_condition(condition)
+    else:
+        _validate_pull_document_condition(condition)
+
+
+def _validate_update_operators(update_doc):
+    for operator, changes in update_doc.items():
+        if operator not in _UPDATE_OPERATORS:
+            raise TinyMongoNotSupportedError(
+                "Unsupported update operator: {0}".format(operator)
+            )
+        if not isinstance(changes, dict):
+            raise ValueError("{0} update requires a dict".format(operator))
+        if operator == "$push":
+            for value in changes.values():
+                _validate_push_operand(value)
+        elif operator == "$addToSet":
+            for value in changes.values():
+                _validate_add_to_set_operand(value)
+        elif operator == "$pull":
+            for value in changes.values():
+                _validate_pull_condition(value)
+
+
+def _sort_pushed_values(values, sort_spec):
+    """Sort array values using whole-value BSON ordering."""
+
+    order = TinyMongoCursor([])._order
+    if _is_sort_direction(sort_spec):
+        values.sort(key=order, reverse=sort_spec < 0)
+        return
+
+    # Stable passes from the least-significant field implement a compound
+    # sort while retaining the BSON ordering already shared by cursors.
+    for field, direction in reversed(list(sort_spec.items())):
+        values.sort(
+            key=lambda item, path=field: order(_get_nested(item, path, None)),
+            reverse=direction < 0,
+        )
+
+
+def _apply_push(current, value):
+    if not _validate_push_operand(value):
+        current.append(copy.deepcopy(value))
+        return current
+
+    additions = copy.deepcopy(list(value["$each"]))
+    if "$position" not in value:
+        current.extend(additions)
+    else:
+        position = value["$position"]
+        if position < 0:
+            position = max(len(current) + position, 0)
+        else:
+            position = min(position, len(current))
+        current[position:position] = additions
+
+    if "$sort" in value:
+        _sort_pushed_values(current, value["$sort"])
+
+    if "$slice" in value:
+        limit = value["$slice"]
+        if limit > 0:
+            current = current[:limit]
+        elif limit < 0:
+            current = current[limit:]
+        else:
+            current = []
+    return current
+
+
+def _apply_add_to_set(current, value):
+    candidates = value["$each"] if _validate_add_to_set_operand(value) else [value]
+    for candidate in candidates:
+        if not any(bson_values_equal(candidate, existing) for existing in current):
+            current.append(copy.deepcopy(candidate))
+    return current
+
+
+def _pull_comparison_matches(actual, operand, comparison):
+    operand_identity = bson_identity_key(operand)
+    operand_order = bson_scalar_sort_key(operand)
+    values = actual if isinstance(actual, (list, tuple)) else [actual]
+    for value in values:
+        value_identity = bson_identity_key(value)
+        value_order = bson_scalar_sort_key(value)
+        if (
+            value_identity is not None
+            and value_order is not None
+            and value_identity[0] == operand_identity[0]
+            and comparison(value_order[1], operand_order[1])
+        ):
+            return True
+    return False
+
+
+def _pull_field_matches(actual, condition):
+    if actual is _MISSING:
+        return False
+    if not isinstance(condition, Mapping) or not any(
+        isinstance(key, str) and key.startswith("$") for key in condition
+    ):
+        return _value_matches(actual, condition)
+
+    for query_operator, operand in condition.items():
+        if query_operator == "$eq":
+            if not _value_matches(actual, operand):
+                return False
+        elif not _pull_comparison_matches(
+            actual, operand, _PULL_COMPARISON_OPERATORS[query_operator]
+        ):
+            return False
+    return True
+
+
+def _pull_document_matches(document, condition):
+    for key, expected in condition.items():
+        if key == "$and":
+            if not all(_pull_document_matches(document, item) for item in expected):
+                return False
+        elif key == "$or":
+            if not any(_pull_document_matches(document, item) for item in expected):
+                return False
+        elif key == "$nor":
+            if any(_pull_document_matches(document, item) for item in expected):
+                return False
+        elif not _pull_field_matches(_get_nested(document, key), expected):
+            return False
+    return True
+
+
+def _pull_matches(item, condition):
+    if not isinstance(condition, Mapping):
+        return bson_values_equal(item, condition)
+
+    operator_keys = [
+        key for key in condition if isinstance(key, str) and key.startswith("$")
+    ]
+    if any(key in _PULL_LOGICAL_OPERATORS for key in operator_keys):
+        return isinstance(item, Mapping) and _pull_document_matches(item, condition)
+    if operator_keys:
+        return _pull_field_matches(item, condition)
+    return isinstance(item, Mapping) and _pull_document_matches(item, condition)
+
+
 def _apply_update_document(item, update_doc):
     updated = copy.deepcopy(item)
     operator_keys = [key for key in update_doc if key.startswith("$")]
@@ -280,10 +568,9 @@ def _apply_update_document(item, update_doc):
             replacement["_id"] = item["_id"]
         return replacement
 
-    for operator, changes in update_doc.items():
-        if not isinstance(changes, dict):
-            raise ValueError("{0} update requires a dict".format(operator))
+    _validate_update_operators(update_doc)
 
+    for operator, changes in update_doc.items():
         if operator == "$set":
             for path, value in changes.items():
                 _set_nested(updated, path, value)
@@ -300,25 +587,26 @@ def _apply_update_document(item, update_doc):
                 if not isinstance(current, list):
                     raise ValueError("$push target must be a list")
                 current = list(current)
-                current.append(value)
+                current = _apply_push(current, value)
                 _set_nested(updated, path, current)
         elif operator == "$pull":
             for path, value in changes.items():
                 current = _get_nested(updated, path, [])
                 if not isinstance(current, list):
                     raise ValueError("$pull target must be a list")
-                _set_nested(updated, path, [item for item in current if item != value])
-        elif operator == "$addToSet":
+                _set_nested(
+                    updated,
+                    path,
+                    [item for item in current if not _pull_matches(item, value)],
+                )
+        elif operator == "$addToSet":  # pragma: no branch - operators prevalidated
             for path, value in changes.items():
                 current = _get_nested(updated, path, [])
                 if not isinstance(current, list):
                     raise ValueError("$addToSet target must be a list")
                 current = list(current)
-                if value not in current:
-                    current.append(value)
+                current = _apply_add_to_set(current, value)
                 _set_nested(updated, path, current)
-        else:
-            raise ValueError("Unsupported update operator: {0}".format(operator))
 
     updated["_id"] = item["_id"]
     return updated
@@ -360,6 +648,7 @@ def _validate_update_document(update_doc):
         or not all(key.startswith("$") for key in update_doc)
     ):
         raise ValueError("update only works with $ operators; use replace_one instead")
+    _validate_update_operators(update_doc)
 
 
 def _reject_session(kwargs):
@@ -1749,7 +2038,7 @@ class TinyMongoCollection(object):
                 return UpdateResult(raw_result=[], matched_count=0, modified_count=0)
             updated = self.parent.engine.apply_update(matches[0], doc)
             self._validate_storage_document(updated)
-            modified = updated != matches[0]
+            modified = not bson_values_equal(updated, matches[0])
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
                 [
@@ -1817,7 +2106,7 @@ class TinyMongoCollection(object):
 
             updated = _apply_update_document(item, doc)
             self._validate_storage_document(updated)
-            modified = updated != item
+            modified = not bson_values_equal(updated, item)
             if modified:
                 post_image = [
                     (
@@ -1881,7 +2170,9 @@ class TinyMongoCollection(object):
             ]
             for _original, updated in updates:
                 self._validate_storage_document(updated)
-            modified_count = sum(updated != item for item, updated in updates)
+            modified_count = sum(
+                not bson_values_equal(updated, item) for item, updated in updates
+            )
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
                 [
@@ -1963,7 +2254,7 @@ class TinyMongoCollection(object):
             result = []
             modified_count = 0
             for item, updated in updates:
-                if updated != item:
+                if not bson_values_equal(updated, item):
                     modified_count += 1
                     result.extend(
                         self.table.update(


### PR DESCRIPTION
## Summary

Fix the silent array corruption reported in #144 and implement the practical MongoDB array-update family in TinyMongo's shared update path.

- Implement `$push/$each` with `$position`, scalar or document `$sort`, and `$slice`.
- Apply modifiers in MongoDB's required order: insert, sort, then slice, regardless of key order.
- Implement `$addToSet/$each` with BSON-aware equality and input-order preservation.
- Add safe query-aware `$pull` support for exact values, `$eq`, scalar `$gt/$gte/$lt/$lte`, embedded-document predicates, dotted paths, and document `$and/$or/$nor`.
- Raise TinyMongo `WriteError` failures for malformed or unsupported modifiers and pull predicates instead of silently returning the wrong result.
- Raise `TinyMongoNotSupportedError` for unsupported top-level update operators.
- Preserve plain scalar, list, and document operands with no modifier keys.
- Use BSON-aware post-image comparison so bool/number-distinct changes are persisted and counted correctly.

## Root cause

The old `$push` path always called `current.append(value)`. A modifier document such as:

```python
{"$push": {"pages": {"$each": ["p2", "p3"], "$slice": -2}}}
```

was therefore stored as one literal dictionary. The write reported success, the intended values were not appended, and the cap never ran, allowing a supposedly bounded array to grow indefinitely.

The nearby `$addToSet` and `$pull` paths had the same silent-wrong-answer shape: `$each` was treated literally, while query-form pull conditions were compared as ordinary values.

## Implementation details

The change stays in the shared update engine used by Memory, TinyDB/JSON, SQLite, DuckDB, Parquet, and both synchronous and asynchronous APIs.

Validation now happens before document lookup and mutation, so malformed updates fail consistently even when no document matches. Recognized but invalid modifier shapes use Mongo-shaped `WriteError(code=2)` exceptions that remain subclasses of `TinyMongoError`.

`$pull` is deliberately fail-closed. Predicates whose semantics are fully pinned are supported; broader forms such as `$all`, `$not`, and regex/options currently raise rather than risk another silent compatibility error.

BSON-aware equality is also used when deciding whether update post-images differ. This prevents Python's `True == 1` behavior from suppressing writes such as sorting `[True, 1]` into MongoDB BSON order `[1, True]`.

## Tests

Added focused edge/error tests and a transport-neutral contract suite that runs through sync and async APIs across every backend, including real MongoDB.

Validation completed:

- `1,252 passed, 141 deselected`
- 100% statement and branch coverage: `5,035` statements and `1,894` branches
- New MongoDB 8 contract file: `10 passed` across sync and async
- Full MongoDB contract suite during development: `92 passed`
- Ruff passed
- Black passed
- mypy passed
- Two independent final audits found no remaining blocker

Fixes #144
