### PR TITLE
Add $sort, $skip, $limit, and $count aggregation stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,15 @@
 ## [Unreleased]
 
 ### Added
-- A shared, backend-independent aggregation engine for `$match`, `$project`,
-  `$set`, `$addFields`, `$unset`, and `$group`, with `$ifNull`, `$literal`, and
-  `$size` projection expressions, `$$REMOVE`, field-path or null group keys,
-  and `$min`, `$max`, and `$sum` accumulators across synchronous and
-  asynchronous clients.
+- A shared, backend-independent aggregation engine for `$match`, `$sort`,
+  `$skip`, `$limit`, `$count`, `$project`, `$set`, `$addFields`, `$unset`, and
+  `$group`, with `$ifNull`, `$literal`, and `$size` projection expressions,
+  `$$REMOVE`, field-path or null group keys, and `$min`, `$max`, and `$sum`
+  accumulators across synchronous and asynchronous clients.
 - Cross-backend and real-MongoDB aggregation contracts based on production
   application pipelines, including full inclusion/exclusion and computed
-  projection modes, dotted array writes, BSON ordering, null/missing values,
-  empty inputs, and async cursor behavior.
+  projection modes, dotted array writes and sorts, BSON ordering, pagination,
+  counts, null/missing values, empty inputs, and async cursor behavior.
 
 ### Changed
 - Aggregation capability reporting now describes the exact supported stages,
@@ -23,6 +23,8 @@
   inside another array before reaching the requested field.
 - Aggregation projections preserve source BSON field order for retained fields
   and append directly computed fields in specification order.
+- Cursor and aggregation sorting now traverse dotted paths through multi-item
+  arrays consistently instead of treating those values as missing.
 
 ## [1.2.1] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -483,13 +483,13 @@ Broader BSON comparison across query ranges and indexes remains tracked in
 ## Aggregation core subset
 
 `Collection.aggregate()` supports the production-driven core of `$match`,
-`$project`, `$set`, `$addFields`, `$unset`, and `$group`. `$match` uses the same
-query operators as `find()`. `$project` supports inclusion, exclusion, renamed
-or computed fields, nested specifications, dotted output paths through arrays,
-and MongoDB's special `_id` rules. The available projection expressions are
-`$ifNull`, `$literal`, and `$size`; `$$REMOVE` conditionally omits or removes a
-field. `$group` accepts a field-path or `None` `_id` and the `$min`, `$max`, and
-`$sum` accumulators:
+`$sort`, `$skip`, `$limit`, `$count`, `$project`, `$set`, `$addFields`, `$unset`,
+and `$group`. `$match` uses the same query operators as `find()`. `$project`
+supports inclusion, exclusion, renamed or computed fields, nested
+specifications, dotted output paths through arrays, and MongoDB's special
+`_id` rules. The available projection expressions are `$ifNull`, `$literal`,
+and `$size`; `$$REMOVE` conditionally omits or removes a field. `$group` accepts
+a field-path or `None` `_id` and the `$min`, `$max`, and `$sum` accumulators:
 
 ```python
 activity = events.aggregate(
@@ -513,11 +513,20 @@ rows = activity.to_list()
 ```
 
 In the async API, await `aggregate()` to obtain an async cursor, then use
-`async for` or `await cursor.to_list()`. `$set` and `$addFields` are aliases that
-retain the input document, support nested and dotted array-aware writes, and
-evaluate every right-hand expression against the original stage input. `$unset`
-accepts one field name or a nonempty list of field names and follows exclusion
-projection behavior. Numeric array-index paths remain unsupported.
+`async for` or `await cursor.to_list()`. `$sort` accepts up to 32 ascending or
+descending keys and shares `find().sort()` field-path, array, and BSON ordering
+rules. `$skip` accepts a nonnegative 64-bit integer, `$limit` requires a positive
+64-bit integer, and `$count` emits one named count document—or no document for
+empty input. Integral floating-point values are accepted for sort directions,
+skip, and limit like MongoDB. Compound sorts preserve values from the same
+array element and reject independent parallel arrays; canonical numeric path
+parts select array indexes.
+
+`$set` and `$addFields` are aliases that retain the input document, support
+nested and dotted array-aware writes, and evaluate every right-hand expression
+against the original stage input. `$unset` accepts one field name or a nonempty
+list of field names and follows exclusion projection behavior. Numeric
+array-index paths remain unsupported for projection output.
 
 `$min` and `$max` ignore null and missing inputs unless every input is null or
 missing, in which case they return null. `$sum` ignores missing and nonnumeric
@@ -530,8 +539,8 @@ Other stages, accumulators, expressions, and aggregation options raise
 `client.capabilities()["aggregation"]` value lists the exact supported stages,
 accumulators, and expressions; `client.supports("aggregation")` reports whether
 any aggregation subset is available. In particular, `$replaceRoot`,
-`$replaceWith`, variables other than `$$REMOVE`, and MongoDB's broader expression
-language are not part of this slice yet.
+`$replaceWith`, `$meta` sort expressions, variables other than `$$REMOVE`, and
+MongoDB's broader expression language are not part of this slice yet.
 
 ## ObjectId, datetime, and binary values
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -176,9 +176,10 @@ Exit criteria:
   - [x] Land the first shared sync/async engine slice with pipeline validation,
     compatible cursors, structured capability reporting, and clear unsupported
     feature errors.
-- [ ] [#96: Basic aggregation stages](https://github.com/schapman1974/tinymongo/issues/96)
+- [x] [#96: Basic aggregation stages](https://github.com/schapman1974/tinymongo/issues/96)
   - [x] Implement `$match` through the existing query matcher.
-  - [ ] Add the remaining basic stages.
+  - [x] Add `$sort`, `$skip`, `$limit`, and `$count` through the shared
+    synchronous and asynchronous engine.
 - [x] [#97: Aggregation projection stages](https://github.com/schapman1974/tinymongo/issues/97)
   - [x] Add the application-required `$project`, `$size`, and `$ifNull` slice.
   - [x] Complete the initial projection scope with full `$project` modes,
@@ -358,6 +359,7 @@ Exit criteria:
    - [x] Deliver the shared `$match` plus `$group`/`$min`/`$max`/`$sum` slice
      across synchronous and asynchronous APIs.
    - [x] Add the measured `$project`/`$size`/`$ifNull` slice.
+   - [x] Complete the basic `$sort`, `$skip`, `$limit`, and `$count` stages.
    - [ ] Complete the second-application acceptance rerun with Mike.
 6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
    compatibility gaps.

--- a/tests/contracts/test_aggregation_basic_stages_contract.py
+++ b/tests/contracts/test_aggregation_basic_stages_contract.py
@@ -1,0 +1,378 @@
+"""Issue #96 contracts for basic non-transforming aggregation stages."""
+
+import pytest
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _ids(rows):
+    return [row["_id"] for row in rows]
+
+
+def test_sort_uses_mongodb_keys_for_missing_null_arrays_and_bson_types(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "missing"},
+            {"_id": "null", "value": None},
+            {"_id": "empty", "value": []},
+            {"_id": "array", "value": [9, 1, 5]},
+            {"_id": "number", "value": 2},
+            {"_id": "string", "value": "a"},
+            {"_id": "object", "value": {"score": 3}},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"value": 1, "_id": 1}}])) == [
+        "empty",
+        "missing",
+        "null",
+        "array",
+        "number",
+        "string",
+        "object",
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"value": -1, "_id": 1}}])) == [
+        "object",
+        "string",
+        "array",
+        "number",
+        "missing",
+        "null",
+        "empty",
+    ]
+
+
+def test_sort_traverses_dotted_array_paths_and_compounds_ties(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [{"score": 8}, {"score": 2}]},
+            {"_id": 2, "items": [{"score": 5}]},
+            {"_id": 3, "items": [{}]},
+            {"_id": 4},
+            {"_id": 5, "items": []},
+            {"_id": 6, "items": [{"score": [7, 1]}]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.score": 1, "_id": 1}}])) == [
+        3,
+        4,
+        5,
+        6,
+        1,
+        2,
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.score": -1, "_id": 1}}])) == [
+        1,
+        6,
+        2,
+        3,
+        4,
+        5,
+    ]
+
+
+def test_sort_numeric_path_segments_address_array_indexes(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [{"score": 9}, {"score": 1}]},
+            {"_id": 2, "items": [{"score": 2}, {"score": 8}]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.1.score": 1}}])) == [1, 2]
+    assert _ids(collection.aggregate([{"$sort": {"items.1.score": -1}}])) == [2, 1]
+
+
+def test_compound_numeric_sort_paths_can_select_separate_array_indexes(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [2, 1]},
+            {"_id": 2, "items": [1, 2]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.0": 1, "items.1": 1}}])) == [
+        2,
+        1,
+    ]
+
+
+def test_compound_numeric_sort_rejects_parallel_selected_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "items": [[2], [1]]})
+
+    outcome = observe(
+        lambda: list(collection.aggregate([{"$sort": {"items.0": 1, "items.1": 1}}]))
+    )
+
+    assert outcome.error == "operation_failure"
+
+
+def test_numeric_sort_path_compares_selected_array_as_a_whole_value(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "array", "items": [[2, 1]]},
+            {"_id": "object", "items": [{"value": 1}]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.0": 1}}])) == [
+        "object",
+        "array",
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.0": -1}}])) == [
+        "array",
+        "object",
+    ]
+
+
+def test_numeric_sort_path_keeps_empty_array_special_order(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "empty", "items": [[]]},
+            {"_id": "missing"},
+            {"_id": "null", "items": [None]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.0": 1, "_id": 1}}])) == [
+        "empty",
+        "missing",
+        "null",
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.0": -1, "_id": 1}}])) == [
+        "missing",
+        "null",
+        "empty",
+    ]
+
+
+def test_sort_rejects_ambiguous_numeric_array_paths(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "items": [{"0": 7}]})
+
+    outcome = observe(lambda: list(collection.aggregate([{"$sort": {"items.0": 1}}])))
+
+    assert outcome.error == "operation_failure"
+
+
+def test_sort_array_fanout_includes_missing_but_not_nested_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [{"score": 3}, {}]},
+            {"_id": 2, "items": [{"score": 2}]},
+            {"_id": 3, "items": [{"score": 4}]},
+            {"_id": 4, "items": [[{"score": 9}]]},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"items.score": 1, "_id": 1}}])) == [
+        1,
+        4,
+        2,
+        3,
+    ]
+    assert _ids(collection.aggregate([{"$sort": {"items.score": -1, "_id": 1}}])) == [
+        3,
+        1,
+        2,
+        4,
+    ]
+
+
+def test_compound_sort_preserves_shared_array_element_correlation(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "array",
+                "values": [{"x": 1, "y": 9}, {"x": 2, "y": 8}],
+            },
+            {"_id": "scalar", "values": {"x": 1, "y": 8.5}},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"values.x": 1, "values.y": 1}}])) == [
+        "scalar",
+        "array",
+    ]
+
+
+def test_compound_sort_rejects_parallel_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "first": [1, 2], "second": [3, 4]})
+
+    outcome = observe(
+        lambda: list(collection.aggregate([{"$sort": {"first": 1, "second": 1}}]))
+    )
+
+    assert outcome.error == "operation_failure"
+
+
+def test_compound_sort_allows_nested_arrays_in_separate_parent_elements(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "values": [
+                    {"x": [1], "y": 0},
+                    {"x": 0, "y": [1]},
+                ],
+            },
+            {"_id": 2},
+        ]
+    )
+
+    assert _ids(
+        collection.aggregate([{"$sort": {"values.x": 1, "values.y": 1, "_id": 1}}])
+    ) == [2, 1]
+
+
+def test_out_of_range_numeric_sort_path_fans_out_to_named_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "values": [{"9": 7}]},
+            {"_id": 2},
+        ]
+    )
+
+    assert _ids(collection.aggregate([{"$sort": {"values.9": 1, "_id": 1}}])) == [2, 1]
+
+
+@pytest.mark.parametrize("path", ["first.1", "first.9"])
+def test_compound_sort_rejects_numeric_path_parallel_arrays(contract_target, path):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "first": [1, 2], "second": [3]})
+
+    outcome = observe(
+        lambda: list(collection.aggregate([{"$sort": {path: 1, "second": 1}}]))
+    )
+
+    assert outcome.error == "operation_failure"
+
+
+def test_sort_skip_limit_and_count_compose_with_other_stages(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "keep": True, "score": 20},
+            {"_id": 2, "keep": False, "score": 100},
+            {"_id": 3, "keep": True, "score": 50},
+            {"_id": 4, "keep": True, "score": 50},
+            {"_id": 5, "keep": True, "score": 10},
+            {"_id": 6, "keep": True, "score": 30},
+        ]
+    )
+
+    page = list(
+        collection.aggregate(
+            [
+                {"$match": {"keep": True}},
+                {"$sort": {"score": -1, "_id": 1}},
+                {"$skip": 1},
+                {"$limit": 3},
+                {"$project": {"_id": 1, "score": 1}},
+            ]
+        )
+    )
+    assert page == [
+        {"_id": 4, "score": 50},
+        {"_id": 6, "score": 30},
+        {"_id": 1, "score": 20},
+    ]
+    assert list(
+        collection.aggregate(
+            [
+                {"$match": {"keep": True}},
+                {"$sort": {"score": -1, "_id": 1}},
+                {"$skip": 1},
+                {"$limit": 3},
+                {"$count": "selected"},
+                {"$set": {"label": "page"}},
+            ]
+        )
+    ) == [{"selected": 3, "label": "page"}]
+
+
+def test_integral_numeric_arguments_and_pagination_boundaries(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": value} for value in range(1, 5)])
+
+    assert _ids(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": -1.0}},
+                {"$skip": 1.0},
+                {"$limit": 2.0},
+            ]
+        )
+    ) == [3, 2]
+    assert list(collection.aggregate([{"$skip": 20}])) == []
+    assert _ids(collection.aggregate([{"$limit": 20}])) == [1, 2, 3, 4]
+
+
+def test_empty_input_stays_empty_and_count_emits_no_document(contract_target):
+    collection = contract_target.collection
+
+    assert (
+        list(
+            collection.aggregate(
+                [
+                    {"$sort": {"value": 1}},
+                    {"$skip": 0},
+                    {"$limit": 1},
+                ]
+            )
+        )
+        == []
+    )
+    assert list(collection.aggregate([{"$count": "total"}])) == []
+
+
+@pytest.mark.parametrize(
+    "stage",
+    [
+        {"$sort": None},
+        {"$sort": {}},
+        {"$sort": {"value": 0}},
+        {"$sort": {"value": True}},
+        {"$sort": {"value.": 1}},
+        {"$sort": {"field{0}".format(index): 1 for index in range(33)}},
+        {"$skip": -1},
+        {"$skip": 1.5},
+        {"$skip": True},
+        {"$limit": -1},
+        {"$limit": 0},
+        {"$limit": 1.5},
+        {"$limit": True},
+        {"$count": 1},
+        {"$count": ""},
+        {"$count": "$total"},
+        {"$count": "nested.total"},
+        {"$count": "bad\x00total"},
+        {"$count": "_id"},
+    ],
+)
+def test_basic_stage_validation_is_mongodb_shaped(contract_target, stage):
+    outcome = observe(lambda: list(contract_target.collection.aggregate([stage])))
+
+    assert outcome.error == "operation_failure"

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -156,6 +156,21 @@ def test_remote_sql_aggregation_core(backend, env_name):
                 "items": 2,
             }
         ]
+
+        assert docs.aggregate(
+            [
+                {"$sort": {"score": -1, "_id": 1}},
+                {"$skip": 1},
+                {"$limit": 1},
+                {"$project": {"_id": 1, "score": 1}},
+            ]
+        ).to_list() == [{"_id": 2, "score": 5}]
+        assert docs.aggregate(
+            [
+                {"$match": {"team": "alpha"}},
+                {"$count": "matched"},
+            ]
+        ).to_list() == [{"matched": 2}]
     finally:
         docs.drop()
         client.close()
@@ -203,6 +218,24 @@ def test_remote_sql_async_aggregation_projection(backend, env_name):
                 ]
             )
             assert await cursor.to_list() == [{"_id": "python", "total": 2}]
+
+            page = await docs.aggregate(
+                [
+                    {"$sort": {"_id": -1}},
+                    {"$skip": 1},
+                    {"$limit": 2},
+                    {"$project": {"_id": 1}},
+                ]
+            )
+            assert await page.to_list() == [{"_id": 3}, {"_id": 2}]
+
+            count = await docs.aggregate(
+                [
+                    {"$limit": 3},
+                    {"$count": "selected"},
+                ]
+            )
+            assert await count.to_list() == [{"selected": 3}]
         finally:
             await docs.drop()
             await client.close()

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -389,7 +389,6 @@ def test_project_validation_fails_before_storage_read(pipeline, error, message):
     ("pipeline", "message"),
     [
         ([{"$lookup": {}}], r"\$lookup"),
-        ([{"$sort": {"value": 1}}], r"\$sort"),
         ([{"$group": {"_id": "$key", "mean": {"$avg": "$value"}}}], r"\$avg"),
         ([{"$group": {"_id": "literal"}}], "field path or None"),
         ([{"$group": {"_id": "$$ROOT"}}], "field path or None"),
@@ -513,6 +512,10 @@ def test_capability_descriptions_are_fresh_and_supports_is_true():
     client = tinymongo.TinyMongoClient(backend="memory")
     assert second["stages"] == (
         "$match",
+        "$sort",
+        "$skip",
+        "$limit",
+        "$count",
         "$project",
         "$set",
         "$addFields",
@@ -522,6 +525,10 @@ def test_capability_descriptions_are_fresh_and_supports_is_true():
     assert second["expressions"] == ("$ifNull", "$literal", "$size")
     assert client.capabilities()["aggregation"]["stages"] == (
         "$match",
+        "$sort",
+        "$skip",
+        "$limit",
+        "$count",
         "$project",
         "$set",
         "$addFields",

--- a/tests/test_aggregation_basic_stages.py
+++ b/tests/test_aggregation_basic_stages.py
@@ -1,0 +1,268 @@
+"""Focused validation and edge tests for issue #96 aggregation stages."""
+
+import copy
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+import tinymongo
+from tinymongo.aggregation import AggregationEngine
+from tinymongo.errors import OperationFailure, TinyMongoNotSupportedError
+from tinymongo.sorting import bson_document_sort_value_key, document_sort_key
+
+
+def _collection(name="aggregation-basic-stages"):
+    return tinymongo.TinyMongoClient(
+        "memory://{0}-{1}".format(name, uuid4().hex), backend="memory"
+    ).db.items
+
+
+@pytest.mark.parametrize(
+    ("stage", "code"),
+    [
+        ({"$sort": None}, 15973),
+        ({"$sort": []}, 15973),
+        ({"$sort": {}}, 15976),
+        ({"$sort": {"value": True}}, 15974),
+        ({"$sort": {1: 1}}, 15974),
+        ({"$sort": {"value": 0}}, 15975),
+        ({"$sort": {"value": 2}}, 15975),
+        ({"$sort": {"": 1}}, 40352),
+        ({"$sort": {"value..nested": 1}}, 15998),
+        ({"$sort": {"value.": 1}}, 40353),
+        ({"$sort": {"$value": 1}}, 16410),
+        (
+            {"$sort": {"field{0}".format(index): 1 for index in range(33)}},
+            13103,
+        ),
+        ({"$skip": -1}, 5107200),
+        ({"$skip": 1.5}, 5107200),
+        ({"$skip": True}, 5107200),
+        ({"$skip": "1"}, 5107200),
+        ({"$skip": 2**63}, 5107200),
+        ({"$limit": -1}, 5107201),
+        ({"$limit": 0}, 15958),
+        ({"$limit": 1.5}, 5107201),
+        ({"$limit": True}, 5107201),
+        ({"$limit": "1"}, 5107201),
+        ({"$limit": 2**63}, 5107201),
+        ({"$count": 1}, 40156),
+        ({"$count": ""}, 40157),
+        ({"$count": "$total"}, 40158),
+        ({"$count": "nested.total"}, 40160),
+        ({"$count": "bad\x00total"}, 40159),
+        ({"$count": "_id"}, 15948),
+    ],
+)
+def test_invalid_stage_arguments_fail_before_collection_storage_is_opened(stage, code):
+    client = tinymongo.TinyMongoClient(
+        "memory://aggregation-basic-validation-{0}".format(uuid4().hex),
+        backend="memory",
+    )
+    collection = client.db.items
+
+    with pytest.raises(OperationFailure) as caught:
+        collection.aggregate([{"$match": {}}, stage])
+
+    assert caught.value.code == code
+    assert client.db.list_collection_names() == []
+
+
+def test_sort_meta_expression_is_rejected_before_collection_storage_is_opened():
+    client = tinymongo.TinyMongoClient(
+        "memory://aggregation-sort-meta-{0}".format(uuid4().hex),
+        backend="memory",
+    )
+    collection = client.db.items
+
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$sort \$meta"):
+        collection.aggregate([{"$sort": {"score": {"$meta": "textScore"}}}])
+
+    assert client.db.list_collection_names() == []
+
+
+def test_integral_numeric_arguments_are_normalized_without_mutating_pipeline():
+    collection = _collection("aggregation-basic-integral-numbers")
+    collection.insert_many([{"_id": value} for value in range(1, 5)])
+    pipeline = [
+        {"$sort": {"_id": -1.0}},
+        {"$skip": 1.0},
+        {"$limit": 2.0},
+    ]
+    original = copy.deepcopy(pipeline)
+
+    assert collection.aggregate(pipeline).to_list() == [{"_id": 3}, {"_id": 2}]
+    assert pipeline == original
+
+
+def test_skip_and_limit_accept_signed_64_bit_upper_bound():
+    collection = _collection("aggregation-basic-int64-bound")
+    collection.insert_many([{"_id": 1}, {"_id": 2}])
+    maximum = 2**63 - 1
+
+    assert collection.aggregate([{"$skip": maximum}]).to_list() == []
+    assert collection.aggregate([{"$limit": maximum}]).to_list() == [
+        {"_id": 1},
+        {"_id": 2},
+    ]
+
+
+def test_count_can_feed_later_stages_and_is_empty_on_empty_input():
+    collection = _collection("aggregation-basic-count")
+
+    assert collection.aggregate([{"$count": "total"}]).to_list() == []
+    collection.insert_many(
+        [
+            {"_id": 1, "keep": True},
+            {"_id": 2, "keep": False},
+            {"_id": 3, "keep": True},
+        ]
+    )
+
+    assert collection.aggregate(
+        [
+            {"$match": {"keep": True}},
+            {"$count": "total"},
+            {"$project": {"_id": 0, "total": 1}},
+        ]
+    ).to_list() == [{"total": 2}]
+
+
+def test_compound_sort_is_deterministic_and_does_not_mutate_documents():
+    collection = _collection("aggregation-basic-compound-sort")
+    documents = [
+        {"_id": 1, "team": "b", "score": 2, "nested": {"value": "one"}},
+        {"_id": 2, "team": "a", "score": 1, "nested": {"value": "two"}},
+        {"_id": 3, "team": "a", "score": 3, "nested": {"value": "three"}},
+        {"_id": 4, "team": "a", "score": 3, "nested": {"value": "four"}},
+    ]
+    collection.insert_many(copy.deepcopy(documents))
+
+    rows = collection.aggregate(
+        [{"$sort": {"team": 1, "score": -1, "_id": 1}}]
+    ).to_list()
+
+    assert [row["_id"] for row in rows] == [3, 4, 2, 1]
+    rows[0]["nested"]["value"] = "changed"
+    assert collection.find().sort("_id").to_list() == documents
+
+
+def test_sort_rejects_ambiguous_numeric_array_path_with_mongodb_code():
+    collection = _collection("aggregation-basic-ambiguous-array-index")
+    collection.insert_one({"_id": 1, "items": [{"0": 7}]})
+
+    with pytest.raises(OperationFailure) as caught:
+        collection.aggregate([{"$sort": {"items.0": 1}}])
+
+    assert caught.value.code == 16746
+
+
+def test_parallel_array_error_precedes_ambiguous_numeric_path_error():
+    collection = _collection("aggregation-basic-array-error-precedence")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "first": [{"0": -5}, {"0": None}],
+            "second": [2],
+        }
+    )
+
+    with pytest.raises(OperationFailure) as caught:
+        collection.aggregate([{"$sort": {"first.0": -1, "second": -1}}])
+
+    assert caught.value.code == 2
+
+
+def test_skip_and_limit_apply_at_their_pipeline_positions():
+    collection = _collection("aggregation-basic-pagination-order")
+    collection.insert_many(
+        [
+            {"_id": 1, "value": 30},
+            {"_id": 2, "value": 10},
+            {"_id": 3, "value": 40},
+            {"_id": 4, "value": 20},
+        ]
+    )
+
+    assert collection.aggregate(
+        [
+            {"$sort": {"value": 1}},
+            {"$skip": 1},
+            {"$limit": 2},
+            {"$sort": {"value": -1}},
+        ]
+    ).to_list() == [
+        {"_id": 1, "value": 30},
+        {"_id": 4, "value": 20},
+    ]
+
+
+def test_aggregation_sort_warns_once_for_each_unsupported_field_type():
+    engine = AggregationEngine()
+    documents = [
+        {"_id": 1, "published": date(2026, 1, 2)},
+        {"_id": 2, "published": date(2026, 1, 1)},
+    ]
+
+    with pytest.warns(tinymongo.TinyMongoUnsupportedWarning) as caught:
+        assert engine.run(documents, [{"$sort": {"published": 1}}]) == documents
+        assert engine.run(documents, [{"$sort": {"published": -1}}]) == documents
+
+    assert len(caught) == 1
+    assert "published" in str(caught[0].message)
+    assert "date" in str(caught[0].message)
+
+
+def test_shared_sort_helpers_cover_missing_scalar_and_array_path_edges():
+    assert bson_document_sort_value_key(object()) == (0, None)
+    assert document_sort_key({"item": 1}, "item.value") == (0, None)
+    assert document_sort_key({"items": [1]}, "items.9") == (0, None)
+    assert document_sort_key(
+        {"items": [{"score": 2}, {"score": 1}]}, "items.score"
+    ) == (1, (1, 1))
+    assert document_sort_key(
+        {"items": [{"score": 2}, {"score": 1}]},
+        "items.score",
+        descending=True,
+    ) == (1, (1, 2))
+
+
+def test_compound_sort_joins_large_shared_arrays_without_cartesian_work(monkeypatch):
+    collection = _collection("aggregation-basic-linear-multikey-sort")
+    collection.insert_one(
+        {
+            "_id": 1,
+            "values": [{"left": value, "right": 1000 - value} for value in range(1000)],
+        }
+    )
+    from tinymongo import sorting
+
+    calls = []
+    candidate_key = sorting._candidate_key
+
+    def counted_candidate_key(*args, **kwargs):
+        calls.append(None)
+        return candidate_key(*args, **kwargs)
+
+    monkeypatch.setattr(sorting, "_candidate_key", counted_candidate_key)
+
+    assert (
+        collection.aggregate(
+            [{"$sort": {"values.left": 1, "values.right": 1}}]
+        ).to_list()[0]["_id"]
+        == 1
+    )
+    assert len(calls) == 2000
+
+
+def test_cursor_order_compatibility_helper_warns_and_handles_sort_direction():
+    cursor = tinymongo.TinyMongoCursor([])
+
+    with pytest.warns(tinymongo.TinyMongoUnsupportedWarning):
+        assert cursor._order(object(), sort_field="value") == (0, None)
+
+    assert cursor._order([2, 1], is_reverse=False, sort_field="value") == (
+        1,
+        (1, 1),
+    )

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -133,6 +133,10 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
     assert capabilities["aggregation"] == {
         "stages": (
             "$match",
+            "$sort",
+            "$skip",
+            "$limit",
+            "$count",
             "$project",
             "$set",
             "$addFields",

--- a/tinymongo/aggregation.py
+++ b/tinymongo/aggregation.py
@@ -9,7 +9,10 @@ from __future__ import absolute_import
 
 import copy
 from collections.abc import Mapping
+from itertools import islice
+import math
 from numbers import Number
+import warnings
 
 from .bson_types import (
     binary_components,
@@ -18,7 +21,9 @@ from .bson_types import (
     bson_value_sort_key,
 )
 from .errors import OperationFailure, TinyMongoNotSupportedError
+from .indexes import TinyMongoUnsupportedWarning
 from .projection import normalize_projection, project_document
+from .sorting import sort_documents
 from .table_backends import matches_filter, validate_filter_operators
 
 
@@ -43,6 +48,10 @@ _SUPPORTED_ACCUMULATORS = ("$max", "$min", "$sum")
 _SUPPORTED_EXPRESSIONS = ("$ifNull", "$literal", "$size")
 _SUPPORTED_STAGES = (
     "$match",
+    "$sort",
+    "$skip",
+    "$limit",
+    "$count",
     "$project",
     "$set",
     "$addFields",
@@ -479,8 +488,13 @@ class AggregationEngine(object):
 
     def __init__(self):
         self.context = AggregationContext()
+        self._unsupported_sort_warnings = set()
         self.stage_registry = {
             "$match": (self._validate_match, self._match),
+            "$sort": (self._validate_sort, self._sort),
+            "$skip": (self._validate_skip, self._skip),
+            "$limit": (self._validate_limit, self._limit),
+            "$count": (self._validate_count, self._count),
             "$project": (self._validate_project, self._project),
             "$set": (self._validate_add_fields, self._add_fields),
             "$addFields": (self._validate_add_fields, self._add_fields),
@@ -548,6 +562,151 @@ class AggregationEngine(object):
             for document in documents
             if matches_filter(document, specification)
         )
+
+    def _validate_sort(self, specification):
+        if not isinstance(specification, Mapping):
+            raise OperationFailure(
+                "the $sort key specification must be an object", code=15973
+            )
+        if not specification:
+            raise OperationFailure(
+                "$sort stage must have at least one sort key", code=15976
+            )
+        if len(specification) > 32:
+            raise OperationFailure("too many compound keys", code=13103)
+
+        prepared = []
+        for field, direction in specification.items():
+            if not isinstance(field, str):
+                raise OperationFailure(
+                    "Illegal non-string key in $sort specification", code=15974
+                )
+            if not field:
+                raise OperationFailure(
+                    "FieldPath cannot be constructed with empty string", code=40352
+                )
+            if field.startswith("$"):
+                raise OperationFailure(
+                    "FieldPath field names may not start with '$'", code=16410
+                )
+            self.context.validate_field_path("$placeholder." + field)
+
+            if isinstance(direction, Mapping) and "$meta" in direction:
+                raise TinyMongoNotSupportedError(
+                    "Aggregation $sort $meta expressions are not supported by "
+                    "TinyMongo"
+                )
+            if isinstance(direction, bool) or not isinstance(direction, (int, float)):
+                raise OperationFailure(
+                    "Illegal key in $sort specification: {0}".format(field),
+                    code=15974,
+                )
+            if (
+                isinstance(direction, float) and not math.isfinite(direction)
+            ) or direction not in (-1, 1):
+                raise OperationFailure(
+                    "$sort key ordering must be 1 (for ascending) or -1 "
+                    "(for descending)",
+                    code=15975,
+                )
+            prepared.append((field, int(direction)))
+        return tuple(prepared)
+
+    def _warn_unsupported_sort_value(self, field, value):
+        warning_key = (field, type(value))
+        if warning_key in self._unsupported_sort_warnings:
+            return
+        self._unsupported_sort_warnings.add(warning_key)
+        warnings.warn(
+            "Sorting field '{0}' encountered unsupported value type '{1}'; "
+            "values of this type compare as null.".format(
+                field,
+                type(value).__name__,
+            ),
+            TinyMongoUnsupportedWarning,
+            stacklevel=4,
+        )
+
+    def _sort(self, documents, specification):
+        return sort_documents(
+            documents,
+            specification,
+            unsupported_value_callback=self._warn_unsupported_sort_value,
+        )
+
+    @staticmethod
+    def _validate_integral_stage_number(value, stage, code):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise OperationFailure(
+                "invalid argument to {0} stage: Expected a number".format(stage),
+                code=code,
+            )
+        if isinstance(value, float) and (
+            not math.isfinite(value) or not value.is_integer()
+        ):
+            raise OperationFailure(
+                "invalid argument to {0} stage: Expected an integer".format(stage),
+                code=code,
+            )
+
+        normalized = int(value)
+        if normalized < 0 or normalized > (2**63 - 1):
+            raise OperationFailure(
+                "invalid argument to {0} stage: Expected a non-negative "
+                "64-bit integer".format(stage),
+                code=code,
+            )
+        return normalized
+
+    @classmethod
+    def _validate_skip(cls, value):
+        return cls._validate_integral_stage_number(value, "$skip", 5107200)
+
+    @classmethod
+    def _validate_limit(cls, value):
+        normalized = cls._validate_integral_stage_number(value, "$limit", 5107201)
+        if normalized == 0:
+            raise OperationFailure("the limit must be positive", code=15958)
+        return normalized
+
+    @staticmethod
+    def _skip(documents, amount):
+        return islice(documents, amount, None)
+
+    @staticmethod
+    def _limit(documents, amount):
+        return islice(documents, amount)
+
+    @staticmethod
+    def _validate_count(field):
+        if not isinstance(field, str):
+            raise OperationFailure(
+                "the count field must be a non-empty string", code=40156
+            )
+        if not field:
+            raise OperationFailure(
+                "the count field must be a non-empty string", code=40157
+            )
+        if field.startswith("$"):
+            raise OperationFailure(
+                "the count field cannot be a $-prefixed path", code=40158
+            )
+        if "\x00" in field:
+            raise OperationFailure(
+                "the count field cannot contain a null byte", code=40159
+            )
+        if "." in field:
+            raise OperationFailure("the count field cannot contain '.'", code=40160)
+        if field == "_id":
+            raise OperationFailure(
+                "a group's fields must not include '_id'", code=15948
+            )
+        return field
+
+    @staticmethod
+    def _count(documents, field):
+        amount = sum(1 for _document in documents)
+        return [] if amount == 0 else [{field: amount}]
 
     def _validate_project(self, specification):
         if not isinstance(specification, Mapping):

--- a/tinymongo/sorting.py
+++ b/tinymongo/sorting.py
@@ -1,0 +1,376 @@
+"""Shared MongoDB-style document sorting helpers.
+
+Cursor sorting and aggregation ``$sort`` both use this module so BSON value
+ordering, dotted-path traversal, and array sort-key selection cannot drift.
+"""
+
+from __future__ import absolute_import
+
+from collections.abc import Mapping
+from functools import cmp_to_key
+
+from .bson_types import bson_value_sort_key
+from .errors import OperationFailure
+
+
+_MISSING_SORT_KEY = (0, None)
+_EMPTY_ARRAY_SORT_KEY = (-1, ())
+_MISSING = object()
+
+
+class _AmbiguousArrayField(object):
+    """Defer numeric-path errors until parallel-array checks have run."""
+
+    def __init__(self, field):
+        self.field = field
+
+
+def _plain_bson_sort_key(value, sort_field, unsupported_value_callback):
+    value_key = bson_value_sort_key(value)
+    if value_key is None:
+        if unsupported_value_callback is not None and sort_field is not None:
+            unsupported_value_callback(sort_field, value)
+        return _MISSING_SORT_KEY
+    return value_key
+
+
+def bson_document_sort_value_key(
+    value,
+    descending=False,
+    sort_field=None,
+    unsupported_value_callback=None,
+):
+    """Return the BSON key used when ``value`` is a document sort value.
+
+    MongoDB compares an array-valued sort field by its smallest member for an
+    ascending sort and its largest member for a descending sort. Empty arrays
+    sort before missing/null in ascending order and after them in descending
+    order. Unsupported values retain TinyMongo's established null-like order
+    and can be reported by the caller.
+    """
+
+    if isinstance(value, (list, tuple)):
+        member_keys = (
+            [
+                _plain_bson_sort_key(
+                    member,
+                    sort_field=sort_field,
+                    unsupported_value_callback=unsupported_value_callback,
+                )
+                for member in value
+            ]
+            if value
+            else [_EMPTY_ARRAY_SORT_KEY]
+        )
+        return max(member_keys) if descending else min(member_keys)
+
+    return _plain_bson_sort_key(value, sort_field, unsupported_value_callback)
+
+
+def _is_canonical_array_index(part):
+    return part == "0" or (
+        part
+        and part[0] in "123456789"
+        and all("0" <= character <= "9" for character in part)
+    )
+
+
+def _sort_path_candidates(
+    value,
+    parts,
+    traversed=(),
+    provenance=(),
+    array_sources=frozenset(),
+    positional_endpoint=False,
+):
+    """Return endpoint values plus the array elements that produced them."""
+
+    if not parts:
+        if isinstance(value, (list, tuple)):
+            array_sources = array_sources.union((".".join(traversed),))
+        return [(value, provenance, array_sources, positional_endpoint)]
+
+    if isinstance(value, Mapping):
+        field = parts[0]
+        if field not in value:
+            return [(_MISSING, provenance, array_sources, False)]
+        return _sort_path_candidates(
+            value[field],
+            parts[1:],
+            traversed + (field,),
+            provenance,
+            array_sources,
+            False,
+        )
+
+    if isinstance(value, (list, tuple)):
+        field = parts[0]
+        if _is_canonical_array_index(field):
+            index = int(field)
+            source = ".".join(traversed)
+            expanded_sources = array_sources.union((source,))
+            named_field_exists = any(
+                isinstance(member, Mapping) and field in member for member in value
+            )
+            if index < len(value) and named_field_exists:
+                return [
+                    (
+                        _AmbiguousArrayField(field),
+                        provenance,
+                        expanded_sources,
+                        False,
+                    )
+                ]
+            if index < len(value):
+                return _sort_path_candidates(
+                    value[index],
+                    parts[1:],
+                    traversed + (field,),
+                    provenance,
+                    expanded_sources,
+                    True,
+                )
+            if not named_field_exists:
+                return [(_MISSING, provenance, expanded_sources, False)]
+            # When the numeric index is out of range, MongoDB falls back to
+            # treating the component as a literal field name in each embedded
+            # array document. The ordinary fan-out path below provides that
+            # behavior.
+
+        source = ".".join(traversed)
+        expanded_sources = array_sources.union((source,))
+        if not value:
+            return [(_MISSING, provenance, expanded_sources, False)]
+        resolved = []
+        for index, member in enumerate(value):
+            member_provenance = provenance + ((source, index),)
+            # Field-path traversal fans out across arrays of documents, but a
+            # raw array nested directly inside another array is a boundary.
+            # Canonical numeric path components above can still select either
+            # array explicitly.
+            if isinstance(member, Mapping):
+                resolved.extend(
+                    _sort_path_candidates(
+                        member,
+                        parts,
+                        traversed,
+                        member_provenance,
+                        expanded_sources,
+                        False,
+                    )
+                )
+            else:
+                resolved.append((_MISSING, member_provenance, expanded_sources, False))
+        return resolved
+
+    return [(_MISSING, provenance, array_sources, False)]
+
+
+def _candidate_key(
+    candidate,
+    field,
+    descending,
+    unsupported_value_callback,
+):
+    value = candidate[0]
+    if value is _MISSING:
+        return _MISSING_SORT_KEY
+    if isinstance(value, _AmbiguousArrayField):
+        raise OperationFailure(
+            "Ambiguous field name found in array (do not use numeric "
+            "field names in embedded elements in an array), field: "
+            "'{0}'".format(value.field),
+            code=16746,
+        )
+    if candidate[3] and isinstance(value, (list, tuple)) and value:
+        return _plain_bson_sort_key(
+            value,
+            sort_field=field,
+            unsupported_value_callback=unsupported_value_callback,
+        )
+    return bson_document_sort_value_key(
+        value,
+        descending=descending,
+        sort_field=field,
+        unsupported_value_callback=unsupported_value_callback,
+    )
+
+
+def document_sort_key(
+    document,
+    field,
+    descending=False,
+    unsupported_value_callback=None,
+):
+    """Return one document's key for a field in a MongoDB sort specification."""
+
+    candidates = _sort_path_candidates(document, field.split("."))
+    keys = [
+        _candidate_key(
+            candidate,
+            field,
+            descending,
+            unsupported_value_callback,
+        )
+        for candidate in candidates
+    ]
+    return max(keys) if descending else min(keys)
+
+
+def _compare_compound_keys(left, right, sort_specification):
+    for index, (_field, direction) in enumerate(sort_specification):
+        if left[index] == right[index]:
+            continue
+        if left[index] < right[index]:
+            return -1 if direction > 0 else 1
+        return 1 if direction > 0 else -1
+    return 0
+
+
+def _sources_are_one_chain(sources):
+    def is_prefix(left, right):
+        return left == right or right.startswith(left + ".")
+
+    return all(
+        is_prefix(left, right) or is_prefix(right, left)
+        for left in sources
+        for right in sources
+    )
+
+
+def _candidate_lookup(candidates):
+    """Index candidates by array provenance for efficient compound joins."""
+
+    by_source = {}
+    for candidate_index, candidate in enumerate(candidates):
+        for source, index in candidate[1]:
+            by_source.setdefault(source, {}).setdefault(index, []).append(
+                candidate_index
+            )
+
+    all_indexes = tuple(range(len(candidates)))
+    without_source = {}
+    for source, groups in by_source.items():
+        with_source = {
+            candidate_index
+            for indexes in groups.values()
+            for candidate_index in indexes
+        }
+        without_source[source] = tuple(
+            candidate_index
+            for candidate_index in all_indexes
+            if candidate_index not in with_source
+        )
+    return candidates, by_source, without_source
+
+
+def _compatible_candidates(lookup, selected_provenance):
+    """Return candidates that can share array elements with selected values."""
+
+    candidates, by_source, without_source = lookup
+    shared_sources = [source for source in selected_provenance if source in by_source]
+    if not shared_sources:
+        return candidates
+
+    source = min(
+        shared_sources,
+        key=lambda item: len(by_source[item].get(selected_provenance[item], ()))
+        + len(without_source[item]),
+    )
+    candidate_indexes = (
+        tuple(by_source[source].get(selected_provenance[source], ()))
+        + without_source[source]
+    )
+    return [
+        candidates[candidate_index]
+        for candidate_index in candidate_indexes
+        if all(
+            selected_provenance.get(candidate_source, candidate_index_value)
+            == candidate_index_value
+            for candidate_source, candidate_index_value in candidates[candidate_index][
+                1
+            ]
+        )
+    ]
+
+
+def _compound_document_sort_key(
+    document,
+    sort_specification,
+    unsupported_value_callback,
+):
+    candidate_lookups = [
+        _candidate_lookup(_sort_path_candidates(document, field.split(".")))
+        for field, _direction in sort_specification
+    ]
+
+    # Build only combinations whose values came from the same element whenever
+    # fields fan out through a shared array. This preserves the compound key a
+    # real MongoDB multikey index would produce instead of independently taking
+    # each field's minimum or maximum.
+    combinations = [((), {}, frozenset())]
+    for candidate_lookup in candidate_lookups:
+        next_combinations = []
+        for selected_candidates, selected_provenance, selected_sources in combinations:
+            for candidate in _compatible_candidates(
+                candidate_lookup, selected_provenance
+            ):
+                candidate_provenance = dict(candidate[1])
+                merged_provenance = dict(selected_provenance)
+                merged_provenance.update(candidate_provenance)
+                merged_sources = selected_sources.union(candidate[2])
+                if not _sources_are_one_chain(merged_sources):
+                    raise OperationFailure(
+                        "cannot sort with keys that are parallel arrays", code=2
+                    )
+                next_combinations.append(
+                    (
+                        selected_candidates + (candidate,),
+                        merged_provenance,
+                        merged_sources,
+                    )
+                )
+        combinations = next_combinations
+
+    keys = [
+        tuple(
+            _candidate_key(
+                candidate,
+                field,
+                direction < 0,
+                unsupported_value_callback,
+            )
+            for candidate, (field, direction) in zip(
+                selected_candidates, sort_specification
+            )
+        )
+        for selected_candidates, _provenance, _sources in combinations
+    ]
+    selected = keys[0]
+    for candidate in keys[1:]:
+        if _compare_compound_keys(candidate, selected, sort_specification) < 0:
+            selected = candidate
+    return selected
+
+
+def sort_documents(documents, sort_specification, unsupported_value_callback=None):
+    """Return documents ordered by an already validated sort specification."""
+
+    specification = tuple(sort_specification)
+    keyed = [
+        (
+            document,
+            _compound_document_sort_key(
+                document,
+                specification,
+                unsupported_value_callback,
+            ),
+        )
+        for document in documents
+    ]
+    keyed.sort(
+        key=cmp_to_key(
+            lambda left, right: _compare_compound_keys(left[1], right[1], specification)
+        )
+    )
+    return [document for document, _key in keyed]

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -25,6 +25,7 @@ from .bson_types import (
     object_id_type,
 )
 from .aggregation import AggregationEngine, aggregation_capabilities
+from .sorting import bson_document_sort_value_key, sort_documents
 from .storage_backends import (
     clear_memory_database,
     clear_memory_namespace,
@@ -2808,22 +2809,19 @@ class TinyMongoCursor(object):
         into a sortable tuple.
         """
 
-        if isinstance(value, list) and is_reverse is not None:
-            members = (
-                [self._order(member, sort_field=sort_field) for member in value]
-                if value
-                else [(-1, ())]
-            )
-            # MongoDB compares an array sort field by its smallest element for
-            # ascending order and its largest element for descending order.
-            return max(members) if is_reverse else min(members)
-
-        value_key = bson_value_sort_key(value)
-        if value_key is None:
-            if sort_field is not None:
-                self._warn_unsupported_sort_value(sort_field, value)
-            return 0, None
-        return value_key
+        if is_reverse is None:
+            value_key = bson_value_sort_key(value)
+            if value_key is None:
+                if sort_field is not None:
+                    self._warn_unsupported_sort_value(sort_field, value)
+                return 0, None
+            return value_key
+        return bson_document_sort_value_key(
+            value,
+            descending=is_reverse,
+            sort_field=sort_field,
+            unsupported_value_callback=self._warn_unsupported_sort_value,
+        )
 
     def sort(self, key_or_list, direction=None):
         """
@@ -2879,91 +2877,11 @@ class TinyMongoCursor(object):
 
         self._sort_spec = (copy.deepcopy(key_or_list), direction)
 
-        # sorting
-
-        _cursordat = list(self._source_data)
-
-        total = len(_cursordat)
-        pre_sect_stack = list()
-        for pair in sort_specifier:
-
-            is_reverse = bool(1 - pair[1])
-            value_stack = list()
-            for index, data in enumerate(_cursordat):
-
-                # get field value
-
-                not_found = None
-                for key in pair[0].split("."):
-                    not_found = True
-
-                    if isinstance(data, dict) and key in data:
-                        data = copy.deepcopy(data[key])
-                        not_found = False
-
-                    elif isinstance(data, list):
-                        if not is_reverse and len(data) == 1:
-                            # MongoDB treat [{data}] as {data}
-                            # when finding fields
-                            if isinstance(data[0], dict) and key in data[0]:
-                                data = copy.deepcopy(data[0][key])
-                                not_found = False
-
-                        elif is_reverse:
-                            # MongoDB will keep finding field in reverse mode
-                            for _d in data:
-                                if isinstance(_d, dict) and key in _d:
-                                    data = copy.deepcopy(_d[key])
-                                    not_found = False
-                                    break
-
-                    if not_found:
-                        break
-
-                # parsing data for sorting
-
-                if not_found:
-                    # treat no match as None
-                    data = None
-
-                value = self._order(data, is_reverse, pair[0])
-
-                # read previous section
-                pre_sect = pre_sect_stack[index] if pre_sect_stack else 0
-                # inverse if in reverse mode
-                # for keeping order as ASCENDING after sort
-                pre_sect = (total - pre_sect) if is_reverse else pre_sect
-                _ind = (total - index) if is_reverse else index
-
-                value_stack.append((pre_sect, value, _ind))
-
-            # sorting cursor data
-
-            value_stack.sort(reverse=is_reverse)
-
-            ordereddat = list()
-            sect_stack = list()
-            sect_id = -1
-            last_dat = None
-            for dat in value_stack:
-                # restore if in reverse mode
-                _ind = (total - dat[-1]) if is_reverse else dat[-1]
-                ordereddat.append(_cursordat[_ind])
-
-                # define section
-                # maintain the sorting result in next level sorting
-                if not dat[1] == last_dat:
-                    sect_id += 1
-                sect_stack.append(sect_id)
-                last_dat = dat[1]
-
-            # save result for next level sorting
-            _cursordat = ordereddat
-            pre_sect_stack = sect_stack
-
-        # done
-
-        self._source_data = _cursordat
+        self._source_data = sort_documents(
+            self._source_data,
+            sort_specifier,
+            unsupported_value_callback=self._warn_unsupported_sort_value,
+        )
         self._refresh_view()
 
         return self


### PR DESCRIPTION
## Summary

This completes the basic aggregation-stage work tracked in #96 by adding `$sort`, `$skip`, `$limit`, and `$count` to the shared aggregation engine. These stages work through both synchronous and asynchronous clients across every TinyMongo backend.

The implementation also moves document sorting into a shared helper so `find().sort()` and aggregation `$sort` use the same BSON ordering, dotted-path traversal, and array behavior.

## What changed

- Added `$sort` with MongoDB-compatible validation and behavior for:
  - ascending and descending compound sorts
  - missing, null, empty-array, scalar, document, and array values
  - dotted paths through arrays
  - canonical numeric array-index paths
  - values correlated within the same array element
  - parallel-array and ambiguous numeric-field errors
  - the 32-key compound-sort limit
- Added lazy `$skip` and `$limit` stages with signed 64-bit integer validation.
- Added `$count`, including MongoDB's empty-input behavior of returning no document.
- Validated stage specifications before reading or processing pipeline documents.
- Kept `$meta` sorting explicit: TinyMongo raises a clear unsupported-feature error.
- Fixed existing cursor sorting for dotted paths through multi-item arrays.
- Updated capability reporting, README guidance, changelog notes, and `ROADMAP.md`.
- Added embedded, cross-backend, async, and live MongoDB contracts.

## Compatibility boundary

This PR does not expand `Decimal128` behavior. That broader BSON compatibility work, including Michael's recent `$sum` finding, remains tracked in #75.

## Validation

- 1,992 non-integration tests passed
- 100% statement and branch coverage:
  - 5,757 statements
  - 2,302 branches
- 411 focused issue #96 tests passed
- 74 live MongoDB sync and async contract checks passed
- 4 live PostgreSQL and MariaDB sync/async checks passed
- 2,600 randomized MongoDB differential cases completed with zero mismatches
- Ruff, Black, and mypy passed
- Package build and Twine package validation passed

Closes #96
