### PR TITLE
Complete MongoDB-compatible aggregation projection stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,25 @@
 
 ### Added
 - A shared, backend-independent aggregation engine for `$match`, `$project`,
-  and `$group`, with `$size` and `$ifNull` projection expressions, field-path or
-  null group keys, and `$min`, `$max`, and `$sum` accumulators across
-  synchronous and asynchronous clients.
+  `$set`, `$addFields`, `$unset`, and `$group`, with `$ifNull`, `$literal`, and
+  `$size` projection expressions, `$$REMOVE`, field-path or null group keys,
+  and `$min`, `$max`, and `$sum` accumulators across synchronous and
+  asynchronous clients.
 - Cross-backend and real-MongoDB aggregation contracts based on production
-  application pipelines, including BSON ordering, null/missing values, empty
-  inputs, and async cursor behavior.
+  application pipelines, including full inclusion/exclusion and computed
+  projection modes, dotted array writes, BSON ordering, null/missing values,
+  empty inputs, and async cursor behavior.
 
 ### Changed
 - Aggregation capability reporting now describes the exact supported stages,
   accumulators, and expressions instead of reporting a blanket unsupported
   value.
+
+### Fixed
+- Aggregation field references no longer cross a raw array nested directly
+  inside another array before reaching the requested field.
+- Aggregation projections preserve source BSON field order for retained fields
+  and append directly computed fields in specification order.
 
 ## [1.2.1] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -483,10 +483,13 @@ Broader BSON comparison across query ranges and indexes remains tracked in
 ## Aggregation core subset
 
 `Collection.aggregate()` supports the production-driven core of `$match`,
-`$project`, and `$group`. `$match` uses the same query operators as `find()`.
-`$project` supports inclusion fields, `_id: 0`, and top-level computed fields
-using `$size` and `$ifNull`. `$group` accepts a field-path or `None` `_id` and
-the `$min`, `$max`, and `$sum` accumulators:
+`$project`, `$set`, `$addFields`, `$unset`, and `$group`. `$match` uses the same
+query operators as `find()`. `$project` supports inclusion, exclusion, renamed
+or computed fields, nested specifications, dotted output paths through arrays,
+and MongoDB's special `_id` rules. The available projection expressions are
+`$ifNull`, `$literal`, and `$size`; `$$REMOVE` conditionally omits or removes a
+field. `$group` accepts a field-path or `None` `_id` and the `$min`, `$max`, and
+`$sum` accumulators:
 
 ```python
 activity = events.aggregate(
@@ -510,20 +513,25 @@ rows = activity.to_list()
 ```
 
 In the async API, await `aggregate()` to obtain an async cursor, then use
-`async for` or `await cursor.to_list()`. Dotted field paths and dotted inclusion
-projections are supported. Computed dotted output paths and exclusion of fields
-other than `_id` remain outside this measured projection slice and fail clearly.
+`async for` or `await cursor.to_list()`. `$set` and `$addFields` are aliases that
+retain the input document, support nested and dotted array-aware writes, and
+evaluate every right-hand expression against the original stage input. `$unset`
+accepts one field name or a nonempty list of field names and follows exclusion
+projection behavior. Numeric array-index paths remain unsupported.
+
 `$min` and `$max` ignore null and missing inputs unless every input is null or
 missing, in which case they return null. `$sum` ignores missing and nonnumeric
 values, and an empty input produces no groups, including for `_id: None`.
-TinyMongo keeps first-seen group order for repeatable local results, but—as
-with MongoDB—`$group` output order is not a public guarantee.
+TinyMongo keeps first-seen group order for repeatable local results, but—as with
+MongoDB—`$group` output order is not a public guarantee.
 
 Other stages, accumulators, expressions, and aggregation options raise
 `TinyMongoNotSupportedError` with the unsupported feature named. The structured
 `client.capabilities()["aggregation"]` value lists the exact supported stages,
 accumulators, and expressions; `client.supports("aggregation")` reports whether
-any aggregation subset is available.
+any aggregation subset is available. In particular, `$replaceRoot`,
+`$replaceWith`, variables other than `$$REMOVE`, and MongoDB's broader expression
+language are not part of this slice yet.
 
 ## ObjectId, datetime, and binary values
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -179,9 +179,10 @@ Exit criteria:
 - [ ] [#96: Basic aggregation stages](https://github.com/schapman1974/tinymongo/issues/96)
   - [x] Implement `$match` through the existing query matcher.
   - [ ] Add the remaining basic stages.
-- [ ] [#97: Aggregation projection stages](https://github.com/schapman1974/tinymongo/issues/97)
+- [x] [#97: Aggregation projection stages](https://github.com/schapman1974/tinymongo/issues/97)
   - [x] Add the application-required `$project`, `$size`, and `$ifNull` slice.
-  - [ ] Complete the remaining projection-stage and expression scope.
+  - [x] Complete the initial projection scope with full `$project` modes,
+    `$set`, `$addFields`, `$unset`, `$literal`, and `$$REMOVE`.
 - [ ] [#91: Grouping and accumulators](https://github.com/schapman1974/tinymongo/issues/91)
   - [x] Support field-path and `None` group keys with `$min`, `$max`, and
     `$sum`.

--- a/tests/contracts/test_aggregation_projection_stages_contract.py
+++ b/tests/contracts/test_aggregation_projection_stages_contract.py
@@ -1,0 +1,283 @@
+"""Projection-stage contracts shared by TinyMongo and MongoDB."""
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def test_project_inclusion_exclusion_and_computed_modes(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [{"name": "one", "extra": 1}, {}, 3],
+        }
+    )
+
+    assert list(
+        collection.aggregate([{"$project": {"name": 1, "profile.email": 1}}])
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+        }
+    ]
+    assert list(
+        collection.aggregate([{"$project": {"secret": 0, "profile.age": 0}}])
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+            "items": [{"name": "one", "extra": 1}, {}, 3],
+        }
+    ]
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "renamed": "$name",
+                        "profile": {"email": 1, "label": "$name"},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "renamed": "Ada",
+            "profile": {"email": "ada@example.com", "label": "Ada"},
+        }
+    ]
+
+    for invalid_project in (
+        {"name": 1, "secret": 0},
+        {"secret": 0, "computed": "$name"},
+    ):
+        outcome = observe(
+            lambda invalid_project=invalid_project: list(
+                collection.aggregate([{"$project": invalid_project}])
+            )
+        )
+        assert outcome.error == "operation_failure"
+
+
+def test_project_computed_dotted_paths_preserve_array_shape(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "title": "Course",
+            "items": [{"name": "one", "extra": 1}, {}, 3],
+            "scalar": "old",
+            "empty": [],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "items.name": 1,
+                        "items.label": "$title",
+                        "created.value": "$title",
+                        "scalar.value": "$title",
+                        "empty.value": "$title",
+                        "missing.value": "$not_there",
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "items": [
+                {"name": "one", "label": "Course"},
+                {"label": "Course"},
+                {"label": "Course"},
+            ],
+            "created": {"value": "Course"},
+            "scalar": {"value": "Course"},
+            "empty": [],
+            "missing": {},
+        }
+    ]
+
+
+def test_set_and_add_fields_are_aliases_using_original_input(contract_target):
+    collection = contract_target.collection
+    original = {
+        "_id": 1,
+        "existing": "old",
+        "profile": {"name": "Ada"},
+        "items": [{"name": "one"}, {}, 3],
+    }
+    collection.insert_one(original.copy())
+    expected = {
+        "_id": 1,
+        "existing": "new",
+        "copied": "old",
+        "profile": {"name": "Ada", "label": "old"},
+        "items": [
+            {"name": "one", "label": "old"},
+            {"label": "old"},
+            {"label": "old"},
+        ],
+    }
+    specification = {
+        "existing": "new",
+        "copied": "$existing",
+        "missing": "$not_there",
+        "profile.label": "$existing",
+        "items.label": "$existing",
+    }
+
+    for stage in ("$set", "$addFields"):
+        assert list(collection.aggregate([{stage: specification}])) == [expected]
+        assert list(collection.aggregate([{stage: {}}])) == [original]
+
+
+def test_unset_accepts_one_or_many_dotted_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [{"name": "one", "secret": 1}, {}, 3],
+        }
+    )
+
+    assert list(collection.aggregate([{"$unset": "secret"}])) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [{"name": "one", "secret": 1}, {}, 3],
+        }
+    ]
+    assert list(
+        collection.aggregate([{"$unset": ["secret", "profile.age", "items.secret"]}])
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+            "items": [{"name": "one"}, {}, 3],
+        }
+    ]
+
+
+def test_literal_and_remove_expression_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "profile": {"email": "ada@example.com", "age": 36},
+            "items": [1, 2],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "kept": "$name",
+                        "literal_number": {"$literal": 1},
+                        "literal_bool": {"$literal": False},
+                        "literal_path": {"$literal": "$name"},
+                        "literal_document": {"$literal": {"$size": "$items"}},
+                        "literal_array": {"$literal": ("$name", {"$size": "$items"})},
+                        "dropped": "$$REMOVE",
+                        "holder.drop": "$$REMOVE",
+                        "array": ["$$REMOVE", "$name"],
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "kept": "Ada",
+            "literal_number": 1,
+            "literal_bool": False,
+            "literal_path": "$name",
+            "literal_document": {"$size": "$items"},
+            "literal_array": ["$name", {"$size": "$items"}],
+            "holder": {},
+            "array": [None, "Ada"],
+        }
+    ]
+    assert list(
+        collection.aggregate(
+            [{"$set": {"secret": "$$REMOVE", "profile.age": "$$REMOVE"}}]
+        )
+    ) == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "profile": {"email": "ada@example.com"},
+            "items": [1, 2],
+        }
+    ]
+
+
+def test_field_paths_do_not_descend_through_nested_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": 1,
+            "nested": [[{"score": 7}], 2],
+            "direct": [{"score": 3}, [{"score": 4}], {"score": 5}],
+        }
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$project": {
+                        "_id": 0,
+                        "nested_scores": "$nested.score",
+                        "direct_scores": "$direct.score",
+                    }
+                }
+            ]
+        )
+    ) == [{"nested_scores": [], "direct_scores": [3, 5]}]
+
+
+def test_project_preserves_embedded_source_order_for_group_identity(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": {"x": 1, "y": 2}},
+            {"_id": 2, "value": {"y": 2, "x": 1}},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$project": {"_id": 0, "value.x": 1, "value.y": 1}},
+                {"$group": {"_id": "$value", "count": {"$sum": 1}}},
+            ]
+        )
+    )
+
+    assert len(rows) == 2
+    assert [row["count"] for row in rows] == [1, 1]
+    assert {tuple(row["_id"]) for row in rows} == {("x", "y"), ("y", "x")}

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -122,10 +122,17 @@ def test_remote_sql_aggregation_core(backend, env_name):
             [
                 {"$match": {"score": {"$lte": 5}}},
                 {
+                    "$set": {
+                        "item_count": {"$size": {"$ifNull": ["$items", []]}},
+                        "temporary": {"$literal": "$score"},
+                    }
+                },
+                {"$unset": ["items", "temporary"]},
+                {
                     "$project": {
                         "team": 1,
                         "score": 1,
-                        "item_count": {"$size": {"$ifNull": ["$items", []]}},
+                        "item_count": 1,
                     }
                 },
                 {
@@ -175,9 +182,16 @@ def test_remote_sql_async_aggregation_projection(backend, env_name):
                 [
                     {"$match": {"course_id": {"$in": ["python"]}}},
                     {
+                        "$addFields": {
+                            "count": {"$size": {"$ifNull": ["$lectures", []]}},
+                            "literal": {"$literal": "$course_id"},
+                        }
+                    },
+                    {"$unset": ["lectures", "literal"]},
+                    {
                         "$project": {
                             "course_id": 1,
-                            "count": {"$size": {"$ifNull": ["$lectures", []]}},
+                            "count": 1,
                         }
                     },
                     {

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -289,8 +289,9 @@ def test_project_size_rejects_non_array_runtime_values(document):
     collection = _collection("aggregation-project-size-type")
     collection.insert_one(document)
 
-    with pytest.raises(OperationFailure, match=r"\$size.*array"):
+    with pytest.raises(OperationFailure, match=r"\$size.*array") as caught:
         collection.aggregate([{"$project": {"size": {"$size": "$value"}}}])
+    assert caught.value.code == 17124
 
 
 @pytest.mark.parametrize(
@@ -298,21 +299,6 @@ def test_project_size_rejects_non_array_runtime_values(document):
     [
         ([{"$project": []}], OperationFailure, r"\$project"),
         ([{"$project": {}}], OperationFailure, "non-empty"),
-        (
-            [{"$project": {"secret": 0}}],
-            TinyMongoNotSupportedError,
-            "exclusion",
-        ),
-        (
-            [{"$project": {"profile": {"secret": 0}}}],
-            TinyMongoNotSupportedError,
-            "exclusion",
-        ),
-        (
-            [{"$project": {"nested.count": {"$size": "$values"}}}],
-            TinyMongoNotSupportedError,
-            "dotted output",
-        ),
         (
             [{"$project": {"value": {"$add": [1, 2]}}}],
             TinyMongoNotSupportedError,
@@ -525,11 +511,21 @@ def test_capability_descriptions_are_fresh_and_supports_is_true():
     first["stages"] = ()
 
     client = tinymongo.TinyMongoClient(backend="memory")
-    assert second["stages"] == ("$match", "$project", "$group")
-    assert second["expressions"] == ("$ifNull", "$size")
+    assert second["stages"] == (
+        "$match",
+        "$project",
+        "$set",
+        "$addFields",
+        "$unset",
+        "$group",
+    )
+    assert second["expressions"] == ("$ifNull", "$literal", "$size")
     assert client.capabilities()["aggregation"]["stages"] == (
         "$match",
         "$project",
+        "$set",
+        "$addFields",
+        "$unset",
         "$group",
     )
     assert client.supports("aggregation") is True

--- a/tests/test_aggregation_projection_stages.py
+++ b/tests/test_aggregation_projection_stages.py
@@ -1,0 +1,718 @@
+"""Issue #97 contracts for projection-oriented aggregation stages."""
+
+import asyncio
+from collections import OrderedDict
+from uuid import uuid4
+
+import pytest
+
+import tinymongo
+from tinymongo.aggregation import AggregationEngine
+from tinymongo.asyncio import AsyncTinyMongoClient, AsyncTinyMongoCursor
+from tinymongo.errors import OperationFailure, TinyMongoNotSupportedError
+
+
+def _collection(name):
+    return tinymongo.TinyMongoClient(
+        "memory://{0}-{1}".format(name, uuid4().hex), backend="memory"
+    ).db.items
+
+
+def _projection_document():
+    return {
+        "_id": 1,
+        "name": "Ada",
+        "secret": "hidden",
+        "source": 5,
+        "a": {"b": 2, "c": 3},
+        "arr": [{"x": 1, "keep": "a"}, {"y": 2}, 3],
+        "scalar": 5,
+        "empty": [],
+        "nested": [[{"a": 1}], 2],
+        "profile": {"email": "ada@example.com", "secret": "hidden"},
+    }
+
+
+def test_project_supports_inclusion_exclusion_and_id_modes():
+    collection = _collection("project-modes")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate([{"$project": {"name": 1}}]).to_list() == [
+        {"_id": 1, "name": "Ada"}
+    ]
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "secret": 0,
+                    "profile.secret": 0,
+                    "arr.x": 0,
+                    "_id": 1,
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "source": 5,
+            "a": {"b": 2, "c": 3},
+            "arr": [{"keep": "a"}, {"y": 2}, 3],
+            "scalar": 5,
+            "empty": [],
+            "nested": [[{"a": 1}], 2],
+            "profile": {"email": "ada@example.com"},
+        }
+    ]
+    assert collection.aggregate([{"$project": {"_id": 0}}]).to_list() == [
+        {key: value for key, value in _projection_document().items() if key != "_id"}
+    ]
+    nested_exclusion = _projection_document()
+    nested_exclusion["a"] = {"c": 3}
+    assert collection.aggregate(
+        [{"$project": {"_id": 0, "a": {"b": 0}}}]
+    ).to_list() == [
+        {key: value for key, value in nested_exclusion.items() if key != "_id"}
+    ]
+    assert collection.aggregate(
+        [{"$project": {"_id": False, "name": 2, "absent": 7}}]
+    ).to_list() == [{"name": "Ada"}]
+
+
+def test_project_computes_renames_and_nested_specifications_from_input():
+    collection = _collection("project-computed")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": "$a.b",
+                    "a": {"b": 1, "copied": "$source"},
+                    "new": {"label": "literal"},
+                    "renamed": "$name",
+                    "missing": "$missing",
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "_id": 2,
+            "a": {"b": 2, "copied": 5},
+            "new": {"label": "literal"},
+            "renamed": "Ada",
+        }
+    ]
+
+
+def test_project_preserves_source_order_then_appends_computed_fields():
+    collection = _collection("project-output-order")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "a": {"y": 2, "x": 1, "old": 0},
+            "b": 2,
+            "source": 9,
+            "c": 3,
+        }
+    )
+
+    result = collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": 0,
+                    "new_one": "$source",
+                    "c": 1,
+                    "new_two": "$source",
+                    "b": 1,
+                    "a.old": "$source",
+                    "a.x": 1,
+                    "a.y": "$source",
+                }
+            }
+        ]
+    ).next()
+
+    assert list(result) == ["a", "b", "c", "new_one", "new_two"]
+    assert list(result["a"]) == ["x", "old", "y"]
+    assert result == {
+        "a": {"x": 1, "old": 9, "y": 9},
+        "b": 2,
+        "c": 3,
+        "new_one": 9,
+        "new_two": 9,
+    }
+
+
+def test_project_dotted_outputs_preserve_array_shape_and_missing_shells():
+    collection = _collection("project-dotted-arrays")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": 0,
+                    "arr.x": 1,
+                    "arr.z": "$source",
+                    "scalar.z": "$source",
+                    "empty.z": "$source",
+                    "nested.z": "$source",
+                    "missing.z": "$missing",
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "arr": [{"x": 1, "z": 5}, {"z": 5}, {"z": 5}],
+            "scalar": {"z": 5},
+            "empty": [],
+            "nested": [[{"z": 5}], {"z": 5}],
+            "missing": {},
+        }
+    ]
+
+
+def test_project_dotted_inclusion_skips_scalar_array_members():
+    collection = _collection("project-dotted-inclusion")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate([{"$project": {"_id": 0, "arr.x": 1}}]).to_list() == [
+        {"arr": [{"x": 1}, {}]}
+    ]
+
+
+def test_computed_project_keeps_include_only_branch_rules():
+    collection = _collection("project-computed-include-branches")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "source": 5,
+            "arr": [{"x": 1}, 2],
+            "scalar": 3,
+        }
+    )
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "arr.x": 1,
+                    "scalar.x": 1,
+                    "copy": "$source",
+                }
+            }
+        ]
+    ).to_list() == [{"_id": 1, "arr": [{"x": 1}], "copy": 5}]
+
+
+def test_literal_emits_constants_without_evaluating_its_operand():
+    collection = _collection("project-literal")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": 0,
+                    "numeric": {"$literal": 2},
+                    "boolean": {"$literal": False},
+                    "path": {"$literal": "$source"},
+                    "document": {"$literal": {"$size": "$arr"}},
+                    "array": {"$literal": ("$source", {"$size": "$arr"})},
+                    "projection_flag": 2,
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "numeric": 2,
+            "boolean": False,
+            "path": "$source",
+            "document": {"$size": "$arr"},
+            "array": ["$source", {"$size": "$arr"}],
+        }
+    ]
+
+
+def test_pipeline_binary_constants_follow_bson_generic_subtype_decoding():
+    binary = pytest.importorskip("bson.binary")
+    generic = binary.Binary(b"generic", subtype=0)
+    custom = binary.Binary(b"custom", subtype=128)
+    collection = _collection("project-binary-literal")
+    collection.insert_one({"_id": 1})
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": 0,
+                    "direct": generic,
+                    "literal": {"$literal": generic},
+                    "custom": {"$literal": custom},
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "direct": b"generic",
+            "literal": b"generic",
+            "custom": custom,
+        }
+    ]
+
+
+def test_remove_is_missing_except_inside_expression_arrays_or_literal():
+    collection = _collection("project-remove")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": 0,
+                    "name": 1,
+                    "secret": "$$REMOVE",
+                    "array": ["$$REMOVE"],
+                    "fallback": {"$ifNull": ["$$REMOVE", "fallback"]},
+                    "literal": {"$literal": "$$REMOVE"},
+                    "new.deep": "$$REMOVE",
+                    "arr.z": "$$REMOVE",
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "name": "Ada",
+            "array": [None],
+            "fallback": "fallback",
+            "literal": "$$REMOVE",
+            "new": {},
+            "arr": [{}, {}, {}],
+        }
+    ]
+
+
+def test_remove_field_references_also_resolve_to_missing():
+    collection = _collection("project-remove-field-reference")
+    collection.insert_one({"_id": 1, "gone": True, "nested": {"gone": True}})
+
+    assert collection.aggregate(
+        [
+            {
+                "$project": {
+                    "_id": 0,
+                    "gone": "$$REMOVE.foo",
+                    "holder.deep": "$$REMOVE.foo.bar",
+                    "array": ["$$REMOVE.0"],
+                }
+            }
+        ]
+    ).to_list() == [{"holder": {}, "array": [None]}]
+    assert collection.aggregate(
+        [{"$set": {"gone": "$$REMOVE.foo", "nested.gone": "$$REMOVE.0"}}]
+    ).to_list() == [{"_id": 1, "nested": {}}]
+
+
+def test_nested_arrays_are_not_recursively_crossed_by_field_references():
+    collection = _collection("project-nested-array-reference")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate(
+        [{"$project": {"_id": 0, "value": "$nested.a"}}]
+    ).to_list() == [{"value": []}]
+
+
+@pytest.mark.parametrize("stage_name", ["$set", "$addFields"])
+def test_set_and_addfields_are_aliases_and_use_the_original_input(stage_name):
+    collection = _collection("set-original-input")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "name": "Ada",
+            "gone": "remove me",
+            "nested": {"value": 3},
+        }
+    )
+
+    assert collection.aggregate(
+        [
+            {
+                stage_name: {
+                    "_id": 2,
+                    "name": "new",
+                    "previous": "$name",
+                    "old_id": "$_id",
+                    "nested_copy": "$nested.value",
+                    "gone": "$missing",
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "_id": 2,
+            "name": "new",
+            "nested": {"value": 3},
+            "previous": "Ada",
+            "old_id": 1,
+            "nested_copy": 3,
+        }
+    ]
+
+
+@pytest.mark.parametrize("stage_name", ["$set", "$addFields"])
+def test_set_and_addfields_accept_an_empty_noop(stage_name):
+    collection = _collection("set-empty")
+    document = {"_id": 1, "nested": {"value": 2}}
+    collection.insert_one(document)
+
+    assert collection.aggregate([{stage_name: {}}]).to_list() == [document]
+
+
+def test_set_writes_dotted_paths_through_objects_scalars_and_arrays():
+    collection = _collection("set-dotted")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate(
+        [
+            {
+                "$set": {
+                    "a.new": "$source",
+                    "arr.z": "$source",
+                    "scalar.z": "$source",
+                    "empty.z": "$source",
+                    "nested.z": "$source",
+                    "missing.z": "$missing",
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "secret": "hidden",
+            "source": 5,
+            "a": {"b": 2, "c": 3, "new": 5},
+            "arr": [
+                {"x": 1, "keep": "a", "z": 5},
+                {"y": 2, "z": 5},
+                {"z": 5},
+            ],
+            "scalar": {"z": 5},
+            "empty": [],
+            "nested": [[{"a": 1, "z": 5}], {"z": 5}],
+            "profile": {"email": "ada@example.com", "secret": "hidden"},
+            "missing": {},
+        }
+    ]
+
+
+def test_set_direct_engine_normalizes_tuple_containers_to_arrays():
+    document = {
+        "tuple_parent": ({"old": True}, 2),
+        "array": [({"old": True}, 2)],
+    }
+
+    assert AggregationEngine().run(
+        [document],
+        [{"$set": {"tuple_parent.new": 1, "array.new": 1}}],
+    ) == [
+        {
+            "tuple_parent": [{"old": True, "new": 1}, {"new": 1}],
+            "array": [[{"old": True, "new": 1}, {"new": 1}]],
+        }
+    ]
+    assert document == {
+        "tuple_parent": ({"old": True}, 2),
+        "array": [({"old": True}, 2)],
+    }
+
+
+def test_set_nested_specs_modify_paths_while_literal_replaces_whole_values():
+    collection = _collection("set-nested-spec")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "a": {"b": 2, "c": 3},
+            "whole": {"old": True},
+            "empty": {"old": True},
+        }
+    )
+
+    assert collection.aggregate(
+        [
+            {
+                "$set": {
+                    "a": {"b": 1},
+                    "whole": {"$literal": {"b": 1}},
+                    "empty": {},
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "_id": 1,
+            "a": {"b": 1, "c": 3},
+            "whole": {"b": 1},
+            "empty": {},
+        }
+    ]
+
+
+def test_set_remove_deletes_leaves_and_preserves_or_creates_containers():
+    collection = _collection("set-remove")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate(
+        [
+            {
+                "$set": {
+                    "secret": "$$REMOVE",
+                    "a.b": "$$REMOVE",
+                    "arr.x": "$$REMOVE",
+                    "scalar.z": "$$REMOVE",
+                    "new.deep": "$$REMOVE",
+                }
+            }
+        ]
+    ).to_list() == [
+        {
+            "_id": 1,
+            "name": "Ada",
+            "source": 5,
+            "a": {"c": 3},
+            "arr": [{"keep": "a"}, {"y": 2}, {}],
+            "scalar": {},
+            "empty": [],
+            "nested": [[{"a": 1}], 2],
+            "profile": {"email": "ada@example.com", "secret": "hidden"},
+            "new": {},
+        }
+    ]
+
+
+def test_unset_accepts_a_string_list_or_tuple_and_uses_exclusion_semantics():
+    collection = _collection("unset-valid")
+    collection.insert_one(_projection_document())
+
+    assert collection.aggregate([{"$unset": "secret"}]).to_list() == [
+        {key: value for key, value in _projection_document().items() if key != "secret"}
+    ]
+
+    expected = {
+        "name": "Ada",
+        "source": 5,
+        "a": {"b": 2, "c": 3},
+        "arr": [{"keep": "a"}, {"y": 2}, 3],
+        "scalar": 5,
+        "empty": [],
+        "nested": [[{"a": 1}], 2],
+        "profile": {"email": "ada@example.com"},
+    }
+    paths = ["_id", "secret", "profile.secret", "arr.x"]
+    assert collection.aggregate([{"$unset": paths}]).to_list() == [expected]
+    assert collection.aggregate([{"$unset": tuple(paths)}]).to_list() == [expected]
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "code"),
+    [
+        ([{"$project": {}}], 51272),
+        ([{"$project": []}], 15969),
+        ([{"$project": {"a": {}}}], 51270),
+        ([{"$project": {"a": {"": 1}}}], 40352),
+        ([{"$project": {"value": {"$ifNull": []}}}], 1257300),
+        ([{"$project": {"value": {"$size": []}}}], 16020),
+        ([{"$project": OrderedDict((("a", 0), ("copy", "$source")))}], 31310),
+        (
+            [{"$project": OrderedDict((("a", 0), ("copy", {"$literal": 1})))}],
+            31252,
+        ),
+        (
+            [{"$project": OrderedDict((("a", 0), ("copy", {"$ifNull": []})))}],
+            31252,
+        ),
+        ([{"$project": OrderedDict((("copy", "$source"), ("a", 0)))}], 31254),
+        ([{"$project": OrderedDict((("a", 0), ("name", 1)))}], 31253),
+        ([{"$project": OrderedDict((("a", 1), ("a.b", 1)))}], 31249),
+        ([{"$project": OrderedDict((("a.b", 1), ("a", 1)))}], 31250),
+        ([{"$set": OrderedDict((("a", 1), ("a.b", 2)))}], 40176),
+        ([{"$addFields": OrderedDict((("a.b", 2), ("a", 1)))}], 40176),
+        ([{"$set": []}], 40272),
+        ([{"$set": {"": 1}}], 40352),
+        ([{"$project": {"a.": 1}}], 40353),
+        ([{"$set": {"a.": 1}}], 40353),
+        ([{"$unset": "a."}], 40353),
+        ([{"$project": {"$bad": 1}}], 16410),
+        ([{"$unset": []}], 31119),
+        ([{"$unset": ""}], 40352),
+        ([{"$unset": ["", ""]}], 40352),
+        ([{"$unset": ["a.", "a."]}], 40353),
+        ([{"$unset": 1}], 31002),
+        ([{"$unset": ["a", 1]}], 31120),
+        ([{"$unset": ["a", "a"]}], 31250),
+        ([{"$unset": ["a", "a.b"]}], 31249),
+        ([{"$unset": ["a.b", "a"]}], 31250),
+    ],
+)
+def test_projection_stage_errors_match_mongodb_before_storage_read(pipeline, code):
+    client = tinymongo.TinyMongoClient(
+        "memory://projection-errors-{0}".format(uuid4().hex), backend="memory"
+    )
+    collection = client.db.items
+
+    with pytest.raises(OperationFailure) as caught:
+        collection.aggregate(pipeline)
+
+    assert caught.value.code == code
+    assert client.db.list_collection_names() == []
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "message"),
+    [
+        ([{"$project": {"value": {"$add": [1, 2]}}}], r"\$add"),
+        ([{"$set": {"arr.0": 1}}], "numeric array"),
+        ([{"$set": {"value": "$$ROOT"}}], r"\$\$ROOT"),
+        ([{"$addFields": {"value": "$$CURRENT"}}], r"\$\$CURRENT"),
+        ([{"$unset": "arr.0"}], "numeric array"),
+    ],
+)
+def test_projection_stage_unsupported_features_fail_before_storage_read(
+    pipeline, message
+):
+    client = tinymongo.TinyMongoClient(
+        "memory://projection-unsupported-{0}".format(uuid4().hex), backend="memory"
+    )
+
+    with pytest.raises(TinyMongoNotSupportedError, match=message):
+        client.db.items.aggregate(pipeline)
+
+    assert client.db.list_collection_names() == []
+
+
+@pytest.mark.parametrize(
+    ("reference", "code"),
+    [
+        ("$$REMOVE.", 40353),
+        ("$$REMOVE.foo.", 40353),
+        ("$$REMOVE..foo", 15998),
+        ("$$REMOVE.foo..bar", 15998),
+        ("$$REMOVE.$foo", 16410),
+    ],
+)
+def test_remove_field_reference_suffixes_are_validated(reference, code):
+    client = tinymongo.TinyMongoClient(
+        "memory://projection-remove-path-{0}".format(uuid4().hex), backend="memory"
+    )
+
+    with pytest.raises(OperationFailure) as caught:
+        client.db.items.aggregate([{"$project": {"value": reference}}])
+
+    assert caught.value.code == code
+    assert client.db.list_collection_names() == []
+
+
+def test_project_validates_paths_and_expressions_before_later_mode_conflicts():
+    client = tinymongo.TinyMongoClient(
+        "memory://projection-validation-order-{0}".format(uuid4().hex),
+        backend="memory",
+    )
+
+    with pytest.raises(OperationFailure) as invalid_path:
+        client.db.items.aggregate(
+            [{"$project": OrderedDict((("a.", 1), ("excluded", 0)))}]
+        )
+    assert invalid_path.value.code == 40353
+
+    with pytest.raises(OperationFailure, match=r"\$ifNull") as invalid_expression:
+        client.db.items.aggregate(
+            [{"$project": OrderedDict((("value", {"$ifNull": []}), ("excluded", 0)))}]
+        )
+    assert invalid_expression.value.code == 1257300
+    assert client.db.list_collection_names() == []
+
+
+@pytest.mark.parametrize("stage_name", ["$set", "$addFields"])
+def test_set_stage_requires_a_document_before_storage_read(stage_name):
+    client = tinymongo.TinyMongoClient(
+        "memory://set-invalid-{0}".format(uuid4().hex), backend="memory"
+    )
+
+    with pytest.raises(OperationFailure, match="document"):
+        client.db.items.aggregate([{stage_name: []}])
+
+    assert client.db.list_collection_names() == []
+
+
+def test_projection_stage_rejects_non_string_output_fields_before_read():
+    client = tinymongo.TinyMongoClient(
+        "memory://projection-non-string-{0}".format(uuid4().hex), backend="memory"
+    )
+
+    with pytest.raises(TypeError, match="field names"):
+        client.db.items.aggregate([{"$project": {1: 1}}])
+
+    assert client.db.list_collection_names() == []
+
+
+def test_async_projection_stages_smoke():
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            "memory://projection-stages-async-{0}".format(uuid4().hex),
+            backend="memory",
+        )
+        collection = client.db.items
+        await collection.insert_many(
+            [
+                {
+                    "_id": 1,
+                    "name": "Ada",
+                    "items": [1, 2],
+                    "obsolete": True,
+                },
+                {"_id": 2, "name": "Grace", "obsolete": True},
+            ]
+        )
+
+        cursor = await collection.aggregate(
+            [
+                {
+                    "$set": {
+                        "count": {"$size": {"$ifNull": ["$items", []]}},
+                        "copy": "$name",
+                    }
+                },
+                {
+                    "$addFields": {
+                        "literal": {"$literal": "$name"},
+                        "obsolete": "$$REMOVE",
+                    }
+                },
+                {"$unset": "items"},
+                {
+                    "$project": {
+                        "_id": 0,
+                        "name": 1,
+                        "copy": 1,
+                        "count": 1,
+                        "literal": 1,
+                    }
+                },
+            ]
+        )
+
+        assert isinstance(cursor, AsyncTinyMongoCursor)
+        assert await cursor.to_list() == [
+            {"name": "Ada", "copy": "Ada", "count": 2, "literal": "$name"},
+            {
+                "name": "Grace",
+                "copy": "Grace",
+                "count": 0,
+                "literal": "$name",
+            },
+        ]
+        await client.close()
+
+    asyncio.run(scenario())

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -64,6 +64,10 @@ def test_projection_inclusion_sequences_and_id_rules(collection):
         "name": "Ada",
     }
     assert collection.find_one({"_id": 1}, {"name": 2, "_id": 0}) == {"name": "Ada"}
+    assert project_document(
+        {"_id": 1, "name": "Ada", "secret": True},
+        normalize_projection({"name": 1, "_id": 0}),
+    ) == {"name": "Ada"}
     assert collection.find_one({"_id": 1}, {"_id": 1}) == {"_id": 1}
     assert collection.find_one({"_id": 1}, {"_id": 0}) == {
         "name": "Ada",

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -131,9 +131,16 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
     assert capabilities["backend"] == backend
     assert capabilities["persistent"] is True
     assert capabilities["aggregation"] == {
-        "stages": ("$match", "$project", "$group"),
+        "stages": (
+            "$match",
+            "$project",
+            "$set",
+            "$addFields",
+            "$unset",
+            "$group",
+        ),
         "accumulators": ("$max", "$min", "$sum"),
-        "expressions": ("$ifNull", "$size"),
+        "expressions": ("$ifNull", "$literal", "$size"),
     }
     assert capabilities["sessions"] is False
     assert client.supports("multiprocess_writes") is True

--- a/tinymongo/aggregation.py
+++ b/tinymongo/aggregation.py
@@ -1,10 +1,8 @@
 """Backend-independent aggregation pipeline execution.
 
-The production-driven slice intentionally stays small: ``$match``, ``$project``,
-and ``$group`` with the ``$ifNull`` and ``$size`` projection expressions and the
-``$min``, ``$max``, and ``$sum`` accumulators. Keeping the pipeline engine
-separate from storage lets every TinyMongo backend share validation, field-path,
-missing-value, and BSON comparison behavior.
+The supported slice stays deliberately smaller than MongoDB's full aggregation
+language. Keeping it separate from storage lets every TinyMongo backend share
+stage validation, field-path behavior, missing values, and BSON comparisons.
 """
 
 from __future__ import absolute_import
@@ -13,13 +11,22 @@ import copy
 from collections.abc import Mapping
 from numbers import Number
 
-from .bson_types import bson_value_identity_key, bson_value_sort_key
+from .bson_types import (
+    binary_components,
+    binary_type,
+    bson_value_identity_key,
+    bson_value_sort_key,
+)
 from .errors import OperationFailure, TinyMongoNotSupportedError
 from .projection import normalize_projection, project_document
 from .table_backends import matches_filter, validate_filter_operators
 
 
 _MISSING = object()
+_BINARY = binary_type()
+_PROJECT_LEAF = object()
+_PROJECT_INCLUDE = object()
+_PROJECT_COMPUTED = object()
 _ALLOWED_DOLLAR_PREFIXED_FIELDS = frozenset(
     (
         "$db",
@@ -33,8 +40,15 @@ _ALLOWED_DOLLAR_PREFIXED_FIELDS = frozenset(
     )
 )
 _SUPPORTED_ACCUMULATORS = ("$max", "$min", "$sum")
-_SUPPORTED_EXPRESSIONS = ("$ifNull", "$size")
-_SUPPORTED_STAGES = ("$match", "$project", "$group")
+_SUPPORTED_EXPRESSIONS = ("$ifNull", "$literal", "$size")
+_SUPPORTED_STAGES = (
+    "$match",
+    "$project",
+    "$set",
+    "$addFields",
+    "$unset",
+    "$group",
+)
 
 
 def _sum_value(value):
@@ -71,6 +85,12 @@ def _resolve_parts(value, parts):
     if isinstance(value, (list, tuple)):
         resolved = []
         for item in value:
+            # Field references traverse arrays of documents, but do not cross
+            # a raw array nested directly inside another array at the same
+            # path component. Projection output traversal has different rules
+            # and is handled by the stage-specific renderer below.
+            if not isinstance(item, Mapping):
+                continue
             candidate = _resolve_parts(item, parts)
             if candidate is not _MISSING:
                 resolved.append(candidate)
@@ -80,6 +100,198 @@ def _resolve_parts(value, parts):
         return resolved
 
     return _MISSING
+
+
+def _literal_value(value):
+    """Copy a ``$literal`` operand while normalizing BSON arrays to lists."""
+
+    if isinstance(value, Mapping):
+        return {key: _literal_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_literal_value(item) for item in value]
+    if _BINARY is not None and isinstance(value, _BINARY):
+        raw, subtype = binary_components(value)
+        if subtype == 0:
+            return raw
+    return copy.deepcopy(value)
+
+
+def _contains_dollar_operator(value):
+    return isinstance(value, Mapping) and any(str(key).startswith("$") for key in value)
+
+
+def _flatten_stage_specification(specification, project, prefix=None):
+    """Flatten MongoDB's nested projection syntax without losing order."""
+
+    flattened = []
+    for field, value in specification.items():
+        if not isinstance(field, str):
+            raise TypeError("projection field names must be strings")
+        if project and not field:
+            raise OperationFailure("Projection field names cannot be empty", code=40352)
+        path = ".".join(part for part in (prefix, field) if part is not None)
+        if isinstance(value, Mapping) and not _contains_dollar_operator(value):
+            if value:
+                flattened.extend(
+                    _flatten_stage_specification(value, project, prefix=path)
+                )
+                continue
+            if project:
+                raise OperationFailure(
+                    "An empty sub-projection is not a valid $project expression",
+                    code=51270,
+                )
+        if project and isinstance(value, Number):
+            flattened.append((path, "flag", bool(value)))
+        else:
+            flattened.append((path, "computed", copy.deepcopy(value)))
+    return flattened
+
+
+def _ensure_unique_paths(items):
+    seen = set()
+    for path, _kind, _value in items:
+        if path in seen:
+            raise OperationFailure("Path collision at {0}".format(path), code=31250)
+        seen.add(path)
+
+
+def _projection_shape(items):
+    return {path: (value if kind == "flag" else 1) for path, kind, value in items}
+
+
+def _validate_stage_paths(items, collision_code=None):
+    """Validate path syntax before duplicates, collisions, or stage modes."""
+
+    for path, _kind, _value in items:
+        if path.endswith("."):
+            raise OperationFailure(
+                "Aggregation output paths must not end with '.'", code=40353
+            )
+        if any(part.startswith("$") for part in path.split(".")):
+            raise OperationFailure(
+                "Aggregation output path components may not start with '$'",
+                code=16410,
+            )
+        normalize_projection({path: 1})
+
+    try:
+        _ensure_unique_paths(items)
+        normalize_projection({path: 1 for path, _kind, _value in items})
+    except OperationFailure as error:
+        if collision_code is not None and error.code in (31249, 31250):
+            raise OperationFailure(
+                "Conflicting paths in $set or $addFields", code=collision_code
+            )
+        raise
+
+
+def _add_project_path(tree, path, leaf):
+    node = tree
+    for part in path.split("."):
+        node = node.setdefault(part, {})
+    node[_PROJECT_LEAF] = leaf
+
+
+def _project_tree_has_computed(node):
+    leaf = node.get(_PROJECT_LEAF)
+    if leaf is not None:
+        return leaf[0] is _PROJECT_COMPUTED
+    return any(_project_tree_has_computed(child) for child in node.values())
+
+
+def _render_project_node(source, node, computed_values):
+    """Render one compiled inclusion/computed projection tree node."""
+
+    leaf = node.get(_PROJECT_LEAF)
+    if leaf is not None:
+        kind, path = leaf
+        value = source if kind is _PROJECT_INCLUDE else computed_values[path]
+        return _MISSING if value is _MISSING else copy.deepcopy(value)
+
+    if isinstance(source, Mapping):
+        result = {}
+        traversed = set()
+        for key, child_source in source.items():
+            child = node.get(key)
+            if child is None:
+                continue
+            leaf = child.get(_PROJECT_LEAF)
+            if leaf is not None and leaf[0] is _PROJECT_COMPUTED:
+                continue
+            traversed.add(key)
+            rendered = _render_project_node(child_source, child, computed_values)
+            if rendered is not _MISSING:
+                result[key] = rendered
+
+        # Direct computed fields do not retain their source position. MongoDB
+        # appends them in projection-spec order after every retained/traversed
+        # source field. Missing parents created by dotted computations append
+        # in that same second pass.
+        for key, child in node.items():
+            if key in traversed:
+                continue
+            rendered = _render_project_node(
+                source.get(key, _MISSING), child, computed_values
+            )
+            if rendered is not _MISSING:
+                result[key] = rendered
+        return result
+
+    if isinstance(source, (list, tuple)):
+        result = []
+        has_computed = _project_tree_has_computed(node)
+        for item in source:
+            if not has_computed and not isinstance(item, (Mapping, list, tuple)):
+                continue
+            rendered = _render_project_node(item, node, computed_values)
+            result.append(rendered)
+        return result
+
+    if not _project_tree_has_computed(node):
+        return _MISSING
+
+    # A computed descendant creates an object when its source parent is
+    # missing, null, or scalar. Missing leaves are omitted but the structural
+    # shell remains, matching MongoDB's dotted computed-output behavior.
+    result = {}
+    for key, child in node.items():
+        rendered = _render_project_node(_MISSING, child, computed_values)
+        if rendered is not _MISSING:
+            result[key] = rendered
+    return result
+
+
+def _assign_aggregation_path(container, parts, value):
+    """Apply one dotted add-fields assignment, broadcasting through arrays."""
+
+    if isinstance(container, list):
+        for index, item in enumerate(container):
+            if isinstance(item, tuple):
+                item = list(item)
+                container[index] = item
+            elif not isinstance(item, (Mapping, list)):
+                item = {}
+                container[index] = item
+            _assign_aggregation_path(item, parts, value)
+        return
+
+    field = parts[0]
+    if len(parts) == 1:
+        if value is _MISSING:
+            container.pop(field, None)
+        else:
+            container[field] = copy.deepcopy(value)
+        return
+
+    child = container.get(field, _MISSING)
+    if isinstance(child, tuple):
+        child = list(child)
+        container[field] = child
+    elif not isinstance(child, (Mapping, list)):
+        child = {}
+        container[field] = child
+    _assign_aggregation_path(child, parts[1:], value)
 
 
 class AggregationContext(object):
@@ -139,19 +351,32 @@ class AggregationContext(object):
     def _size_operand(operand):
         if isinstance(operand, (list, tuple)):
             if len(operand) != 1:
-                raise OperationFailure("$size requires exactly one expression")
+                raise OperationFailure(
+                    "$size requires exactly one expression", code=16020
+                )
             return operand[0]
         return operand
 
-    def validate_expression(self, expression, allowed_operators=()):
+    def _is_remove_reference(self, expression):
+        if expression == "$$REMOVE":
+            return True
+        if not isinstance(expression, str) or not expression.startswith("$$REMOVE."):
+            return False
+        suffix = expression[len("$$REMOVE.") :]
+        self.validate_field_path("$placeholder." + suffix)
+        return True
+
+    def validate_expression(self, expression, allowed_operators=(), allow_remove=False):
         """Reject unsupported expression operators before reading documents."""
 
+        if allow_remove and self._is_remove_reference(expression):
+            return
         if isinstance(expression, str) and expression.startswith("$"):
             self.validate_field_path(expression)
             return
         if isinstance(expression, (list, tuple)):
             for item in expression:
-                self.validate_expression(item, allowed_operators)
+                self.validate_expression(item, allowed_operators, allow_remove)
             return
         if isinstance(expression, Mapping):
             operator = self._expression_operator(expression)
@@ -163,34 +388,42 @@ class AggregationContext(object):
                         )
                     )
                 operand = expression[operator]
+                if operator == "$literal":
+                    return
                 if operator == "$ifNull":
                     if not isinstance(operand, (list, tuple)) or len(operand) < 2:
                         raise OperationFailure(
-                            "$ifNull requires at least two expressions"
+                            "$ifNull requires at least two expressions", code=1257300
                         )
                     for item in operand:
-                        self.validate_expression(item, allowed_operators)
+                        self.validate_expression(item, allowed_operators, allow_remove)
                     return
-                self.validate_expression(self._size_operand(operand), allowed_operators)
+                self.validate_expression(
+                    self._size_operand(operand), allowed_operators, allow_remove
+                )
                 return
             for value in expression.values():
-                self.validate_expression(value, allowed_operators)
+                self.validate_expression(value, allowed_operators, allow_remove)
 
     def resolve_field_path(self, document, expression):
         self.validate_field_path(expression)
         return _resolve_parts(document, expression[1:].split("."))
 
-    def evaluate(self, document, expression, allowed_operators=()):
+    def evaluate(self, document, expression, allowed_operators=(), allow_remove=False):
+        if allow_remove and self._is_remove_reference(expression):
+            return _MISSING
         if isinstance(expression, str) and expression.startswith("$"):
             return self.resolve_field_path(document, expression)
         if isinstance(expression, list):
             values = [
-                self.evaluate(document, item, allowed_operators) for item in expression
+                self.evaluate(document, item, allowed_operators, allow_remove)
+                for item in expression
             ]
             return [None if value is _MISSING else value for value in values]
         if isinstance(expression, tuple):
             values = [
-                self.evaluate(document, item, allowed_operators) for item in expression
+                self.evaluate(document, item, allowed_operators, allow_remove)
+                for item in expression
             ]
             return [None if value is _MISSING else value for value in values]
         if isinstance(expression, Mapping):
@@ -203,31 +436,42 @@ class AggregationContext(object):
                         )
                     )
                 operand = expression[operator]
+                if operator == "$literal":
+                    return _literal_value(operand)
                 if operator == "$ifNull":
                     if not isinstance(operand, (list, tuple)) or len(operand) < 2:
                         raise OperationFailure(
-                            "$ifNull requires at least two expressions"
+                            "$ifNull requires at least two expressions", code=1257300
                         )
                     for item in operand[:-1]:
-                        value = self.evaluate(document, item, allowed_operators)
+                        value = self.evaluate(
+                            document, item, allowed_operators, allow_remove
+                        )
                         if value is not _MISSING and value is not None:
                             return value
-                    return self.evaluate(document, operand[-1], allowed_operators)
+                    return self.evaluate(
+                        document, operand[-1], allowed_operators, allow_remove
+                    )
 
                 value = self.evaluate(
-                    document, self._size_operand(operand), allowed_operators
+                    document,
+                    self._size_operand(operand),
+                    allowed_operators,
+                    allow_remove,
                 )
                 if not isinstance(value, list):
-                    raise OperationFailure("$size requires an array input")
+                    raise OperationFailure("$size requires an array input", code=17124)
                 return len(value)
 
             result = {}
             for key, value in expression.items():
-                evaluated = self.evaluate(document, value, allowed_operators)
+                evaluated = self.evaluate(
+                    document, value, allowed_operators, allow_remove
+                )
                 if evaluated is not _MISSING:
                     result[key] = evaluated
             return result
-        return copy.deepcopy(expression)
+        return _literal_value(expression)
 
 
 class AggregationEngine(object):
@@ -238,6 +482,9 @@ class AggregationEngine(object):
         self.stage_registry = {
             "$match": (self._validate_match, self._match),
             "$project": (self._validate_project, self._project),
+            "$set": (self._validate_add_fields, self._add_fields),
+            "$addFields": (self._validate_add_fields, self._add_fields),
+            "$unset": (self._validate_unset, self._unset),
             "$group": (self._validate_group, self._group),
         }
 
@@ -302,71 +549,151 @@ class AggregationEngine(object):
             if matches_filter(document, specification)
         )
 
-    @staticmethod
-    def _is_projection_flag(value):
-        return isinstance(value, Number) or (
-            isinstance(value, Mapping)
-            and not any(str(key).startswith("$") for key in value)
-        )
-
-    @classmethod
-    def _has_non_id_exclusion(cls, specification, prefix=""):
-        for field, value in specification.items():
-            path = ".".join(part for part in (prefix, str(field)) if part)
-            if isinstance(value, Mapping) and not any(
-                str(key).startswith("$") for key in value
-            ):
-                if cls._has_non_id_exclusion(value, path):
-                    return True
-            elif isinstance(value, Number) and not bool(value) and path != "_id":
-                return True
-        return False
-
     def _validate_project(self, specification):
-        if not isinstance(specification, Mapping) or not specification:
-            raise OperationFailure("$project stage must contain a non-empty document")
-
-        if self._has_non_id_exclusion(specification):
-            raise TinyMongoNotSupportedError(
-                "$project exclusion of fields other than _id is not supported"
+        if not isinstance(specification, Mapping):
+            raise OperationFailure("$project stage must contain a document", code=15969)
+        if not specification:
+            raise OperationFailure(
+                "$project stage must contain a non-empty document", code=51272
             )
 
-        shape = {}
+        items = _flatten_stage_specification(specification, project=True)
+        _validate_stage_paths(items)
+
+        # MongoDB chooses the mixed-mode error from the order in which paths
+        # establish the projection mode. Exact _id flags remain the one special
+        # inclusion/exclusion exception.
+        mode = None
         computed = []
-        for output_field, expression in specification.items():
-            if self._is_projection_flag(expression):
-                shape[output_field] = copy.deepcopy(expression)
+        for path, kind, value in items:
+            if kind == "flag" and path == "_id":
                 continue
-            self.context.validate_expression(expression, _SUPPORTED_EXPRESSIONS)
-            shape[output_field] = 1
-            computed.append((output_field, copy.deepcopy(expression)))
+            if kind == "computed":
+                if mode == "exclude" and _contains_dollar_operator(value):
+                    raise OperationFailure(
+                        "Cannot use an expression in an exclusion projection",
+                        code=31252,
+                    )
+                self.context.validate_expression(
+                    value, _SUPPORTED_EXPRESSIONS, allow_remove=True
+                )
+                if mode == "exclude":
+                    raise OperationFailure(
+                        "Cannot use an expression in an exclusion projection",
+                        code=31310,
+                    )
+                mode = "include"
+                computed.append((path, value))
+                continue
+            candidate_mode = "include" if value else "exclude"
+            if mode is not None and mode != candidate_mode:
+                code = 31254 if mode == "include" else 31253
+                raise OperationFailure(
+                    "Cannot mix inclusion and exclusion in a projection", code=code
+                )
+            mode = candidate_mode
 
-        projection = normalize_projection(shape)
-        if any(
-            isinstance(output_field, str) and "." in output_field
-            for output_field, _expression in computed
+        projection = normalize_projection(_projection_shape(items))
+
+        if not computed:
+            return "basic", projection
+
+        tree = {}
+        if not any(
+            path == "_id" or path.startswith("_id.") for path, _kind, _value in items
         ):
-            raise TinyMongoNotSupportedError(
-                "$project computed dotted output paths are not supported"
-            )
-        return projection, tuple(computed)
+            _add_project_path(tree, "_id", (_PROJECT_INCLUDE, "_id"))
+        for path, kind, value in items:
+            if kind == "flag":
+                if not value:
+                    # In computed/inclusion mode only exact _id exclusion can
+                    # reach this branch; mixed non-id exclusions failed above.
+                    continue
+                leaf = (_PROJECT_INCLUDE, path)
+            else:
+                leaf = (_PROJECT_COMPUTED, path)
+            _add_project_path(tree, path, leaf)
+        return "computed", tree, tuple(computed)
 
     def _project(self, documents, prepared_project):
-        projection, computed = prepared_project
+        if prepared_project[0] == "basic":
+            projection = prepared_project[1]
+            return (project_document(document, projection) for document in documents)
+
+        _mode, tree, computed = prepared_project
 
         def project_one(document):
-            projected = project_document(document, projection)
-            for output_field, expression in computed:
-                value = self.context.evaluate(
-                    document, expression, _SUPPORTED_EXPRESSIONS
+            computed_values = {
+                path: self.context.evaluate(
+                    document,
+                    expression,
+                    _SUPPORTED_EXPRESSIONS,
+                    allow_remove=True,
                 )
-                if value is _MISSING:
-                    projected.pop(output_field, None)
-                else:
-                    projected[output_field] = copy.deepcopy(value)
-            return projected
+                for path, expression in computed
+            }
+            return _render_project_node(document, tree, computed_values)
 
         return (project_one(document) for document in documents)
+
+    def _validate_add_fields(self, specification):
+        if not isinstance(specification, Mapping):
+            raise OperationFailure(
+                "$set and $addFields stages must contain a document", code=40272
+            )
+
+        items = _flatten_stage_specification(specification, project=False)
+        _validate_stage_paths(items, collision_code=40176)
+
+        for _path, _kind, expression in items:
+            self.context.validate_expression(
+                expression, _SUPPORTED_EXPRESSIONS, allow_remove=True
+            )
+        return tuple((path, expression) for path, _kind, expression in items)
+
+    def _add_fields(self, documents, assignments):
+        def add_fields_one(document):
+            evaluated = [
+                (
+                    path,
+                    self.context.evaluate(
+                        document,
+                        expression,
+                        _SUPPORTED_EXPRESSIONS,
+                        allow_remove=True,
+                    ),
+                )
+                for path, expression in assignments
+            ]
+            result = copy.deepcopy(document)
+            for path, value in evaluated:
+                _assign_aggregation_path(result, path.split("."), value)
+            return result
+
+        return (add_fields_one(document) for document in documents)
+
+    @staticmethod
+    def _validate_unset(specification):
+        if isinstance(specification, str):
+            paths = [specification]
+        elif isinstance(specification, (list, tuple)):
+            if not specification:
+                raise OperationFailure("$unset requires at least one field", code=31119)
+            if any(not isinstance(path, str) for path in specification):
+                raise OperationFailure("$unset field names must be strings", code=31120)
+            paths = list(specification)
+        else:
+            raise OperationFailure(
+                "$unset requires a string or an array of strings", code=31002
+            )
+
+        items = [(path, "flag", False) for path in paths]
+        _validate_stage_paths(items)
+        return normalize_projection({path: 0 for path in paths})
+
+    @staticmethod
+    def _unset(documents, projection):
+        return (project_document(document, projection) for document in documents)
 
     def _group(self, documents, prepared_group):
         group_expression, accumulators = prepared_group

--- a/tinymongo/projection.py
+++ b/tinymongo/projection.py
@@ -127,11 +127,12 @@ def _include_value(value, tree):
         return copy.deepcopy(value)
     if isinstance(value, dict):
         result = {}
-        for key, child_tree in tree.items():
-            if key in value:
-                child = _include_value(value[key], child_tree)
-                if child is not _OMIT:
-                    result[key] = child
+        for key, child_value in value.items():
+            if key not in tree:
+                continue
+            child = _include_value(child_value, tree[key])
+            if child is not _OMIT:
+                result[key] = child
         return result
     if isinstance(value, list):
         result = []
@@ -170,12 +171,13 @@ def project_document(document, projection):
         return result
 
     result = {}
-    if projection.include_id and "_id" in document and "_id" not in projection.tree:
-        result["_id"] = copy.deepcopy(document["_id"])
-    for key, tree in projection.tree.items():
-        if key not in document:
-            continue
-        value = _include_value(document[key], tree)
-        if value is not _OMIT:
-            result[key] = value
+    for key, value in document.items():
+        if key == "_id" and key not in projection.tree:
+            included = copy.deepcopy(value) if projection.include_id else _OMIT
+        elif key in projection.tree:
+            included = _include_value(value, projection.tree[key])
+        else:
+            included = _OMIT
+        if included is not _OMIT:
+            result[key] = included
     return result


### PR DESCRIPTION
## Summary

This completes the original scope of #97: `$project`, `$set`, `$addFields`, and `$unset`. It expands the shared aggregation engine without widening into the separately tracked advanced array or expression work.

Closes #97.

## What changed

- Completed `$project` inclusion, exclusion, renamed, and computed modes within the documented expression subset.
- Added `$set` and `$addFields` as equivalent stages.
- Added `$unset` with string and nonempty field-list forms.
- Added `$literal` and the `$$REMOVE` system variable.
- Retained the existing `$ifNull` and `$size` expressions.
- Updated aggregation capability reporting to expose the exact supported set:
  - Stages: `$match`, `$project`, `$set`, `$addFields`, `$unset`, `$group`
  - Expressions: `$ifNull`, `$literal`, `$size`
  - Accumulators: `$min`, `$max`, `$sum`

## MongoDB compatibility details

`$project` now supports MongoDB-style inclusion, pure exclusion, computed values, renamed fields, nested specifications, dotted output paths, and special `_id` handling. Numeric and Boolean projection values remain projection flags; `$literal` is required when those values should be emitted as constants.

Dotted writes preserve object and array shape, broadcast through arrays, replace scalar intermediate values when MongoDB does, and retain empty arrays. Missing expressions and `$$REMOVE` follow MongoDB's omit/remove behavior, including the structural shells produced by dotted computed paths.

`$set` and `$addFields` retain the input document and evaluate every right-hand expression against the original stage input. This prevents one assignment in a stage from changing what a sibling assignment reads. Nested specifications modify nested paths, while `$literal` can deliberately replace a field with a complete literal document.

Projection output now preserves source BSON field order for retained fields and appends directly computed fields in specification order. This also preserves the field-order-sensitive identity of embedded documents used by later stages such as `$group`.

Field references no longer incorrectly descend through an array nested directly inside another array before reaching the requested field.

Validation covers mixed projection modes, exclusion mixed with computed fields, duplicate or conflicting parent/child paths, malformed specifications, unsupported variables, and invalid `$unset` input. Validation occurs before storage is read and raises MongoDB-shaped `OperationFailure` errors where applicable.

## API and backend coverage

The implementation remains in the shared backend-independent aggregation engine, so the behavior is available through both synchronous and asynchronous clients across JSON, memory, SQLite, DuckDB, Parquet, PostgreSQL, and MariaDB/MySQL backends.

The shared contracts exercise the new behavior against TinyMongo backends and a real MongoDB reference. Remote SQL integration coverage also runs representative `$project`, `$set`/`$addFields`, and `$unset` pipelines.

## Intentional boundaries

This PR does not add:

- `$replaceRoot` or `$replaceWith`
- Variables other than `$$REMOVE`
- `$setField` or `$unsetField`
- MongoDB's broader arithmetic, string, conditional, or array expression language
- Numeric array-index paths
- `$unwind` and the advanced array work tracked separately in #98

Unsupported features continue to raise `TinyMongoNotSupportedError` with the unsupported feature identified.

## Documentation

- Marked the initial #97 projection-stage scope complete in `ROADMAP.md`.
- Expanded the README aggregation section with supported behavior, async usage, and explicit boundaries.
- Added the new stages, expressions, contracts, ordering behavior, and nested-array field-path fix to the changelog.

## Verification

- Full test suite: **1,582 passed**
- Statement and branch coverage: **100%**
- New embedded-backend sync/async contracts: **70 passed**
- Live MongoDB 8 sync/async aggregation contracts: **38 passed**
- Randomized differential checks against MongoDB 8: **640 cases, zero mismatches**
- PostgreSQL 16.14 and MariaDB 11.4 sync/async integration: **4 passed**
- Python 3.14t free-threaded focused suite: **226 passed**
- Ruff, Black, and mypy: passed
- Package build and Twine metadata checks: passed

Related: #82
