### PR TITLE
Add aggregation $project, $size, and $ifNull support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## [Unreleased]
 
 ### Added
-- A shared, backend-independent aggregation engine for `$match` and `$group`,
-  with field-path or null group keys and `$min`, `$max`, and `$sum`
-  accumulators across synchronous and asynchronous clients.
+- A shared, backend-independent aggregation engine for `$match`, `$project`,
+  and `$group`, with `$size` and `$ifNull` projection expressions, field-path or
+  null group keys, and `$min`, `$max`, and `$sum` accumulators across
+  synchronous and asynchronous clients.
 - Cross-backend and real-MongoDB aggregation contracts based on production
   application pipelines, including BSON ordering, null/missing values, empty
   inputs, and async cursor behavior.

--- a/README.md
+++ b/README.md
@@ -482,19 +482,26 @@ Broader BSON comparison across query ranges and indexes remains tracked in
 
 ## Aggregation core subset
 
-`Collection.aggregate()` supports the production-driven core of `$match` and
-`$group`. `$match` uses the same query operators as `find()`. `$group` accepts a
-field-path or `None` `_id` and the `$min`, `$max`, and `$sum` accumulators:
+`Collection.aggregate()` supports the production-driven core of `$match`,
+`$project`, and `$group`. `$match` uses the same query operators as `find()`.
+`$project` supports inclusion fields, `_id: 0`, and top-level computed fields
+using `$size` and `$ifNull`. `$group` accepts a field-path or `None` `_id` and
+the `$min`, `$max`, and `$sum` accumulators:
 
 ```python
 activity = events.aggregate(
     [
-        {"$match": {"user_id": user_id}},
+        {"$match": {"course_id": {"$in": course_ids}}},
+        {
+            "$project": {
+                "course_id": 1,
+                "count": {"$size": {"$ifNull": ["$lectures", []]}},
+            }
+        },
         {
             "$group": {
                 "_id": "$course_id",
-                "last_activity": {"$max": "$created_date"},
-                "plays": {"$sum": 1},
+                "total": {"$sum": "$count"},
             }
         },
     ]
@@ -503,7 +510,9 @@ rows = activity.to_list()
 ```
 
 In the async API, await `aggregate()` to obtain an async cursor, then use
-`async for` or `await cursor.to_list()`. Dotted field paths are supported.
+`async for` or `await cursor.to_list()`. Dotted field paths and dotted inclusion
+projections are supported. Computed dotted output paths and exclusion of fields
+other than `_id` remain outside this measured projection slice and fail clearly.
 `$min` and `$max` ignore null and missing inputs unless every input is null or
 missing, in which case they return null. `$sum` ignores missing and nonnumeric
 values, and an empty input produces no groups, including for `_id: None`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -180,7 +180,8 @@ Exit criteria:
   - [x] Implement `$match` through the existing query matcher.
   - [ ] Add the remaining basic stages.
 - [ ] [#97: Aggregation projection stages](https://github.com/schapman1974/tinymongo/issues/97)
-  - [ ] Add the application-required `$project`, `$size`, and `$ifNull` slice.
+  - [x] Add the application-required `$project`, `$size`, and `$ifNull` slice.
+  - [ ] Complete the remaining projection-stage and expression scope.
 - [ ] [#91: Grouping and accumulators](https://github.com/schapman1974/tinymongo/issues/91)
   - [x] Support field-path and `None` group keys with `$min`, `$max`, and
     `$sum`.
@@ -355,8 +356,8 @@ Exit criteria:
 5. [ ] Build aggregation core after the real-application acceptance path works.
    - [x] Deliver the shared `$match` plus `$group`/`$min`/`$max`/`$sum` slice
      across synchronous and asynchronous APIs.
-   - [ ] Add the measured `$project`/`$size`/`$ifNull` slice and complete the
-     second-application acceptance rerun.
+   - [x] Add the measured `$project`/`$size`/`$ifNull` slice.
+   - [ ] Complete the second-application acceptance rerun with Mike.
 6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
    compatibility gaps.
 7. [ ] Implement GridFS on stable BSON, index, and cursor foundations.

--- a/tests/contracts/test_aggregation_contract.py
+++ b/tests/contracts/test_aggregation_contract.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 import pytest
 
+from .support import observe
+
 
 pytestmark = pytest.mark.contract
 
@@ -326,6 +328,161 @@ def test_dotted_paths_preserve_empty_array_traversals(contract_target):
     assert any(row == {"_id": [], "count": 2} for row in rows)
     assert any(row == {"_id": [3], "count": 1} for row in rows)
     assert any(row == {"_id": None, "count": 1} for row in rows)
+
+
+def test_project_size_ifnull_application_rollup(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "course_id": "python", "lectures": ["a", "b"]},
+            {"_id": 2, "course_id": "python", "lectures": []},
+            {"_id": 3, "course_id": "python", "lectures": None},
+            {"_id": 4, "course_id": "python"},
+            {"_id": 5, "course_id": "mongo", "lectures": ["one"]},
+            {"_id": 6, "course_id": "excluded", "lectures": [1, 2, 3]},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$match": {"course_id": {"$in": ["python", "mongo"]}}},
+                {
+                    "$project": {
+                        "course_id": 1,
+                        "count": {"$size": {"$ifNull": ["$lectures", []]}},
+                    }
+                },
+                {
+                    "$group": {
+                        "_id": "$course_id",
+                        "total": {"$sum": "$count"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert _by_id(rows) == {
+        "python": {"_id": "python", "total": 2},
+        "mongo": {"_id": "mongo", "total": 1},
+    }
+
+
+def test_project_inclusion_id_and_expression_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "course_id": "python",
+            "lectures": ["one", "two"],
+            "profile": {"name": "Ada", "secret": "hidden"},
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "course_id": 1,
+                        "profile.name": 1,
+                        "copied": "$profile.name",
+                        "fallback": {
+                            "$ifNull": ["$missing", "$profile.name", "unknown"]
+                        },
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": 1,
+            "course_id": "python",
+            "profile": {"name": "Ada"},
+            "copied": "Ada",
+            "fallback": "Ada",
+        }
+    ]
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "course_id": 1,
+                        "count": {"$size": "$lectures"},
+                    }
+                }
+            ]
+        )
+    ) == [{"course_id": "python", "count": 2}]
+
+
+def test_project_dotted_inclusion_preserves_array_shape(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "items": [
+                {"name": "intro", "secret": 1},
+                {},
+                {"name": "loops", "secret": 2},
+            ],
+        }
+    )
+
+    assert list(collection.aggregate([{"$project": {"_id": 0, "items.name": 1}}])) == [
+        {"items": [{"name": "intro"}, {}, {"name": "loops"}]}
+    ]
+
+
+def test_project_expression_argument_and_lazy_evaluation_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "zero": 0,
+            "not_an_array": "bad",
+            "values": [1, 2, 3],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "field_size": {"$size": ["$values"]},
+                        "literal_size": {"$size": [[1, 2]]},
+                        "literal_empty_size": {"$size": [[]]},
+                        "lazy": {"$ifNull": ["$zero", {"$size": "$not_an_array"}]},
+                        "missing_ifnull": {"$ifNull": ["$missing_one", "$missing_two"]},
+                        "tuple_literal": (1, 2),
+                        "tuple_size": {"$size": ((1, 2),)},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "field_size": 3,
+            "literal_size": 2,
+            "literal_empty_size": 0,
+            "lazy": 0,
+            "tuple_literal": [1, 2],
+            "tuple_size": 2,
+        }
+    ]
+
+    for operand in ([], [1, 2]):
+        outcome = observe(
+            lambda operand=operand: list(
+                collection.aggregate([{"$project": {"invalid": {"$size": operand}}}])
+            )
+        )
+        assert outcome.error == "operation_failure"
 
 
 def test_aggregate_cursor_consumes_in_chunks(contract_target):

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import UserDict
 import os
 import math
@@ -6,6 +7,7 @@ from uuid import uuid4
 import pytest
 
 import tinymongo as tm
+from tinymongo.asyncio import AsyncTinyMongoClient
 from tinymongo.errors import (
     BulkWriteError,
     DuplicateKeyError,
@@ -110,8 +112,8 @@ def test_remote_sql_aggregation_core(backend, env_name):
     try:
         docs.insert_many(
             [
-                {"_id": 1, "team": "alpha", "score": 2},
-                {"_id": 2, "team": "alpha", "score": 5},
+                {"_id": 1, "team": "alpha", "score": 2, "items": [1, 2]},
+                {"_id": 2, "team": "alpha", "score": 5, "items": None},
                 {"_id": 3, "team": "beta", "score": 9},
             ]
         )
@@ -120,20 +122,78 @@ def test_remote_sql_aggregation_core(backend, env_name):
             [
                 {"$match": {"score": {"$lte": 5}}},
                 {
+                    "$project": {
+                        "team": 1,
+                        "score": 1,
+                        "item_count": {"$size": {"$ifNull": ["$items", []]}},
+                    }
+                },
+                {
                     "$group": {
                         "_id": "$team",
                         "minimum": {"$min": "$score"},
                         "maximum": {"$max": "$score"},
                         "total": {"$sum": "$score"},
+                        "items": {"$sum": "$item_count"},
                     }
                 },
             ]
         ).to_list()
 
-        assert rows == [{"_id": "alpha", "minimum": 2, "maximum": 5, "total": 7}]
+        assert rows == [
+            {
+                "_id": "alpha",
+                "minimum": 2,
+                "maximum": 5,
+                "total": 7,
+                "items": 2,
+            }
+        ]
     finally:
         docs.drop()
         client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_async_aggregation_projection(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_async_aggregation"
+
+    async def scenario():
+        client = AsyncTinyMongoClient(backend=backend, dsn=dsn)
+        docs = client[database][collection]
+        try:
+            await docs.insert_many(
+                [
+                    {"_id": 1, "course_id": "python", "lectures": [1, 2]},
+                    {"_id": 2, "course_id": "python", "lectures": None},
+                    {"_id": 3, "course_id": "python"},
+                    {"_id": 4, "course_id": "excluded", "lectures": [1, 2, 3]},
+                ]
+            )
+            cursor = await docs.aggregate(
+                [
+                    {"$match": {"course_id": {"$in": ["python"]}}},
+                    {
+                        "$project": {
+                            "course_id": 1,
+                            "count": {"$size": {"$ifNull": ["$lectures", []]}},
+                        }
+                    },
+                    {
+                        "$group": {
+                            "_id": "$course_id",
+                            "total": {"$sum": "$count"},
+                        }
+                    },
+                ]
+            )
+            assert await cursor.to_list() == [{"_id": "python", "total": 2}]
+        finally:
+            await docs.drop()
+            await client.close()
+
+    asyncio.run(scenario())
 
 
 @pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -162,6 +162,243 @@ def test_leading_match_is_pushed_into_the_collection_query(monkeypatch):
     assert queries == [{}]
 
 
+def test_project_includes_fields_and_computes_against_original_document():
+    collection = _collection("aggregation-project-computed")
+    stored = {
+        "_id": 1,
+        "name": "Ada",
+        "count": 99,
+        "zero": 0,
+        "lectures": ["intro", "loops"],
+        "profile": {"email": "ada@example.com", "secret": "hidden"},
+    }
+    collection.insert_one(stored)
+    pipeline = [
+        {
+            "$project": {
+                "_id": 0,
+                "name": 1,
+                "profile.email": 1,
+                "alias": "$name",
+                "count": {"$size": {"$ifNull": ["$lectures", []]}},
+                "old_count": "$count",
+                "choice": {"$ifNull": ["$missing", "$zero", "fallback"]},
+                "omitted": "$missing",
+            }
+        }
+    ]
+    original_pipeline = copy.deepcopy(pipeline)
+
+    assert collection.aggregate(pipeline).to_list() == [
+        {
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+            "alias": "Ada",
+            "count": 2,
+            "old_count": 99,
+            "choice": 0,
+        }
+    ]
+    assert pipeline == original_pipeline
+    assert collection.find_one({"_id": 1}) == stored
+
+
+def test_project_default_id_special_id_exclusion_and_missing_inclusion():
+    collection = _collection("aggregation-project-id")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"name": "Ada", "secret": "hidden"},
+        }
+    )
+
+    assert collection.aggregate(
+        [{"$project": {"name": 1, "missing": 1, "copy": "$name"}}]
+    ).to_list() == [{"_id": 1, "name": "Ada", "copy": "Ada"}]
+    assert collection.aggregate([{"$project": {"profile": {"name": 1}}}]).to_list() == [
+        {"_id": 1, "profile": {"name": "Ada"}}
+    ]
+    assert collection.aggregate([{"$project": {"_id": 0}}]).to_list() == [
+        {
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"name": "Ada", "secret": "hidden"},
+        }
+    ]
+
+
+def test_project_ifnull_preserves_non_null_values_and_size_accepts_arrays():
+    collection = _collection("aggregation-project-values")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "zero": 0,
+            "false": False,
+            "empty": [],
+            "nullable": None,
+            "values": [1, 2, 3],
+        }
+    )
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": 0,
+                    "zero": {"$ifNull": ["$zero", 10]},
+                    "false": {"$ifNull": ["$false", True]},
+                    "empty": {"$ifNull": ["$empty", [1]]},
+                    "fallback": {"$ifNull": ["$missing", "$nullable", "last"]},
+                    "missing_fallback": {"$ifNull": ["$missing", "$also_missing"]},
+                    "lazy": {"$ifNull": ["$zero", {"$size": "$nullable"}]},
+                    "size": {"$size": ["$values"]},
+                    "empty_size": {"$size": {"$ifNull": ["$missing", []]}},
+                    "literal_size": {"$size": [[1, 2]]},
+                    "literal_empty_size": {"$size": [[]]},
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "zero": 0,
+            "false": False,
+            "empty": [],
+            "fallback": "last",
+            "lazy": 0,
+            "size": 3,
+            "empty_size": 0,
+            "literal_size": 2,
+            "literal_empty_size": 0,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"_id": 1},
+        {"_id": 1, "value": None},
+        {"_id": 1, "value": "three"},
+        {"_id": 1, "value": {"nested": True}},
+        {"_id": 1, "value": 3},
+    ],
+)
+def test_project_size_rejects_non_array_runtime_values(document):
+    collection = _collection("aggregation-project-size-type")
+    collection.insert_one(document)
+
+    with pytest.raises(OperationFailure, match=r"\$size.*array"):
+        collection.aggregate([{"$project": {"size": {"$size": "$value"}}}])
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "error", "message"),
+    [
+        ([{"$project": []}], OperationFailure, r"\$project"),
+        ([{"$project": {}}], OperationFailure, "non-empty"),
+        (
+            [{"$project": {"secret": 0}}],
+            TinyMongoNotSupportedError,
+            "exclusion",
+        ),
+        (
+            [{"$project": {"profile": {"secret": 0}}}],
+            TinyMongoNotSupportedError,
+            "exclusion",
+        ),
+        (
+            [{"$project": {"nested.count": {"$size": "$values"}}}],
+            TinyMongoNotSupportedError,
+            "dotted output",
+        ),
+        (
+            [{"$project": {"value": {"$add": [1, 2]}}}],
+            TinyMongoNotSupportedError,
+            r"\$add",
+        ),
+        (
+            [{"$project": {"value": "$a..b"}}],
+            OperationFailure,
+            "components",
+        ),
+        (
+            [{"$project": {"value": {"$size": {"$ifNull": ["$a.$bad", []]}}}}],
+            OperationFailure,
+            "start with",
+        ),
+        (
+            [{"$project": {"value": {"$ifNull": "$missing"}}}],
+            OperationFailure,
+            r"\$ifNull",
+        ),
+        (
+            [{"$project": {"value": {"$ifNull": ["$missing"]}}}],
+            OperationFailure,
+            r"\$ifNull",
+        ),
+        (
+            [{"$project": {"value": {"$size": []}}}],
+            OperationFailure,
+            r"\$size",
+        ),
+        (
+            [{"$project": {"value": {"$size": [1, 2]}}}],
+            OperationFailure,
+            r"\$size",
+        ),
+        (
+            [{"$project": {"value": {"$size": "$items", "extra": 1}}}],
+            OperationFailure,
+            "one operator",
+        ),
+        (
+            [{"$project": {"parent": 1, "parent.child": "$value"}}],
+            OperationFailure,
+            "Path collision",
+        ),
+        (
+            [{"$project": {"parent.child": "$value", "parent": 1}}],
+            OperationFailure,
+            "Path collision",
+        ),
+        (
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "total": {"$sum": {"$size": "$items"}},
+                    }
+                }
+            ],
+            TinyMongoNotSupportedError,
+            r"\$size",
+        ),
+        (
+            [{"$group": {"_id": "$a.", "total": {"$sum": 1}}}],
+            OperationFailure,
+            "end with",
+        ),
+        (
+            [{"$group": {"_id": None, "total": {"$sum": "$a\x00b"}}}],
+            OperationFailure,
+            "null bytes",
+        ),
+    ],
+)
+def test_project_validation_fails_before_storage_read(pipeline, error, message):
+    client = tinymongo.TinyMongoClient(
+        "memory://aggregation-project-validation-{0}".format(uuid4().hex),
+        backend="memory",
+    )
+    collection = client.db.items
+
+    with pytest.raises(error, match=message):
+        collection.aggregate(pipeline)
+    assert client.db.list_collection_names() == []
+
+
 @pytest.mark.parametrize(
     ("pipeline", "message"),
     [
@@ -288,9 +525,11 @@ def test_capability_descriptions_are_fresh_and_supports_is_true():
     first["stages"] = ()
 
     client = tinymongo.TinyMongoClient(backend="memory")
-    assert second["stages"] == ("$match", "$group")
+    assert second["stages"] == ("$match", "$project", "$group")
+    assert second["expressions"] == ("$ifNull", "$size")
     assert client.capabilities()["aggregation"]["stages"] == (
         "$match",
+        "$project",
         "$group",
     )
     assert client.supports("aggregation") is True
@@ -303,7 +542,12 @@ def test_expression_literals_are_copied_and_unsupported_paths_fail():
     result["literal"][1]["value"] = 3
 
     assert expression == {"literal": [1, {"value": 2}]}
-    assert context.evaluate({}, (1, 2)) == (1, 2)
+    assert context.evaluate({}, {"missing": "$missing"}) == {}
+    assert context.evaluate({}, (1, 2)) == [1, 2]
+    assert context.evaluate({}, {"$size": ((1, 2),)}, ("$size",)) == 2
+    assert context.resolve_field_path({"reference": {"$id": 7}}, "$reference.$id") == 7
+    with pytest.raises(OperationFailure, match=r"\$ifNull"):
+        context.evaluate({}, {"$ifNull": ["$missing"]}, ("$ifNull",))
     with pytest.raises(TinyMongoNotSupportedError, match=r"\$add"):
         context.evaluate({}, {"$add": [1, 2]})
     for path in ("field", "$"):
@@ -368,8 +612,8 @@ def test_async_aggregate_returns_async_cursor():
         collection = client.db.items
         await collection.insert_many(
             [
-                {"_id": 1, "group": "a", "value": 2},
-                {"_id": 2, "group": "a", "value": 3},
+                {"_id": 1, "group": "a", "value": 2, "items": [1, 2]},
+                {"_id": 2, "group": "a", "value": 3, "items": None},
             ]
         )
         cursor = await collection.aggregate(
@@ -382,6 +626,21 @@ def test_async_aggregate_returns_async_cursor():
         assert [row async for row in cursor] == [{"_id": "a", "total": 5}]
         await cursor.close()
         assert cursor.alive is False
+        projected = await collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "group": 1,
+                        "count": {"$size": {"$ifNull": ["$items", []]}},
+                    }
+                }
+            ]
+        )
+        assert await projected.to_list() == [
+            {"group": "a", "count": 2},
+            {"group": "a", "count": 0},
+        ]
         empty = await collection.aggregate([{"$match": {"_id": "missing"}}])
         assert empty.alive is False
         async with await collection.aggregate([]) as managed:

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -131,9 +131,9 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
     assert capabilities["backend"] == backend
     assert capabilities["persistent"] is True
     assert capabilities["aggregation"] == {
-        "stages": ("$match", "$group"),
+        "stages": ("$match", "$project", "$group"),
         "accumulators": ("$max", "$min", "$sum"),
-        "expressions": (),
+        "expressions": ("$ifNull", "$size"),
     }
     assert capabilities["sessions"] is False
     assert client.supports("multiprocess_writes") is True

--- a/tinymongo/aggregation.py
+++ b/tinymongo/aggregation.py
@@ -1,24 +1,40 @@
 """Backend-independent aggregation pipeline execution.
 
-The first supported slice intentionally stays small: ``$match`` and ``$group``
-with the ``$min``, ``$max``, and ``$sum`` accumulators.  Keeping the pipeline
-engine separate from storage lets every TinyMongo backend share validation,
-field-path, missing-value, and BSON comparison behavior.
+The production-driven slice intentionally stays small: ``$match``, ``$project``,
+and ``$group`` with the ``$ifNull`` and ``$size`` projection expressions and the
+``$min``, ``$max``, and ``$sum`` accumulators. Keeping the pipeline engine
+separate from storage lets every TinyMongo backend share validation, field-path,
+missing-value, and BSON comparison behavior.
 """
 
 from __future__ import absolute_import
 
 import copy
 from collections.abc import Mapping
+from numbers import Number
 
 from .bson_types import bson_value_identity_key, bson_value_sort_key
 from .errors import OperationFailure, TinyMongoNotSupportedError
+from .projection import normalize_projection, project_document
 from .table_backends import matches_filter, validate_filter_operators
 
 
 _MISSING = object()
+_ALLOWED_DOLLAR_PREFIXED_FIELDS = frozenset(
+    (
+        "$db",
+        "$id",
+        "$recordId",
+        "$ref",
+        "$searchRootDocumentId",
+        "$searchScore",
+        "$searchSortValues",
+        "$sortKey",
+    )
+)
 _SUPPORTED_ACCUMULATORS = ("$max", "$min", "$sum")
-_SUPPORTED_STAGES = ("$match", "$group")
+_SUPPORTED_EXPRESSIONS = ("$ifNull", "$size")
+_SUPPORTED_STAGES = ("$match", "$project", "$group")
 
 
 def _sum_value(value):
@@ -37,7 +53,7 @@ def aggregation_capabilities():
     return {
         "stages": _SUPPORTED_STAGES,
         "accumulators": _SUPPORTED_ACCUMULATORS,
-        "expressions": (),
+        "expressions": _SUPPORTED_EXPRESSIONS,
     }
 
 
@@ -86,7 +102,48 @@ class AggregationContext(object):
                 "Aggregation field paths must be strings such as '$field'"
             )
 
-    def validate_expression(self, expression):
+        path = expression[1:]
+        if path.endswith("."):
+            raise OperationFailure(
+                "Aggregation field paths must not end with '.'", code=40353
+            )
+        parts = path.split(".")
+        if any(not part for part in parts):
+            raise OperationFailure(
+                "Aggregation field path components cannot be empty", code=15998
+            )
+        for part in parts:
+            if part.startswith("$") and part not in _ALLOWED_DOLLAR_PREFIXED_FIELDS:
+                raise OperationFailure(
+                    "Aggregation field path components may not start with '$'",
+                    code=16410,
+                )
+            if "\x00" in part:
+                raise OperationFailure(
+                    "Aggregation field path components may not contain null bytes",
+                    code=16411,
+                )
+
+    @staticmethod
+    def _expression_operator(expression):
+        operators = [key for key in expression if str(key).startswith("$")]
+        if not operators:
+            return None
+        if len(expression) != 1 or len(operators) != 1:
+            raise OperationFailure(
+                "Aggregation expression documents must contain one operator"
+            )
+        return operators[0]
+
+    @staticmethod
+    def _size_operand(operand):
+        if isinstance(operand, (list, tuple)):
+            if len(operand) != 1:
+                raise OperationFailure("$size requires exactly one expression")
+            return operand[0]
+        return operand
+
+    def validate_expression(self, expression, allowed_operators=()):
         """Reject unsupported expression operators before reading documents."""
 
         if isinstance(expression, str) and expression.startswith("$"):
@@ -94,41 +151,82 @@ class AggregationContext(object):
             return
         if isinstance(expression, (list, tuple)):
             for item in expression:
-                self.validate_expression(item)
+                self.validate_expression(item, allowed_operators)
             return
         if isinstance(expression, Mapping):
-            operators = [key for key in expression if str(key).startswith("$")]
-            if operators:
-                raise TinyMongoNotSupportedError(
-                    "Aggregation expression {0} is not supported by TinyMongo".format(
-                        operators[0]
+            operator = self._expression_operator(expression)
+            if operator is not None:
+                if operator not in allowed_operators:
+                    raise TinyMongoNotSupportedError(
+                        "Aggregation expression {0} is not supported by TinyMongo".format(
+                            operator
+                        )
                     )
-                )
+                operand = expression[operator]
+                if operator == "$ifNull":
+                    if not isinstance(operand, (list, tuple)) or len(operand) < 2:
+                        raise OperationFailure(
+                            "$ifNull requires at least two expressions"
+                        )
+                    for item in operand:
+                        self.validate_expression(item, allowed_operators)
+                    return
+                self.validate_expression(self._size_operand(operand), allowed_operators)
+                return
             for value in expression.values():
-                self.validate_expression(value)
+                self.validate_expression(value, allowed_operators)
 
     def resolve_field_path(self, document, expression):
         self.validate_field_path(expression)
         return _resolve_parts(document, expression[1:].split("."))
 
-    def evaluate(self, document, expression):
+    def evaluate(self, document, expression, allowed_operators=()):
         if isinstance(expression, str) and expression.startswith("$"):
             return self.resolve_field_path(document, expression)
         if isinstance(expression, list):
-            return [self.evaluate(document, item) for item in expression]
+            values = [
+                self.evaluate(document, item, allowed_operators) for item in expression
+            ]
+            return [None if value is _MISSING else value for value in values]
         if isinstance(expression, tuple):
-            return tuple(self.evaluate(document, item) for item in expression)
+            values = [
+                self.evaluate(document, item, allowed_operators) for item in expression
+            ]
+            return [None if value is _MISSING else value for value in values]
         if isinstance(expression, Mapping):
-            operators = [key for key in expression if str(key).startswith("$")]
-            if operators:
-                raise TinyMongoNotSupportedError(
-                    "Aggregation expression {0} is not supported by TinyMongo".format(
-                        operators[0]
+            operator = self._expression_operator(expression)
+            if operator is not None:
+                if operator not in allowed_operators:
+                    raise TinyMongoNotSupportedError(
+                        "Aggregation expression {0} is not supported by TinyMongo".format(
+                            operator
+                        )
                     )
+                operand = expression[operator]
+                if operator == "$ifNull":
+                    if not isinstance(operand, (list, tuple)) or len(operand) < 2:
+                        raise OperationFailure(
+                            "$ifNull requires at least two expressions"
+                        )
+                    for item in operand[:-1]:
+                        value = self.evaluate(document, item, allowed_operators)
+                        if value is not _MISSING and value is not None:
+                            return value
+                    return self.evaluate(document, operand[-1], allowed_operators)
+
+                value = self.evaluate(
+                    document, self._size_operand(operand), allowed_operators
                 )
-            return {
-                key: self.evaluate(document, value) for key, value in expression.items()
-            }
+                if not isinstance(value, list):
+                    raise OperationFailure("$size requires an array input")
+                return len(value)
+
+            result = {}
+            for key, value in expression.items():
+                evaluated = self.evaluate(document, value, allowed_operators)
+                if evaluated is not _MISSING:
+                    result[key] = evaluated
+            return result
         return copy.deepcopy(expression)
 
 
@@ -139,6 +237,7 @@ class AggregationEngine(object):
         self.context = AggregationContext()
         self.stage_registry = {
             "$match": (self._validate_match, self._match),
+            "$project": (self._validate_project, self._project),
             "$group": (self._validate_group, self._group),
         }
 
@@ -202,6 +301,72 @@ class AggregationEngine(object):
             for document in documents
             if matches_filter(document, specification)
         )
+
+    @staticmethod
+    def _is_projection_flag(value):
+        return isinstance(value, Number) or (
+            isinstance(value, Mapping)
+            and not any(str(key).startswith("$") for key in value)
+        )
+
+    @classmethod
+    def _has_non_id_exclusion(cls, specification, prefix=""):
+        for field, value in specification.items():
+            path = ".".join(part for part in (prefix, str(field)) if part)
+            if isinstance(value, Mapping) and not any(
+                str(key).startswith("$") for key in value
+            ):
+                if cls._has_non_id_exclusion(value, path):
+                    return True
+            elif isinstance(value, Number) and not bool(value) and path != "_id":
+                return True
+        return False
+
+    def _validate_project(self, specification):
+        if not isinstance(specification, Mapping) or not specification:
+            raise OperationFailure("$project stage must contain a non-empty document")
+
+        if self._has_non_id_exclusion(specification):
+            raise TinyMongoNotSupportedError(
+                "$project exclusion of fields other than _id is not supported"
+            )
+
+        shape = {}
+        computed = []
+        for output_field, expression in specification.items():
+            if self._is_projection_flag(expression):
+                shape[output_field] = copy.deepcopy(expression)
+                continue
+            self.context.validate_expression(expression, _SUPPORTED_EXPRESSIONS)
+            shape[output_field] = 1
+            computed.append((output_field, copy.deepcopy(expression)))
+
+        projection = normalize_projection(shape)
+        if any(
+            isinstance(output_field, str) and "." in output_field
+            for output_field, _expression in computed
+        ):
+            raise TinyMongoNotSupportedError(
+                "$project computed dotted output paths are not supported"
+            )
+        return projection, tuple(computed)
+
+    def _project(self, documents, prepared_project):
+        projection, computed = prepared_project
+
+        def project_one(document):
+            projected = project_document(document, projection)
+            for output_field, expression in computed:
+                value = self.context.evaluate(
+                    document, expression, _SUPPORTED_EXPRESSIONS
+                )
+                if value is _MISSING:
+                    projected.pop(output_field, None)
+                else:
+                    projected[output_field] = copy.deepcopy(value)
+            return projected
+
+        return (project_one(document) for document in documents)
 
     def _group(self, documents, prepared_group):
         group_expression, accumulators = prepared_group
@@ -293,6 +458,8 @@ class AggregationEngine(object):
             raise TinyMongoNotSupportedError(
                 "$group _id currently supports a field path or None"
             )
+        if group_expression is not None:
+            self.context.validate_field_path(group_expression)
 
         accumulators = []
         for output_field, accumulator in specification.items():


### PR DESCRIPTION
## Summary

This PR adds the measured aggregation projection slice needed by Mike's production pipeline: `$project` with inclusion fields, `$size`, and `$ifNull`, available through both synchronous and asynchronous clients.

The first aggregation PR supported `$match` and `$group`, but the pipeline discussed in #82 also needs to calculate an array count before grouping. This fills that gap and advances the application-driven work tracked in #97.

## What changed

- Added `$project` to the shared, backend-independent aggregation engine.
- Added `$size` and `$ifNull` expression evaluation.
- Supported regular and dotted inclusion projections while preserving nested array shape.
- Preserved MongoDB's default `_id` inclusion and supported `_id: 0`.
- Evaluated computed fields against the original input document.
- Treated missing and null values correctly in `$ifNull`, including lazy fallback evaluation.
- Preserved valid false, zero, and empty-array values.
- Added field-path, operator-shape, arity, path-collision, and runtime type validation before storage reads.
- Exposed the new stage and expressions through backend capability reporting.
- Added the same behavior to sync and async clients across every storage backend.
- Updated the README, changelog, and roadmap.

## Scope

This is intentionally the narrow production-driven portion of #97. It does not add:

- Exclusion projections other than `_id: 0`
- Computed dotted output paths
- Additional projection expressions
- The remaining aggregation stages or full MongoDB aggregation language

Those cases fail clearly instead of producing partial or misleading results. The remaining projection-stage and expression work stays open on the roadmap.

## Design rationale

Aggregation execution remains in the shared engine so memory, JSON, SQLite, DuckDB, Parquet, PostgreSQL, and MariaDB do not develop different pipeline semantics. `$project` reuses TinyMongo's existing projection normalization and document projection helpers for inclusion rules, dotted paths, `_id` handling, and collision detection.

This allows the production pipeline to run as:

```python
[
    {"$match": {"course_id": {"$in": course_ids}}},
    {
        "$project": {
            "course_id": 1,
            "count": {"$size": {"$ifNull": ["$lectures", []]}},
        }
    },
    {
        "$group": {
            "_id": "$course_id",
            "total": {"$sum": "$count"},
        }
    },
]
```

## Validation

- Full test suite: **1,450 passed**
- Branch coverage: **100%**
- MongoDB 8 sync/async contracts: **24 passed**
- PostgreSQL and MariaDB sync/async checks: **4 passed**
- Ruff: passed
- Black: passed
- mypy: passed
- Package build: passed
- Twine package check: passed

## Follow-up

Once this is merged, @mikeckennedy, could you rerun the production pipeline from your Talk Python testing? That acceptance run is the final unchecked item for this measured slice.

Related: #82  
Advances: #97
