### PR TITLE
Add core sync and async aggregation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- A shared, backend-independent aggregation engine for `$match` and `$group`,
+  with field-path or null group keys and `$min`, `$max`, and `$sum`
+  accumulators across synchronous and asynchronous clients.
+- Cross-backend and real-MongoDB aggregation contracts based on production
+  application pipelines, including BSON ordering, null/missing values, empty
+  inputs, and async cursor behavior.
+
+### Changed
+- Aggregation capability reporting now describes the exact supported stages,
+  accumulators, and expressions instead of reporting a blanket unsupported
+  value.
+
 ## [1.2.1] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ rows = list(users.find({}).sort("score", pymongo.DESCENDING))
 ```
 
 This is intended for the supported TinyMongo subset of PyMongo operations, not
-for server features such as authentication, replica sets, aggregation pipelines,
-sessions, or network connections. MongoDB URIs, host names, ports, and common
-connection kwargs are accepted and ignored so existing code can be tried locally.
+for server features such as authentication, replica sets, sessions, or network
+connections. MongoDB URIs, host names, ports, and common connection kwargs are
+accepted and ignored so existing code can be tried locally.
 Set `TINYMONGO_HOME` or pass `tinymongo_folder=` to choose where TinyMongo stores
 files. See `examples/pymongo_dropin.py` for a runnable example.
 
@@ -476,9 +476,45 @@ binary data with different subtypes remain separate.
 
 Cursor sorting follows MongoDB's comparison order for the currently supported
 scalar families, including BinData, `ObjectId`, booleans, and datetimes.
-Broader BSON comparison across ranges, indexes, and future aggregation remains
-tracked in
+The same recursive BSON order is used by aggregation `$min` and `$max`.
+Broader BSON comparison across query ranges and indexes remains tracked in
 [#94](https://github.com/schapman1974/tinymongo/issues/94).
+
+## Aggregation core subset
+
+`Collection.aggregate()` supports the production-driven core of `$match` and
+`$group`. `$match` uses the same query operators as `find()`. `$group` accepts a
+field-path or `None` `_id` and the `$min`, `$max`, and `$sum` accumulators:
+
+```python
+activity = events.aggregate(
+    [
+        {"$match": {"user_id": user_id}},
+        {
+            "$group": {
+                "_id": "$course_id",
+                "last_activity": {"$max": "$created_date"},
+                "plays": {"$sum": 1},
+            }
+        },
+    ]
+)
+rows = activity.to_list()
+```
+
+In the async API, await `aggregate()` to obtain an async cursor, then use
+`async for` or `await cursor.to_list()`. Dotted field paths are supported.
+`$min` and `$max` ignore null and missing inputs unless every input is null or
+missing, in which case they return null. `$sum` ignores missing and nonnumeric
+values, and an empty input produces no groups, including for `_id: None`.
+TinyMongo keeps first-seen group order for repeatable local results, but—as
+with MongoDB—`$group` output order is not a public guarantee.
+
+Other stages, accumulators, expressions, and aggregation options raise
+`TinyMongoNotSupportedError` with the unsupported feature named. The structured
+`client.capabilities()["aggregation"]` value lists the exact supported stages,
+accumulators, and expressions; `client.supports("aggregation")` reports whether
+any aggregation subset is available.
 
 ## ObjectId, datetime, and binary values
 
@@ -627,9 +663,10 @@ visible.
 
 Operations whose semantics TinyMongo cannot honor raise
 `TinyMongoNotSupportedError`. This includes sessions, transactions, change
-streams, aggregation pipelines, bulk writes, database commands, non-default
-read/write concerns, and unsupported index specifications. Connection options
-that only describe an ignored network target remain harmless for drop-in use.
+streams, aggregation features outside the documented core subset, bulk writes,
+database commands, non-default read/write concerns, and unsupported index
+specifications. Connection options that only describe an ignored network target
+remain harmless for drop-in use.
 `bypass_document_validation` is accepted as a compatibility no-op and never
 disables `_id` or unique-index enforcement. Where a compatibility method
 accepts a `session` keyword, `session=None` is allowed; non-`None` sessions and
@@ -659,8 +696,9 @@ class Person(me.Document):
 ```
 
 The tested subset covers document creation, repeated saves, queries, updates,
-deletes, counts, and collection drops. Advanced aggregation, sessions, and
-MongoDB server features remain outside TinyMongo's compatibility scope.
+deletes, counts, and collection drops. Aggregation beyond the documented core
+subset, sessions, and MongoDB server features remain outside TinyMongo's
+compatibility scope.
 
 
 # Examples

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -173,9 +173,18 @@ Exit criteria:
 [View milestone](https://github.com/schapman1974/tinymongo/milestone/2)
 
 - [ ] [#82: Shared aggregation pipeline engine](https://github.com/schapman1974/tinymongo/issues/82)
+  - [x] Land the first shared sync/async engine slice with pipeline validation,
+    compatible cursors, structured capability reporting, and clear unsupported
+    feature errors.
 - [ ] [#96: Basic aggregation stages](https://github.com/schapman1974/tinymongo/issues/96)
+  - [x] Implement `$match` through the existing query matcher.
+  - [ ] Add the remaining basic stages.
 - [ ] [#97: Aggregation projection stages](https://github.com/schapman1974/tinymongo/issues/97)
+  - [ ] Add the application-required `$project`, `$size`, and `$ifNull` slice.
 - [ ] [#91: Grouping and accumulators](https://github.com/schapman1974/tinymongo/issues/91)
+  - [x] Support field-path and `None` group keys with `$min`, `$max`, and
+    `$sum`.
+  - [ ] Complete the remaining accumulator scope.
 
 Exit criteria:
 
@@ -344,6 +353,10 @@ Exit criteria:
    - [x] Complete the real application run with Mike and record every difference.
    - [ ] Rerun the three follow-up cases and publish the dimensioned baseline.
 5. [ ] Build aggregation core after the real-application acceptance path works.
+   - [x] Deliver the shared `$match` plus `$group`/`$min`/`$max`/`$sum` slice
+     across synchronous and asynchronous APIs.
+   - [ ] Add the measured `$project`/`$size`/`$ifNull` slice and complete the
+     second-application acceptance rerun.
 6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
    compatibility gaps.
 7. [ ] Implement GridFS on stable BSON, index, and cursor foundations.

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -79,6 +79,12 @@ class _AsyncCollectionAdapter:
     def find(self, *args, **kwargs):
         return _AsyncCursorAdapter(self._collection.find(*args, **kwargs), self._runner)
 
+    def aggregate(self, *args, **kwargs):
+        cursor = self._collection.aggregate(*args, **kwargs)
+        if inspect.isawaitable(cursor):
+            cursor = self._runner.run(cursor)
+        return _AsyncCursorAdapter(cursor, self._runner)
+
     def __getattr__(self, name):
         attribute = getattr(self._collection, name)
         if not callable(attribute):

--- a/tests/contracts/test_aggregation_contract.py
+++ b/tests/contracts/test_aggregation_contract.py
@@ -1,0 +1,338 @@
+"""Aggregation behavior shared by every API and storage target."""
+
+from datetime import datetime
+
+import pytest
+
+
+pytestmark = pytest.mark.contract
+
+
+def _by_id(rows):
+    return {row["_id"]: row for row in rows}
+
+
+def test_latest_activity_by_course(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 1, 1, 8),
+            },
+            {
+                "_id": 2,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 1, 3, 8),
+            },
+            {
+                "_id": 3,
+                "user_id": "ada",
+                "course_id": "mongo",
+                "created_date": datetime(2026, 1, 2, 8),
+            },
+            {
+                "_id": 4,
+                "user_id": "grace",
+                "course_id": "python",
+                "created_date": datetime(2026, 1, 9, 8),
+            },
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$match": {"user_id": "ada"}},
+                {
+                    "$group": {
+                        "_id": "$course_id",
+                        "last_activity": {"$max": "$created_date"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert _by_id(rows) == {
+        "python": {
+            "_id": "python",
+            "last_activity": datetime(2026, 1, 3, 8),
+        },
+        "mongo": {
+            "_id": "mongo",
+            "last_activity": datetime(2026, 1, 2, 8),
+        },
+    }
+
+
+def test_first_and_last_play_by_user(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "course_id": "python",
+                "user_id": "ada",
+                "created_date": datetime(2026, 2, 4),
+            },
+            {
+                "_id": 2,
+                "course_id": "python",
+                "user_id": "ada",
+                "created_date": datetime(2026, 2, 1),
+            },
+            {
+                "_id": 3,
+                "course_id": "python",
+                "user_id": "grace",
+                "created_date": datetime(2026, 2, 3),
+            },
+            {
+                "_id": 4,
+                "course_id": "mongo",
+                "user_id": "ada",
+                "created_date": datetime(2026, 2, 9),
+            },
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {
+                    "$match": {
+                        "course_id": "python",
+                        "user_id": {"$in": ["ada", "grace"]},
+                    }
+                },
+                {
+                    "$group": {
+                        "_id": "$user_id",
+                        "first_play": {"$min": "$created_date"},
+                        "last_play": {"$max": "$created_date"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert _by_id(rows) == {
+        "ada": {
+            "_id": "ada",
+            "first_play": datetime(2026, 2, 1),
+            "last_play": datetime(2026, 2, 4),
+        },
+        "grace": {
+            "_id": "grace",
+            "first_play": datetime(2026, 2, 3),
+            "last_play": datetime(2026, 2, 3),
+        },
+    }
+
+
+def test_whole_collection_rollup(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 3, 1),
+            },
+            {
+                "_id": 2,
+                "user_id": "ada",
+                "course_id": "python",
+                "created_date": datetime(2026, 3, 5),
+            },
+            {
+                "_id": 3,
+                "user_id": "grace",
+                "course_id": "python",
+                "created_date": datetime(2026, 3, 9),
+            },
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {"$match": {"user_id": "ada", "course_id": "python"}},
+                {
+                    "$group": {
+                        "_id": None,
+                        "last_activity": {"$max": "$created_date"},
+                    }
+                },
+            ]
+        )
+    ) == [{"_id": None, "last_activity": datetime(2026, 3, 5)}]
+
+
+def test_match_reuses_query_semantics_and_can_follow_group(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "team": "alpha",
+                "profile": {"name": "Ada", "score": 9},
+            },
+            {
+                "_id": 2,
+                "team": "alpha",
+                "profile": {"name": "Grace", "score": 7},
+            },
+            {
+                "_id": 3,
+                "team": "beta",
+                "profile": {"name": "Lin", "score": 10},
+            },
+        ]
+    )
+
+    matched = list(
+        collection.aggregate(
+            [
+                {
+                    "$match": {
+                        "$and": [
+                            {"profile.score": {"$gte": 7, "$lte": 9}},
+                            {"profile.name": {"$regex": "^a", "$options": "i"}},
+                            {"_id": {"$ne": 99}},
+                        ]
+                    }
+                }
+            ]
+        )
+    )
+    assert [row["_id"] for row in matched] == [1]
+
+    grouped = list(
+        collection.aggregate(
+            [
+                {"$group": {"_id": "$team", "total": {"$sum": 1}}},
+                {"$match": {"total": {"$gte": 2}}},
+            ]
+        )
+    )
+    assert grouped == [{"_id": "alpha", "total": 2}]
+
+
+def test_sum_and_min_max_follow_mongodb_value_rules(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "group": "one", "amount": 2, "value": None},
+            {"_id": 2, "group": "one", "amount": 1.5, "value": 5},
+            {"_id": 3, "group": "one", "amount": True, "value": "text"},
+            {
+                "_id": 4,
+                "group": "one",
+                "amount": "ignored",
+                "value": datetime(2026, 4, 1),
+            },
+            {"_id": 5, "group": "one", "amount": [100]},
+            {"_id": 6, "group": "one"},
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": "$group",
+                        "count": {"$sum": 1},
+                        "total": {"$sum": "$amount"},
+                        "minimum": {"$min": "$value"},
+                        "maximum": {"$max": "$value"},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": "one",
+            "count": 6,
+            "total": 3.5,
+            "minimum": 5,
+            "maximum": datetime(2026, 4, 1),
+        }
+    ]
+
+
+def test_null_missing_keys_and_empty_inputs(contract_target):
+    collection = contract_target.collection
+    assert (
+        list(collection.aggregate([{"$group": {"_id": None, "n": {"$sum": 1}}}])) == []
+    )
+
+    collection.insert_many(
+        [
+            {"_id": 1, "bucket": None, "value": None},
+            {"_id": 2},
+        ]
+    )
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": "$bucket",
+                        "minimum": {"$min": "$value"},
+                        "maximum": {"$max": "$value"},
+                    }
+                }
+            ]
+        )
+    ) == [{"_id": None, "minimum": None, "maximum": None}]
+    assert (
+        list(
+            collection.aggregate(
+                [
+                    {"$match": {"_id": "missing"}},
+                    {"$group": {"_id": None, "n": {"$sum": 1}}},
+                ]
+            )
+        )
+        == []
+    )
+
+
+def test_dotted_paths_preserve_empty_array_traversals(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": []},
+            {"_id": 2, "items": [{}, {}]},
+            {"_id": 3, "items": [{}, {"score": 3}]},
+            {"_id": 4},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [{"$group": {"_id": "$items.score", "count": {"$sum": 1}}}]
+        )
+    )
+
+    assert len(rows) == 3
+    assert any(row == {"_id": [], "count": 2} for row in rows)
+    assert any(row == {"_id": [3], "count": 1} for row in rows)
+    assert any(row == {"_id": None, "count": 1} for row in rows)
+
+
+def test_aggregate_cursor_consumes_in_chunks(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": 1}, {"_id": 2}])
+
+    cursor = collection.aggregate([])
+    assert cursor.to_list(length=1) == [{"_id": 1}]
+    assert cursor.to_list() == [{"_id": 2}]
+    assert cursor.to_list() == []

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -102,6 +102,41 @@ def test_remote_sql_backend_round_trip(backend, env_name):
 
 
 @pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_aggregation_core(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_aggregation"
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][collection]
+    try:
+        docs.insert_many(
+            [
+                {"_id": 1, "team": "alpha", "score": 2},
+                {"_id": 2, "team": "alpha", "score": 5},
+                {"_id": 3, "team": "beta", "score": 9},
+            ]
+        )
+
+        rows = docs.aggregate(
+            [
+                {"$match": {"score": {"$lte": 5}}},
+                {
+                    "$group": {
+                        "_id": "$team",
+                        "minimum": {"$min": "$score"},
+                        "maximum": {"$max": "$score"},
+                        "total": {"$sum": "$score"},
+                    }
+                },
+            ]
+        ).to_list()
+
+        assert rows == [{"_id": "alpha", "minimum": 2, "maximum": 5, "total": 7}]
+    finally:
+        docs.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
 def test_remote_sql_insert_many_partial_failures(backend, env_name):
     dsn, database, prefix = _remote_target(backend, env_name)
     collection = prefix + "_insert_many"

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,0 +1,396 @@
+"""Focused validation and edge tests for TinyMongo aggregation."""
+
+import copy
+from uuid import uuid4
+
+import pytest
+
+import tinymongo
+from tinymongo.aggregation import (
+    AggregationContext,
+    AggregationEngine,
+    aggregation_capabilities,
+)
+from tinymongo.asyncio import AsyncTinyMongoClient, AsyncTinyMongoCursor
+from tinymongo.bson_types import bson_value_identity_key, bson_value_sort_key
+from tinymongo.errors import OperationFailure, TinyMongoNotSupportedError
+from tinymongo.tinymongo import TinyMongoCursor
+
+
+def _collection(name="aggregation-unit"):
+    return tinymongo.TinyMongoClient(
+        "memory://{0}-{1}".format(name, uuid4().hex), backend="memory"
+    ).db.items
+
+
+def test_empty_pipeline_returns_cloneable_snapshot_without_mutation():
+    collection = _collection("aggregation-snapshot")
+    stored = {"_id": 1, "nested": {"value": 2}}
+    collection.insert_one(stored)
+    pipeline = []
+
+    cursor = collection.aggregate(pipeline)
+    clone = cursor.clone()
+    first = cursor.next()
+    first["nested"]["value"] = 99
+
+    assert isinstance(cursor, TinyMongoCursor)
+    assert clone.to_list() == [{"_id": 1, "nested": {"value": 2}}]
+    assert collection.find_one({"_id": 1}) == stored
+    assert pipeline == []
+
+
+def test_dotted_paths_arrays_and_bson_group_identity():
+    collection = _collection("aggregation-paths")
+    collection.insert_many(
+        [
+            {"_id": 1, "key": 1, "nested": {"amount": 2}},
+            {"_id": 2, "key": 1.0, "nested": {"amount": 3}},
+            {"_id": 3, "key": True, "nested": {"amount": 4}},
+            {"_id": 4, "key": ["a", "b"], "nested": {"amount": 5}},
+            {"_id": 5, "key": ["a", "b"], "nested": {"amount": 6}},
+            {"_id": 6, "key": {"kind": "object"}, "nested": {"amount": 7}},
+            {"_id": 7, "key": {"kind": "object"}, "nested": {"amount": 8}},
+        ]
+    )
+
+    rows = collection.aggregate(
+        [
+            {
+                "$group": {
+                    "_id": "$key",
+                    "total": {"$sum": "$nested.amount"},
+                }
+            }
+        ]
+    ).to_list()
+
+    assert rows == [
+        {"_id": 1, "total": 5},
+        {"_id": True, "total": 4},
+        {"_id": ["a", "b"], "total": 11},
+        {"_id": {"kind": "object"}, "total": 15},
+    ]
+    context = AggregationContext()
+    assert context.resolve_field_path(
+        {"items": [{"score": 1}, {}, {"score": 3}]}, "$items.score"
+    ) == [1, 3]
+    assert context.resolve_field_path({"items": []}, "$items.score") == []
+    assert context.resolve_field_path({"items": [{}, {}]}, "$items.score") == []
+    missing_path = collection.aggregate(
+        [{"$group": {"_id": "$nested.amount.missing", "n": {"$sum": 1}}}]
+    ).to_list()
+    assert missing_path == [{"_id": None, "n": 7}]
+
+
+def test_shared_bson_order_rejects_unsupported_container_members():
+    marker = object()
+
+    assert bson_value_sort_key({"value": marker}) is None
+    assert bson_value_sort_key([marker]) is None
+    assert bson_value_identity_key({"value": marker}) is None
+    assert bson_value_identity_key([marker]) is None
+    assert bson_value_identity_key(marker) is None
+    assert bson_value_identity_key({"a": 1, "b": 2}) != bson_value_identity_key(
+        {"b": 2, "a": 1}
+    )
+    with pytest.raises(TinyMongoNotSupportedError, match="group.*object"):
+        AggregationEngine().run(
+            [{"key": marker}],
+            [{"$group": {"_id": "$key", "n": {"$sum": 1}}}],
+        )
+
+
+@pytest.mark.parametrize("pipeline", [None, (), {}, iter(())])
+def test_pipeline_must_be_a_list(pipeline):
+    with pytest.raises(TypeError, match="pipeline must be a list"):
+        _collection("aggregation-pipeline-type").aggregate(pipeline)
+
+
+@pytest.mark.parametrize(
+    "stage",
+    [
+        None,
+        {},
+        {"$match": {}, "$group": {"_id": None}},
+        {"match": {}},
+    ],
+)
+def test_pipeline_stage_shape_is_validated(stage):
+    with pytest.raises(OperationFailure, match="stage"):
+        _collection("aggregation-stage-shape").aggregate([stage])
+
+
+def test_pipeline_is_prepared_before_collection_storage_is_opened():
+    client = tinymongo.TinyMongoClient(
+        "memory://aggregation-prepare-{0}".format(uuid4().hex), backend="memory"
+    )
+    database = client.db
+    collection = database.items
+
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$lookup"):
+        collection.aggregate([{"$lookup": {}}])
+
+    assert database.list_collection_names() == []
+    assert AggregationEngine().run([{"_id": 1}], []) == [{"_id": 1}]
+
+
+def test_leading_match_is_pushed_into_the_collection_query(monkeypatch):
+    collection = _collection("aggregation-match-pushdown")
+    collection.insert_many([{"_id": 1, "keep": True}, {"_id": 2, "keep": False}])
+    queries = []
+    original_find = collection.find
+
+    def tracking_find(query, *args, **kwargs):
+        queries.append(copy.deepcopy(query))
+        return original_find(query, *args, **kwargs)
+
+    monkeypatch.setattr(collection, "find", tracking_find)
+
+    assert collection.aggregate([{"$match": {"keep": True}}]).to_list() == [
+        {"_id": 1, "keep": True}
+    ]
+    assert queries == [{"keep": True}]
+
+    queries.clear()
+    collection.aggregate(
+        [
+            {"$group": {"_id": "$keep", "n": {"$sum": 1}}},
+            {"$match": {"n": 1}},
+        ]
+    ).to_list()
+    assert queries == [{}]
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "message"),
+    [
+        ([{"$lookup": {}}], r"\$lookup"),
+        ([{"$sort": {"value": 1}}], r"\$sort"),
+        ([{"$group": {"_id": "$key", "mean": {"$avg": "$value"}}}], r"\$avg"),
+        ([{"$group": {"_id": "literal"}}], "field path or None"),
+        ([{"$group": {"_id": "$$ROOT"}}], "field path or None"),
+        (
+            [{"$group": {"_id": "$key", "top": {"$max": {"$add": [1, 2]}}}}],
+            r"\$add",
+        ),
+    ],
+)
+def test_unsupported_features_name_the_feature(pipeline, message):
+    collection = _collection("aggregation-unsupported")
+    collection.insert_one({"_id": 1, "key": "one"})
+    with pytest.raises(TinyMongoNotSupportedError, match=message):
+        collection.aggregate(pipeline)
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "message"),
+    [
+        (
+            [{"$group": {"_id": None, "top": {"$max": {"$add": [1, 2]}}}}],
+            r"\$add",
+        ),
+        (
+            [{"$group": {"_id": None, "total": {"$sum": "$$ROOT"}}}],
+            r"\$\$ROOT",
+        ),
+    ],
+)
+def test_unsupported_expressions_fail_before_empty_input_is_read(pipeline, message):
+    with pytest.raises(TinyMongoNotSupportedError, match=message):
+        _collection("aggregation-empty-unsupported").aggregate(pipeline)
+
+
+@pytest.mark.parametrize(
+    ("query", "message"),
+    [
+        ({"$expr": {"$eq": ["$value", 1]}}, r"\$expr"),
+        ({"value": {"$madeUp": 1}}, r"\$madeUp"),
+        ({"$and": []}, r"\$and"),
+        ({"$or": ["bad"]}, "Filter"),
+        ({1: "bad"}, "field names"),
+        ({"value": {"$options": "i"}}, r"\$options"),
+        ({"value": {"$gt": 1, "literal": 2}}, "mix operators"),
+        ({"value": {"$not": {"$madeUp": 1}}}, r"\$madeUp"),
+        ({"value": {"$in": 1}}, r"\$in.*array"),
+        ({"value": {"$nin": "one"}}, r"\$nin.*array"),
+        ({"value": {"$all": 1}}, r"\$all.*array"),
+        ({"value": {"$not": {"$in": 1}}}, r"\$in.*array"),
+        (
+            {"value": {"$not": {"$not": {"$madeUp": 1}}}},
+            r"\$madeUp",
+        ),
+        (
+            {"value": {"$not": {"$gt": 1, "literal": 2}}},
+            "mix operators",
+        ),
+        ({"value": {"$not": {"$options": "i"}}}, r"\$options"),
+    ],
+)
+def test_match_rejects_unknown_or_malformed_query_operators(query, message):
+    with pytest.raises((OperationFailure, TinyMongoNotSupportedError), match=message):
+        _collection("aggregation-match-validation").aggregate([{"$match": query}])
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"value": {"nested": 1}},
+        {"value": {"$not": {"$gt": 1}}},
+    ],
+)
+def test_match_accepts_literal_documents_and_valid_nested_not(query):
+    assert (
+        _collection("aggregation-match-valid").aggregate([{"$match": query}]).to_list()
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "pipeline",
+    [
+        [{"$match": []}],
+        [{"$group": []}],
+        [{"$group": {}}],
+        [{"$group": {"_id": None, "bad.name": {"$sum": 1}}}],
+        [{"$group": {"_id": None, "$bad": {"$sum": 1}}}],
+        [{"$group": {"_id": None, "bad": []}}],
+        [{"$group": {"_id": None, "bad": {"$sum": 1, "$max": 2}}}],
+    ],
+)
+def test_supported_stage_arguments_are_validated(pipeline):
+    with pytest.raises(OperationFailure):
+        _collection("aggregation-stage-arguments").aggregate(pipeline)
+
+
+def test_sessions_options_and_unsupported_comparison_values_fail_loudly():
+    collection = _collection("aggregation-options")
+    collection.insert_one({"_id": 1, "value": 2})
+
+    with pytest.raises(TinyMongoNotSupportedError, match="Sessions"):
+        collection.aggregate([], session=object())
+    with pytest.raises(TinyMongoNotSupportedError, match="Sessions"):
+        collection.aggregate([], {})
+    with pytest.raises(TinyMongoNotSupportedError, match="allowDiskUse"):
+        collection.aggregate([], allowDiskUse=True)
+    assert collection.aggregate([], None).to_list() == [{"_id": 1, "value": 2}]
+    with pytest.raises(TypeError):
+        collection.aggregate([], None, None)
+
+    marker = object()
+    with pytest.raises(TinyMongoNotSupportedError, match="object"):
+        collection.aggregate([{"$group": {"_id": None, "maximum": {"$max": marker}}}])
+
+
+def test_capability_descriptions_are_fresh_and_supports_is_true():
+    first = aggregation_capabilities()
+    second = aggregation_capabilities()
+    first["stages"] = ()
+
+    client = tinymongo.TinyMongoClient(backend="memory")
+    assert second["stages"] == ("$match", "$group")
+    assert client.capabilities()["aggregation"]["stages"] == (
+        "$match",
+        "$group",
+    )
+    assert client.supports("aggregation") is True
+
+
+def test_expression_literals_are_copied_and_unsupported_paths_fail():
+    context = AggregationContext()
+    expression = {"literal": [1, {"value": 2}]}
+    result = context.evaluate({}, expression)
+    result["literal"][1]["value"] = 3
+
+    assert expression == {"literal": [1, {"value": 2}]}
+    assert context.evaluate({}, (1, 2)) == (1, 2)
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$add"):
+        context.evaluate({}, {"$add": [1, 2]})
+    for path in ("field", "$"):
+        with pytest.raises(TinyMongoNotSupportedError, match="field paths"):
+            context.resolve_field_path({}, path)
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$\$ROOT"):
+        context.resolve_field_path({}, "$$ROOT")
+    context.validate_expression(1)
+    context.validate_expression(["$field", (1, {"literal": 2})])
+
+
+def test_repeated_group_results_are_deterministic():
+    collection = _collection("aggregation-order")
+    collection.insert_many(
+        [
+            {"_id": 1, "group": "b"},
+            {"_id": 2, "group": "a"},
+            {"_id": 3, "group": "b"},
+        ]
+    )
+    pipeline = [{"$group": {"_id": "$group", "count": {"$sum": 1}}}]
+
+    assert collection.aggregate(copy.deepcopy(pipeline)).to_list() == [
+        {"_id": "b", "count": 2},
+        {"_id": "a", "count": 1},
+    ]
+    assert collection.aggregate(copy.deepcopy(pipeline)).to_list() == [
+        {"_id": "b", "count": 2},
+        {"_id": "a", "count": 1},
+    ]
+
+
+def test_aggregate_cursor_is_a_context_manager():
+    collection = _collection("aggregation-context-manager")
+    collection.insert_one({"_id": 1})
+
+    with collection.aggregate([]) as cursor:
+        assert cursor.to_list() == [{"_id": 1}]
+    assert cursor.alive is False
+
+
+def test_sum_ignores_every_supported_non_numeric_value():
+    collection = _collection("aggregation-nonnumeric-sum")
+    collection.insert_many(
+        [
+            {"_id": 1, "value": True},
+            {"_id": 2, "value": "2"},
+            {"_id": 3, "value": None},
+            {"_id": 4, "value": [2]},
+            {"_id": 5},
+        ]
+    )
+
+    assert collection.aggregate(
+        [{"$group": {"_id": None, "total": {"$sum": "$value"}}}]
+    ).to_list() == [{"_id": None, "total": 0}]
+
+
+def test_async_aggregate_returns_async_cursor():
+    async def scenario():
+        client = AsyncTinyMongoClient("memory://aggregation-async", backend="memory")
+        collection = client.db.items
+        await collection.insert_many(
+            [
+                {"_id": 1, "group": "a", "value": 2},
+                {"_id": 2, "group": "a", "value": 3},
+            ]
+        )
+        cursor = await collection.aggregate(
+            [{"$group": {"_id": "$group", "total": {"$sum": "$value"}}}]
+        )
+        assert isinstance(cursor, AsyncTinyMongoCursor)
+        assert cursor.alive is True
+        assert await cursor.next() == {"_id": "a", "total": 5}
+        await cursor.rewind()
+        assert [row async for row in cursor] == [{"_id": "a", "total": 5}]
+        await cursor.close()
+        assert cursor.alive is False
+        empty = await collection.aggregate([{"$match": {"_id": "missing"}}])
+        assert empty.alive is False
+        async with await collection.aggregate([]) as managed:
+            assert len(await managed.to_list()) == 2
+        assert managed.alive is False
+        with pytest.raises(TinyMongoNotSupportedError, match=r"\$lookup"):
+            await collection.aggregate([{"$lookup": {}}])
+        await client.close()
+
+    import asyncio
+
+    asyncio.run(scenario())

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -220,8 +220,9 @@ def test_database_helpers_and_unsupported_calls():
 
             with pytest.raises(TinyMongoNotSupportedError):
                 await database.command("ping")
-            with pytest.raises(TinyMongoNotSupportedError):
-                await collection.aggregate([])
+            cursor = await collection.aggregate([])
+            assert isinstance(cursor, AsyncTinyMongoCursor)
+            assert await cursor.to_list() == []
 
     run(scenario())
 

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -130,10 +130,14 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
 
     assert capabilities["backend"] == backend
     assert capabilities["persistent"] is True
-    assert capabilities["aggregation"] is False
+    assert capabilities["aggregation"] == {
+        "stages": ("$match", "$group"),
+        "accumulators": ("$max", "$min", "$sum"),
+        "expressions": (),
+    }
     assert capabilities["sessions"] is False
     assert client.supports("multiprocess_writes") is True
-    assert client.supports("aggregation") is False
+    assert client.supports("aggregation") is True
 
 
 def test_object_storage_capabilities_are_conservative(tmp_path):
@@ -159,13 +163,15 @@ def test_unsupported_features_fail_loudly(tmp_path):
         client.watch,
         database.command,
         database.watch,
-        collection.aggregate,
         collection.bulk_write,
         collection.watch,
     ]
     for call in unsupported_calls:
         with pytest.raises(TinyMongoNotSupportedError):
             call([])
+
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$lookup"):
+        collection.aggregate([{"$lookup": {}}])
 
     with pytest.raises(TinyMongoNotSupportedError, match="single-field"):
         collection.create_index([("email", 1), ("name", 1)])

--- a/tinymongo/aggregation.py
+++ b/tinymongo/aggregation.py
@@ -1,0 +1,324 @@
+"""Backend-independent aggregation pipeline execution.
+
+The first supported slice intentionally stays small: ``$match`` and ``$group``
+with the ``$min``, ``$max``, and ``$sum`` accumulators.  Keeping the pipeline
+engine separate from storage lets every TinyMongo backend share validation,
+field-path, missing-value, and BSON comparison behavior.
+"""
+
+from __future__ import absolute_import
+
+import copy
+from collections.abc import Mapping
+
+from .bson_types import bson_value_identity_key, bson_value_sort_key
+from .errors import OperationFailure, TinyMongoNotSupportedError
+from .table_backends import matches_filter, validate_filter_operators
+
+
+_MISSING = object()
+_SUPPORTED_ACCUMULATORS = ("$max", "$min", "$sum")
+_SUPPORTED_STAGES = ("$match", "$group")
+
+
+def _sum_value(value):
+    """Return the numeric contribution MongoDB's group ``$sum`` would use."""
+
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return value
+    return 0
+
+
+def aggregation_capabilities():
+    """Return a fresh description of the currently supported pipeline slice."""
+
+    return {
+        "stages": _SUPPORTED_STAGES,
+        "accumulators": _SUPPORTED_ACCUMULATORS,
+        "expressions": (),
+    }
+
+
+def _resolve_parts(value, parts):
+    if not parts:
+        return copy.deepcopy(value)
+
+    part = parts[0]
+    remaining = parts[1:]
+    if isinstance(value, Mapping):
+        if part not in value:
+            return _MISSING
+        return _resolve_parts(value[part], remaining)
+
+    if isinstance(value, (list, tuple)):
+        resolved = []
+        for item in value:
+            candidate = _resolve_parts(item, parts)
+            if candidate is not _MISSING:
+                resolved.append(candidate)
+        # Once a path traverses an array, MongoDB preserves an empty traversal
+        # as an empty array. Only a missing field before array traversal is
+        # represented by the missing sentinel.
+        return resolved
+
+    return _MISSING
+
+
+class AggregationContext(object):
+    """Evaluate the field paths and literals shared by pipeline stages."""
+
+    @staticmethod
+    def validate_field_path(expression):
+        if isinstance(expression, str) and expression.startswith("$$"):
+            raise TinyMongoNotSupportedError(
+                "Aggregation variable {0} is not supported by TinyMongo".format(
+                    expression
+                )
+            )
+        if (
+            not isinstance(expression, str)
+            or not expression.startswith("$")
+            or len(expression) == 1
+        ):
+            raise TinyMongoNotSupportedError(
+                "Aggregation field paths must be strings such as '$field'"
+            )
+
+    def validate_expression(self, expression):
+        """Reject unsupported expression operators before reading documents."""
+
+        if isinstance(expression, str) and expression.startswith("$"):
+            self.validate_field_path(expression)
+            return
+        if isinstance(expression, (list, tuple)):
+            for item in expression:
+                self.validate_expression(item)
+            return
+        if isinstance(expression, Mapping):
+            operators = [key for key in expression if str(key).startswith("$")]
+            if operators:
+                raise TinyMongoNotSupportedError(
+                    "Aggregation expression {0} is not supported by TinyMongo".format(
+                        operators[0]
+                    )
+                )
+            for value in expression.values():
+                self.validate_expression(value)
+
+    def resolve_field_path(self, document, expression):
+        self.validate_field_path(expression)
+        return _resolve_parts(document, expression[1:].split("."))
+
+    def evaluate(self, document, expression):
+        if isinstance(expression, str) and expression.startswith("$"):
+            return self.resolve_field_path(document, expression)
+        if isinstance(expression, list):
+            return [self.evaluate(document, item) for item in expression]
+        if isinstance(expression, tuple):
+            return tuple(self.evaluate(document, item) for item in expression)
+        if isinstance(expression, Mapping):
+            operators = [key for key in expression if str(key).startswith("$")]
+            if operators:
+                raise TinyMongoNotSupportedError(
+                    "Aggregation expression {0} is not supported by TinyMongo".format(
+                        operators[0]
+                    )
+                )
+            return {
+                key: self.evaluate(document, value) for key, value in expression.items()
+            }
+        return copy.deepcopy(expression)
+
+
+class AggregationEngine(object):
+    """Validate and execute supported pipeline stages over document iterables."""
+
+    def __init__(self):
+        self.context = AggregationContext()
+        self.stage_registry = {
+            "$match": (self._validate_match, self._match),
+            "$group": (self._validate_group, self._group),
+        }
+
+    def prepare(self, pipeline):
+        """Validate a pipeline before any storage is opened or read."""
+
+        if not isinstance(pipeline, list):
+            raise TypeError("pipeline must be a list")
+
+        prepared = []
+        for index, stage in enumerate(pipeline):
+            name, argument = self._validate_stage(stage, index)
+            stage_entry = self.stage_registry.get(name)
+            if stage_entry is None:
+                raise TinyMongoNotSupportedError(
+                    "Aggregation stage {0} is not supported by TinyMongo".format(name)
+                )
+            validator, handler = stage_entry
+            prepared_argument = validator(argument)
+            prepared.append((name, handler, prepared_argument))
+        return prepared
+
+    @staticmethod
+    def run_prepared(documents, prepared):
+        current = documents
+        for _name, handler, argument in prepared:
+            current = handler(current, argument)
+        return list(current)
+
+    def run(self, documents, pipeline):
+        return self.run_prepared(documents, self.prepare(pipeline))
+
+    @staticmethod
+    def _validate_stage(stage, index):
+        if not isinstance(stage, Mapping) or len(stage) != 1:
+            raise OperationFailure(
+                "Aggregation pipeline stage {0} must contain exactly one field".format(
+                    index
+                )
+            )
+        name, argument = next(iter(stage.items()))
+        if not isinstance(name, str) or not name.startswith("$"):
+            raise OperationFailure(
+                "Aggregation pipeline stage {0} must use a $-prefixed name".format(
+                    index
+                )
+            )
+        return name, argument
+
+    @staticmethod
+    def _validate_match(specification):
+        if not isinstance(specification, Mapping):
+            raise OperationFailure("$match stage must contain a query document")
+        validate_filter_operators(specification)
+        return copy.deepcopy(dict(specification))
+
+    @staticmethod
+    def _match(documents, specification):
+        return (
+            document
+            for document in documents
+            if matches_filter(document, specification)
+        )
+
+    def _group(self, documents, prepared_group):
+        group_expression, accumulators = prepared_group
+        groups = []
+        groups_by_key = {}
+
+        for document in documents:
+            group_value = (
+                None
+                if group_expression is None
+                else self.context.resolve_field_path(document, group_expression)
+            )
+            if group_value is _MISSING:
+                group_value = None
+
+            group_key = bson_value_identity_key(group_value)
+            if group_key is None:
+                raise TinyMongoNotSupportedError(
+                    "$group cannot use values of type {0} as keys".format(
+                        type(group_value).__name__
+                    )
+                )
+            group = groups_by_key.get(group_key)
+            if group is None:
+                group = {
+                    "key": copy.deepcopy(group_value),
+                    "states": {
+                        output_field: 0 if operator == "$sum" else _MISSING
+                        for output_field, operator, _operand in accumulators
+                    },
+                }
+                groups.append(group)
+                groups_by_key[group_key] = group
+
+            for output_field, operator, operand in accumulators:
+                value = self.context.evaluate(document, operand)
+                if operator == "$sum":
+                    group["states"][output_field] += _sum_value(value)
+                    continue
+
+                # MongoDB ignores both null and missing values for min/max when
+                # any comparable value exists, and returns null when none does.
+                if value is _MISSING or value is None:
+                    continue
+                if bson_value_sort_key(value) is None:
+                    raise TinyMongoNotSupportedError(
+                        "Aggregation cannot compare values of type {0}".format(
+                            type(value).__name__
+                        )
+                    )
+                current = group["states"][output_field]
+                if current is _MISSING or self._is_better(operator, value, current):
+                    group["states"][output_field] = copy.deepcopy(value)
+
+        results = []
+        for group in groups:
+            result = {"_id": copy.deepcopy(group["key"])}
+            for output_field, operator, _operand in accumulators:
+                value = group["states"][output_field]
+                result[output_field] = (
+                    None
+                    if operator != "$sum" and value is _MISSING
+                    else copy.deepcopy(value)
+                )
+            results.append(result)
+        return results
+
+    @staticmethod
+    def _is_better(operator, candidate, current):
+        candidate_key = bson_value_sort_key(candidate)
+        current_key = bson_value_sort_key(current)
+        if operator == "$min":
+            return candidate_key < current_key
+        return candidate_key > current_key
+
+    def _validate_group(self, specification):
+        if not isinstance(specification, Mapping):
+            raise OperationFailure("$group stage must contain a document")
+        if "_id" not in specification:
+            raise OperationFailure("$group stage requires an _id expression")
+
+        group_expression = specification["_id"]
+        if group_expression is not None and (
+            not isinstance(group_expression, str)
+            or not group_expression.startswith("$")
+            or group_expression.startswith("$$")
+            or len(group_expression) == 1
+        ):
+            raise TinyMongoNotSupportedError(
+                "$group _id currently supports a field path or None"
+            )
+
+        accumulators = []
+        for output_field, accumulator in specification.items():
+            if output_field == "_id":
+                continue
+            if (
+                not isinstance(output_field, str)
+                or output_field.startswith("$")
+                or "." in output_field
+            ):
+                raise OperationFailure(
+                    "$group output field names must be plain strings"
+                )
+            if not isinstance(accumulator, Mapping) or len(accumulator) != 1:
+                raise OperationFailure(
+                    "$group output field {0!r} must contain one accumulator".format(
+                        output_field
+                    )
+                )
+            operator, operand = next(iter(accumulator.items()))
+            if operator not in _SUPPORTED_ACCUMULATORS:
+                raise TinyMongoNotSupportedError(
+                    "Aggregation accumulator {0} is not supported by TinyMongo".format(
+                        operator
+                    )
+                )
+            self.context.validate_expression(operand)
+            accumulators.append((output_field, operator, operand))
+        return group_expression, accumulators

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -455,8 +455,19 @@ class AsyncTinyMongoCollection:
     async def drop(self, *args: Any, **kwargs: Any) -> Any:
         return await self._call("drop", *args, **kwargs)
 
-    async def aggregate(self, *args: Any, **kwargs: Any) -> Any:
-        return await self._call("aggregate", *args, **kwargs)
+    async def aggregate(self, *args: Any, **kwargs: Any) -> "AsyncTinyMongoCursor":
+        """Run aggregation off-thread and return an async command cursor."""
+
+        collection_handle = self
+
+        def operation(client: TinyMongoClient) -> "AsyncTinyMongoCursor":
+            collection = client[collection_handle.database.name][collection_handle.name]
+            documents = collection.aggregate(*args, **kwargs).to_list()
+            # Cursor construction deep-copies its seed, so keep that work in
+            # the worker with storage and pipeline execution.
+            return AsyncTinyMongoCursor(documents=documents)
+
+        return await self.database.client._state.call(operation)
 
     async def bulk_write(self, *args: Any, **kwargs: Any) -> Any:
         return await self._call("bulk_write", *args, **kwargs)
@@ -631,12 +642,31 @@ class AsyncTinyMongoCursor:
     def alive(self) -> bool:
         if self._closed:
             return False
+        if self._documents is None and self._seed_documents is not None:
+            start = min(self._skip, len(self._seed_documents))
+            end = (
+                len(self._seed_documents)
+                if self._limit == 0
+                else min(start + self._limit, len(self._seed_documents))
+            )
+            return self._position < end - start
         if self._documents is None:
             return True
         return self._position < len(self._documents)
 
     def __aiter__(self) -> "AsyncTinyMongoCursor":
         return self
+
+    async def __aenter__(self) -> "AsyncTinyMongoCursor":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type],
+        exc_value: Optional[BaseException],
+        traceback: Any,
+    ) -> None:
+        await self.close()
 
     async def __anext__(self) -> Dict[str, Any]:
         documents = await self._ensure_loaded()

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -205,6 +205,39 @@ def bson_scalar_sort_key(value):
     return spec.sort_rank, spec.sort_key(value)
 
 
+def bson_value_sort_key(value):
+    """Return MongoDB-style ordering metadata for scalars and containers.
+
+    Cursor sorting and aggregation accumulators both need the same recursive
+    BSON comparison order.  ``None`` means the value is outside TinyMongo's
+    supported BSON families and cannot be compared safely.
+    """
+
+    if isinstance(value, Mapping):
+        parsed = []
+        for key, item in value.items():
+            item_key = bson_value_sort_key(item)
+            if item_key is None:
+                return None
+            parsed.append((item_key[0], key, item_key[1]))
+        return 3, tuple(parsed)
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            # Preserve TinyMongo's established ordering where an empty array
+            # sorts before null while arrays remain in the array type family.
+            return 4, ((-1, ()),)
+        parsed = []
+        for item in value:
+            item_key = bson_value_sort_key(item)
+            if item_key is None:
+                return None
+            parsed.append(item_key)
+        return 4, tuple(parsed)
+
+    return bson_scalar_sort_key(value)
+
+
 def bson_identity_key(value):
     """Return a hashable, BSON-type-aware scalar equality key.
 
@@ -218,6 +251,39 @@ def bson_identity_key(value):
     if spec is None:
         return None
     return spec.name, spec.identity_key(value)
+
+
+def bson_value_identity_key(value):
+    """Return a recursive, hashable key using MongoDB value equality rules.
+
+    Mapping field order remains significant, arrays retain member order, and
+    registered scalar families use :func:`bson_identity_key`. ``None`` means
+    the value cannot be represented safely by the current BSON registry.
+    """
+
+    scalar_key = bson_identity_key(value)
+    if scalar_key is not None:
+        return scalar_key
+
+    if isinstance(value, Mapping):
+        items = []
+        for key, item in value.items():
+            item_key = bson_value_identity_key(item)
+            if item_key is None:
+                return None
+            items.append((key, item_key))
+        return "object", tuple(items)
+
+    if isinstance(value, (list, tuple)):
+        items = []
+        for item in value:
+            item_key = bson_value_identity_key(item)
+            if item_key is None:
+                return None
+            items.append(item_key)
+        return "array", tuple(items)
+
+    return None
 
 
 def bson_values_equal(left, right):

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -39,6 +39,24 @@ from .parquet_storage import _acquire_rlock, _local_rlocks, portalocker
 _MISSING = object()
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
 _PHYSICAL_ID_PREFIX = "__tinymongo_id_v2__:"
+_LOGICAL_FILTER_OPERATORS = frozenset(("$and", "$or", "$nor"))
+_FIELD_FILTER_OPERATORS = frozenset(
+    (
+        "$all",
+        "$eq",
+        "$exists",
+        "$gt",
+        "$gte",
+        "$in",
+        "$lt",
+        "$lte",
+        "$ne",
+        "$nin",
+        "$not",
+        "$options",
+        "$regex",
+    )
+)
 
 
 def _canonical_id_value(value):
@@ -564,6 +582,60 @@ def matches_filter(doc, filter_doc):
             if not _field_matches(actual, expected, exact=key == "_id"):
                 return False
     return True
+
+
+def _validate_field_filter_operators(expression):
+    """Validate one field's operator document, including nested ``$not``."""
+
+    for operator, operand in expression.items():
+        if operator not in _FIELD_FILTER_OPERATORS:
+            if isinstance(operator, str) and operator.startswith("$"):
+                raise TinyMongoNotSupportedError(
+                    "Query operator {0} is not supported by TinyMongo".format(operator)
+                )
+            raise OperationFailure(
+                "Field query documents cannot mix operators and literal fields"
+            )
+        if operator in ("$all", "$in", "$nin") and not isinstance(
+            operand, (list, tuple)
+        ):
+            raise OperationFailure("{0} requires an array".format(operator))
+        if operator == "$options" and "$regex" not in expression:
+            raise OperationFailure("$options requires $regex in the same query")
+        if (
+            operator == "$not"
+            and isinstance(operand, Mapping)
+            and any(str(key).startswith("$") for key in operand)
+        ):
+            _validate_field_filter_operators(operand)
+
+
+def validate_filter_operators(filter_doc):
+    """Reject operators the shared Python matcher cannot evaluate safely."""
+
+    if not isinstance(filter_doc, Mapping):
+        raise OperationFailure("Filter must be a query document")
+
+    for key, expected in filter_doc.items():
+        if not isinstance(key, str):
+            raise OperationFailure("Filter field names must be strings")
+        if key in _LOGICAL_FILTER_OPERATORS:
+            if not isinstance(expected, (list, tuple)) or not expected:
+                raise OperationFailure(
+                    "{0} requires a non-empty array of query documents".format(key)
+                )
+            for specification in expected:
+                validate_filter_operators(specification)
+            continue
+        if key.startswith("$"):
+            raise TinyMongoNotSupportedError(
+                "Query operator {0} is not supported by TinyMongo".format(key)
+            )
+
+        if isinstance(expected, Mapping) and any(
+            str(operator).startswith("$") for operator in expected
+        ):
+            _validate_field_filter_operators(expected)
 
 
 def _filter_references_id(filter_doc):

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -20,9 +20,11 @@ from .bson_codec import bson_available
 from .bson_types import (
     bson_identity_key,
     bson_scalar_sort_key,
+    bson_value_sort_key,
     bson_values_equal,
     object_id_type,
 )
+from .aggregation import AggregationEngine, aggregation_capabilities
 from .storage_backends import (
     clear_memory_database,
     clear_memory_namespace,
@@ -914,7 +916,7 @@ class TinyMongoClient(object):
             in ("sqlite", "postgres", "postgresql", "mysql", "mariadb"),
             "projections": True,
             "bulk_writes": False,
-            "aggregation": False,
+            "aggregation": aggregation_capabilities(),
             "sessions": False,
             "transactions": False,
             "change_streams": False,
@@ -1258,10 +1260,25 @@ class TinyMongoCollection(object):
                 )
         return self
 
-    def aggregate(self, *args, **kwargs):
-        raise TinyMongoNotSupportedError(
-            "Aggregation pipelines are not supported by TinyMongo"
-        )
+    def aggregate(self, pipeline, session=None, **kwargs):
+        """Run TinyMongo's supported aggregation subset over this collection."""
+
+        _reject_session({"session": session})
+        options = list(kwargs)
+        if options:
+            raise TinyMongoNotSupportedError(
+                "Aggregation option {0} is not supported by TinyMongo".format(
+                    options[0]
+                )
+            )
+        engine = AggregationEngine()
+        prepared = engine.prepare(pipeline)
+        if prepared and prepared[0][0] == "$match":
+            documents = self.find(prepared[0][2])
+            prepared = prepared[1:]
+        else:
+            documents = self.find({})
+        return TinyMongoCursor(engine.run_prepared(documents, prepared))
 
     def bulk_write(self, *args, **kwargs):
         raise TinyMongoNotSupportedError("Bulk writes are not supported by TinyMongo")
@@ -2791,53 +2808,22 @@ class TinyMongoCursor(object):
         into a sortable tuple.
         """
 
-        def _dict_parser(dict_doc):
-            """dict ordered by:
-            valueType_N -> key_N -> value_N
-            """
-            result = list()
-            for key in dict_doc:
-                data = self._order(dict_doc[key], sort_field=sort_field)
-                res = (data[0], key, data[1])
-                result.append(res)
-            return tuple(result)
+        if isinstance(value, list) and is_reverse is not None:
+            members = (
+                [self._order(member, sort_field=sort_field) for member in value]
+                if value
+                else [(-1, ())]
+            )
+            # MongoDB compares an array sort field by its smallest element for
+            # ascending order and its largest element for descending order.
+            return max(members) if is_reverse else min(members)
 
-        def _list_parser(list_doc):
-            """list will iter members to compare"""
-            result = list()
-            for member in list_doc:
-                result.append(self._order(member, sort_field=sort_field))
-            return result
-
-        if isinstance(value, dict):
-            value = (3, _dict_parser(value))
-
-        elif isinstance(value, list):  # pragma: no branch - type chain is exhaustive
-            if len(value) == 0:
-                # [] less then None
-                value = [(-1, [])]
-            else:
-                value = _list_parser(value)
-
-            if is_reverse is not None:
-                # list will firstly compare with other doc by it's smallest
-                # or largest member
-                value = max(value) if is_reverse else min(value)
-            else:
-                # if the smallest or largest member is a list
-                # then compaer with it's sub-member in list index order
-                value = (4, tuple(value))
-
-        else:
-            scalar_key = bson_scalar_sort_key(value)
-            if scalar_key is None:
-                if sort_field is not None:
-                    self._warn_unsupported_sort_value(sort_field, value)
-                value = (0, None)
-            else:
-                value = scalar_key
-
-        return value
+        value_key = bson_value_sort_key(value)
+        if value_key is None:
+            if sort_field is not None:
+                self._warn_unsupported_sort_value(sort_field, value)
+            return 0, None
+        return value_key
 
     def sort(self, key_or_list, direction=None):
         """
@@ -3091,6 +3077,12 @@ class TinyMongoCursor(object):
         if self._closed:
             return iter(())
         return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
     def __next__(self):
         """


### PR DESCRIPTION
## Summary

This PR delivers the first production-driven aggregation slice shared by every TinyMongo backend and exposed through both synchronous and asynchronous clients.

- add a backend-independent aggregation engine for `$match` and `$group`
- support field-path and `None` group IDs
- support `$min`, `$max`, and `$sum`
- reuse TinyMongo's query matcher for `$match`, with malformed and unsupported operators rejected before storage is read
- reuse recursive BSON ordering and add BSON-aware identity keys for efficient grouping
- push an initial `$match` into `find()` so common pipelines avoid reading unrelated rows
- return compatible sync and async cursors, including context-manager behavior and positional `session=None`
- report the exact aggregation subset through structured client capabilities
- document the supported behavior and record completed versus pending roadmap work

## Why

Mike's second production application has nine aggregation calls. This slice implements the three known shapes that only require `$match`, `$group`, `$min`, `$max`, and `$sum`. It establishes the shared engine needed for the remaining narrow `$project` / `$size` / `$ifNull` shape without claiming that follow-up as complete.

The implementation also keeps TinyMongo's fail-loud compatibility policy: unsupported stages, accumulators, expressions, options, sessions, and query operators name the unsupported feature instead of silently returning incorrect results.

## Semantics and implementation notes

- `$min` and `$max` use recursive BSON comparison order and ignore null or missing inputs when a comparable value exists.
- `$sum` ignores booleans, missing values, arrays, and other nonnumeric inputs.
- empty input produces no groups, including `_id: None`
- missing group keys become `None`; dotted traversal through arrays preserves empty arrays
- numeric group keys compare by numeric value while booleans remain distinct
- document field order and array member order remain significant for group identity
- group lookup is indexed by a recursive BSON identity key rather than scanning existing groups
- first-seen group order is deterministic locally but is not a public ordering guarantee
- final aggregation results are currently materialized; broader streaming work remains in #82

## Coverage

New contracts exercise the production pipeline shapes across:

- sync and async APIs
- memory, JSON, SQLite, DuckDB, and Parquet backends
- an opt-in real MongoDB comparison target
- opt-in PostgreSQL and MariaDB aggregation smoke tests

Additional unit coverage covers validation-before-read, unsupported features, BSON ordering and identities, null/missing/array behavior, cursor lifecycle, async parity, leading-`$match` pushdown, and empty input.

## Validation

- `1,384 passed, 159 deselected`
- `100%` statement and branch coverage across `tinymongo/*`
- Ruff clean
- Black clean
- mypy clean
- `git diff --check` clean
- source distribution and wheel build successfully

The deselected tests are opt-in service-backed integration lanes; the real-MongoDB and remote-SQL contracts are included for CI or configured local environments.

## Issue scope

Advances #82, #91, and #96.

The application-required projection follow-up remains tracked in #97: `$project`, `$size`, and `$ifNull`.
