### PR TITLE
Add full Decimal128 support and Talk Python follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,22 @@
   application pipelines, including full inclusion/exclusion and computed
   projection modes, dotted array writes and sorts, BSON ordering, pagination,
   counts, null/missing values, empty inputs, and async cursor behavior.
+- MongoDB-style array updates for `$push` with `$each`, `$position`, `$sort`,
+  and `$slice`; `$addToSet` with `$each`; and literal, query, or document
+  operands for `$pull`, with atomic validation across sync and async backends.
+- Exact optional Decimal128 persistence plus numeric equality, range queries,
+  sorting, embedded unique indexes, `$inc`, and `$group` accumulators across
+  backends.
 
 ### Changed
 - Aggregation capability reporting now describes the exact supported stages,
   accumulators, and expressions instead of reporting a blanket unsupported
-  value.
+  value. The value therefore changed from falsey `False` to a truthy structured
+  mapping; use `client.supports("aggregation")` for a Boolean check or inspect
+  the mapping when selecting individual features.
+- Remote SQL unique indexes fail closed for Decimal128 values, as they already
+  do for arrays, when their native JSON constraints cannot guarantee exact
+  MongoDB numeric identity across concurrent writers.
 
 ### Fixed
 - Aggregation field references no longer cross a raw array nested directly
@@ -25,6 +36,27 @@
   and append directly computed fields in specification order.
 - Cursor and aggregation sorting now traverse dotted paths through multi-item
   arrays consistently instead of treating those values as missing.
+- Degraded index batches now reuse an existing equivalent effective index and
+  emit one warning instead of creating duplicate metadata or native work.
+- Direct equivalent index declarations under a different name now raise
+  MongoDB-compatible error code 85, while exact-name retries remain idempotent
+  for catalogs created by older releases.
+- Unsupported-feature warnings now retain the application call site across
+  synchronous calls and async executor threads.
+- Embedded unique indexes now use exact numeric identity across integers,
+  doubles, and Decimal128 values, including large exactly equivalent integers
+  and integral-looking doubles; SQLite attempts a one-time rebuild of legacy
+  expression indexes when upgrading the token format.
+- If that SQLite rebuild discovers values an older unique token incorrectly
+  treated as distinct, TinyMongo raises `DuplicateKeyError`, removes the unsafe
+  native expression constraint, and retains fail-closed catalog enforcement so
+  the conflicting row can be removed before the index is recreated.
+- Typed backend IDs now encode extreme Decimal128 ratios without relying on
+  Python's bounded decimal integer conversion.
+- Unsorted SQLite projections now shape and release documents during the row
+  scan, and `_id`-only sweeps avoid transferring unrequested JSON payloads into
+  Python. Sorted cursors retain their complete-document fallback so omitted
+  sort keys continue to order results correctly.
 
 ## [1.2.1] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ pip install "tinymongo==1.2.1"
 For development, clone this repository and run `pip install -e .` from its
 root. Use the `v1.2.1` tag when you need source and documentation that match
 the current stable package exactly; `master` may contain unreleased changes.
+This README follows `master`: the aggregation core, advanced array-update
+modifiers, and Decimal128 support described below were added after `v1.2.1`
+and are not part of the 1.2.1 package on PyPI. See
+[`CHANGELOG.md`](https://github.com/schapman1974/tinymongo/blob/master/CHANGELOG.md)
+for the complete unreleased list.
 
 The default JSON backend has a small dependency set. Optional database backends
 may install native binary wheels supplied by DuckDB, PyArrow, or SQL drivers.
@@ -227,10 +232,11 @@ pip install "tinymongo[serialization]"
 
 If an optional driver is missing, selecting that backend raises an `ImportError`
 with the corresponding installation command. PyMongo is not a core runtime
-dependency. It is selected at runtime for `ObjectId`, non-generic `Binary`
-subtypes, patching, and conditional PyMongo exception inheritance, and is also
-used by development compatibility tests. Install `tinymongo[bson]` for BSON
-values or `tinymongo[pymongo]` for patching and installed-version compatibility.
+dependency. It is selected at runtime for `ObjectId`, `Decimal128`, non-generic
+`Binary` subtypes, patching, and conditional PyMongo exception inheritance,
+and is also used by development compatibility tests. Install
+`tinymongo[bson]` for BSON values or `tinymongo[pymongo]` for patching and
+installed-version compatibility.
 
 ## Free-threaded Python 3.14
 
@@ -421,7 +427,9 @@ paths and array members across TinyMongo backends.
 Update support includes `$set`, `$unset`, `$inc`, `$push`, `$pull`, and
 `$addToSet`, including `upsert=True`. As in PyMongo, `update_one()` and
 `update_many()` require update operators; use `replace_one()` for full-document
-replacement.
+replacement. `$push` accepts `$each`, `$position`, `$sort`, and `$slice`;
+`$addToSet` accepts `$each`; and `$pull` accepts literal, query, and document
+operands.
 
 `find()` and `find_one()` accept Mongo-style inclusion and exclusion
 projections. Dotted paths project nested fields, `_id` follows MongoDB's special
@@ -436,6 +444,17 @@ Inclusion and exclusion cannot be mixed except for `_id`. Computed expressions,
 `$meta`, positional projection, and numeric array positions are rejected with a
 clear error. The second positional argument to `find()` is now the PyMongo-style
 projection argument; pass sorting as `sort=` or call `.sort()` on the cursor.
+For unsorted SQLite scans, TinyMongo applies a normalized projection as each row
+is read and releases the complete source document before reading the next row.
+The common `{"_id": 1}` sweep goes further and reads only each JSON `_id` value,
+so large unrequested payloads never enter Python memory. Filters still evaluate
+against complete source values when Python-side matching is required.
+
+This memory bound has explicit limits. Sorting must see unprojected sort keys,
+so a sorted SQLite cursor falls back to complete source documents before it
+projects the results. Other TinyMongo backends also continue to materialize
+complete matched documents before projection. Finally, exclusion projections
+that return most of each document naturally retain the size of those results.
 
 Collections expose durable indexes and unique constraints:
 
@@ -464,9 +483,10 @@ declaration is rejected before any batch entry is created.
 Unique indexes support scalar values and flat arrays on embedded backends;
 missing and `null` share one unique key. Object values, nested arrays,
 non-finite numbers, and array traversal inside a dotted index path are not
-supported for unique indexes yet. Remote SQL uses native constraints for scalar
-races. It rejects array values under unique indexes because its native indexes
-cannot yet guarantee cross-process multikey uniqueness.
+supported for unique indexes yet. Remote SQL uses native constraints for
+ordinary JSON scalar races. It rejects array and `Decimal128` values under
+unique indexes because its native JSON indexes cannot yet guarantee
+cross-process MongoDB multikey or exact numeric uniqueness.
 
 SQL, DuckDB, and Parquet storage uses typed physical `_id` keys for new rows.
 Existing databases with older stringified keys remain readable and mutable.
@@ -542,12 +562,12 @@ any aggregation subset is available. In particular, `$replaceRoot`,
 `$replaceWith`, `$meta` sort expressions, variables other than `$$REMOVE`, and
 MongoDB's broader expression language are not part of this slice yet.
 
-## ObjectId, datetime, and binary values
+## ObjectId, datetime, binary, and Decimal128 values
 
 `datetime` and `bytes` values round-trip through every backend. `bytearray` is
 accepted and reads back as `bytes`. Install the optional BSON extra to use
-`bson.ObjectId` or non-generic `bson.Binary` subtypes without making PyMongo a
-core dependency:
+`bson.ObjectId`, `bson.Decimal128`, or non-generic `bson.Binary` subtypes
+without making PyMongo a core dependency:
 
 ```bash
 pip install "tinymongo[bson]"
@@ -563,13 +583,14 @@ string and integer IDs remain readable and are never rewritten.
 
 ```python
 from datetime import datetime
-from bson import Binary, ObjectId
+from bson import Binary, Decimal128, ObjectId
 
 episode_id = ObjectId()
 episodes.insert_one(
     {
         "_id": episode_id,
         "created_date": datetime.now(),
+        "price": Decimal128("19.95"),
         "image": b"\x89PNG\r\n\x1a\n",
         "asset_id": Binary(bytes(range(16)), subtype=4),
         "title": "Async Python",
@@ -587,8 +608,8 @@ subtypes preserve `bson.Binary.subtype`. The exact two-key mapping shape using
 codec; new user mappings with that shape are escaped automatically. If an
 older database already contains that valid tag shape as ordinary data, whether
 written through an earlier API or edited manually, rename one of those keys
-before upgrading so it is not interpreted as the tagged value. UUID,
-Decimal128, and regular-expression round trips remain
+before upgrading so it is not interpreted as the tagged value. UUID and
+regular-expression round trips remain
 tracked in [#75](https://github.com/schapman1974/tinymongo/issues/75).
 Non-finite floats (`NaN`, positive infinity, and negative infinity) also use
 strict JSON-safe tags. Remote SQL keeps the encoded document as a normal,
@@ -602,6 +623,14 @@ BinData sorts by length, subtype, and then unsigned bytes, matching MongoDB.
 Numeric `NaN` sorts below every other numeric value, matching MongoDB.
 TinyMongo retains Python microseconds, so it can distinguish two datetimes that
 MongoDB would store in the same millisecond.
+
+Decimal128 values retain their exact BSON representation and participate in
+numeric equality and range queries, sorting, embedded-backend unique indexes,
+`$inc`, and the supported `$group` numeric accumulators. Remote SQL rejects
+Decimal128 values under unique indexes until its native constraints can enforce
+MongoDB-equivalent numeric identity across concurrent writers. Reading
+`Decimal128` requires the same optional BSON extra used to write it.
+
 When a sort encounters a genuinely unsupported value type, TinyMongo emits one
 `TinyMongoUnsupportedWarning` per field and type instead of silently returning
 insertion order.
@@ -659,13 +688,13 @@ follow the
 [Talk Python acceptance run](https://github.com/schapman1974/tinymongo/blob/master/docs/TALKPYTHON_ACCEPTANCE.md).
 
 PyMongo remains optional. It is needed for these comparisons,
-`tinymongo.patch()`, `ObjectId` support, and non-generic `Binary` subtypes, but
-it is not required for normal TinyMongo clients, `datetime` storage, or native
-subtype-0 byte values. When it is installed, TinyMongo error classes also
-inherit the matching `pymongo.errors` classes, so existing `PyMongoError`
-handlers continue to work. `InvalidDocument` additionally preserves BSON's
-standard error identity while remaining inside TinyMongo's portable error
-hierarchy.
+`tinymongo.patch()`, `ObjectId` and `Decimal128` support, and non-generic
+`Binary` subtypes, but it is not required for normal TinyMongo clients,
+`datetime` storage, or native subtype-0 byte values. When it is installed,
+TinyMongo error classes also inherit the matching `pymongo.errors` classes, so
+existing `PyMongoError` handlers continue to work. `InvalidDocument`
+additionally preserves BSON's standard error identity while remaining inside
+TinyMongo's portable error hierarchy.
 
 PyMongo's full upstream driver test suite targets a real MongoDB server and
 driver internals, so it is not expected to pass against TinyMongo. The contract
@@ -686,6 +715,14 @@ storage, multiprocess writes, native indexes, projections, bulk writes,
 aggregation, sessions, transactions, change streams, and installed BSON support.
 Unknown capability names raise `ValueError` so configuration mistakes are
 visible.
+
+For local persistent backends, `multiprocess_writes=True` promises safe writes,
+not parallel write throughput. TinyDB JSON, SQLite, and DuckDB clients sharing
+one storage folder serialize writes across databases and collections through a
+store-wide advisory lock. Parquet uses one lock per logical database directory.
+Lock acquisition waits for up to 30 seconds before timing out. SQLite uses WAL
+mode, so reads can continue while another process holds the write lock, but its
+writes remain serialized.
 
 Operations whose semantics TinyMongo cannot honor raise
 `TinyMongoNotSupportedError`. This includes sessions, transactions, change

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,6 +85,34 @@ with the follow-up audit of his
   migration reports, avoid unused nonlocal-storage directories, reject invalid
   backends eagerly with the complete alias list, and guard client metadata and
   listing methods after close.
+- [x] Complete Mike's second-application aggregation acceptance rerun: all 9 of
+  9 real application call sites pass against the current `master` aggregation
+  subset, including projection edge cases and computed-field stages.
+- [x] **TM-011:** Apply normalized projections during unsorted SQLite scans so
+  complete source rows are released one at a time, with an `_id`-only SQL path
+  that never transfers large unrequested payloads into Python. A deterministic
+  public sweep regression now verifies materially lower peak memory; Mike's
+  attached 400-document, 200,000-character reproduction dropped from 160.26 MB
+  to 0.26 MB locally. Sorted SQLite cursors and non-SQLite backends explicitly
+  retain the full-document fallback needed by their current ordering and scan
+  implementations. Mike's private 559-transcript rerun remains an external
+  acceptance check.
+- [x] **TM-001:** When a degraded index resolves to an effective key
+  specification that already exists, warn once and skip the duplicate native
+  index instead of creating redundant metadata or storage work.
+- [x] **TM-002:** Document that `tinymongo.patch()` replaces PyMongo module
+  attributes and therefore cannot replace client names imported before the
+  patch scope begins.
+- [x] **TM-012:** Document SQLite's measured multi-process behavior: writes are
+  safe but store-wide and serialized, use a 30-second lock timeout, and allow
+  concurrent WAL reads; describe the differing Parquet lock scope separately.
+- [x] **TM-005:** Preserve application-level caller attribution for warnings
+  emitted by synchronous work dispatched through the async executor.
+- [ ] **Remote SQL numeric uniqueness:** Persist canonical BSON numeric tokens
+  for remote unique indexes so native constraints can enforce exact
+  cross-process equality for every int/float representation; Decimal128
+  remains fail-closed there until the same token can be derived safely from its
+  BID representation.
 - [ ] Update Mike's agent guide against the `v1.2.1` tag and describe the
   expanded API as available from PyPI.
   Correct its list-only `insert_many()` signature
@@ -135,7 +163,8 @@ Application-compatibility work:
 - [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
 - [ ] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
   - [x] Milestone 1 ObjectId, datetime, and Binary storage/query support.
-  - [ ] Add UUID, Decimal128, and regular-expression round trips.
+  - [x] **TM-014:** Add Decimal128 round trips and numeric behavior.
+  - [ ] Add UUID and regular-expression round trips.
 - [ ] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
   - [x] Talk Python query slice: scalar-to-array equality, combined `$nin`,
     `$not`, `$regex`, case-insensitive `$options`, and Mongo-correct
@@ -360,7 +389,8 @@ Exit criteria:
      across synchronous and asynchronous APIs.
    - [x] Add the measured `$project`/`$size`/`$ifNull` slice.
    - [x] Complete the basic `$sort`, `$skip`, `$limit`, and `$count` stages.
-   - [ ] Complete the second-application acceptance rerun with Mike.
+   - [x] Complete the second-application acceptance rerun with Mike: all 9 of 9
+     real application aggregation call sites pass.
 6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
    compatibility gaps.
 7. [ ] Implement GridFS on stable BSON, index, and cursor foundations.

--- a/tests/contracts/test_decimal128_contract.py
+++ b/tests/contracts/test_decimal128_contract.py
@@ -1,0 +1,427 @@
+"""Decimal128 behavior shared by every API and storage target."""
+
+import pytest
+from tinymongo.bson_types import bson_identity_key
+from tinymongo.errors import TinyMongoNotSupportedError
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+bson = pytest.importorskip("bson")
+Decimal128 = bson.Decimal128
+
+
+def _ids(rows):
+    return {row["_id"] for row in rows}
+
+
+def test_decimal128_extreme_ids_round_trip(contract_target):
+    collection = contract_target.collection
+    high = Decimal128("1E+6144")
+    low = Decimal128("1E-6143")
+
+    collection.insert_many(
+        [
+            {"_id": high, "label": "high"},
+            {"_id": low, "label": "low"},
+        ]
+    )
+
+    assert collection.find_one({"_id": Decimal128.from_bid(high.bid)})["label"] == (
+        "high"
+    )
+    assert collection.find_one({"_id": Decimal128.from_bid(low.bid)})["label"] == (
+        "low"
+    )
+
+
+def test_decimal128_round_trips_and_participates_in_numeric_queries(contract_target):
+    collection = contract_target.collection
+    exact = Decimal128("0.1")
+    collection.insert_many(
+        [
+            {"_id": "negative", "amount": Decimal128("-2.5")},
+            {"_id": "integer", "amount": 1},
+            {"_id": "decimal-one", "amount": Decimal128("1.00")},
+            {"_id": "exact", "amount": exact},
+            {"_id": "double", "amount": 0.1},
+            {"_id": "high", "amount": Decimal128("3.75")},
+        ]
+    )
+
+    restored = collection.find_one({"_id": "exact"})["amount"]
+    assert isinstance(restored, Decimal128)
+    assert restored.bid == exact.bid
+    assert _ids(collection.find({"amount": Decimal128("1")})) == {
+        "integer",
+        "decimal-one",
+    }
+    assert _ids(collection.find({"amount": Decimal128("0.1")})) == {"exact"}
+    assert _ids(collection.find({"amount": 0.1})) == {"double"}
+    assert _ids(collection.find({"amount": {"$gt": Decimal128("1")}})) == {"high"}
+    assert _ids(collection.find({"amount": {"$gt": 1}})) == {"high"}
+    assert [
+        row["_id"]
+        for row in collection.find(
+            {"_id": {"$in": ["negative", "integer", "high"]}}
+        ).sort("amount", 1)
+    ] == ["negative", "integer", "high"]
+
+
+def test_decimal128_nan_query_comparisons_follow_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "nan", "amount": Decimal128("NaN")},
+            {"_id": "signaling", "amount": Decimal128("sNaN")},
+            {"_id": "one", "amount": 1},
+        ]
+    )
+
+    assert _ids(collection.find({"amount": Decimal128("NaN")})) == {
+        "nan",
+        "signaling",
+    }
+    assert _ids(collection.find({"amount": {"$gt": Decimal128("NaN")}})) == set()
+    assert _ids(collection.find({"amount": {"$lt": Decimal128("NaN")}})) == set()
+    assert _ids(collection.find({"amount": {"$gt": 1}})) == set()
+    assert _ids(collection.find({"amount": {"$gte": Decimal128("NaN")}})) == {
+        "nan",
+        "signaling",
+    }
+    assert _ids(collection.find({"amount": {"$lte": Decimal128("NaN")}})) == {
+        "nan",
+        "signaling",
+    }
+
+
+def test_decimal128_grouping_min_max_and_sum_use_one_numeric_family(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "first", "category": 1, "amount": Decimal128("1.00")},
+            {
+                "_id": "second",
+                "category": Decimal128("1.0"),
+                "amount": Decimal128("2.5"),
+            },
+            {"_id": "other", "category": 2, "amount": 4},
+        ]
+    )
+
+    rows = list(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": 1}},
+                {
+                    "$group": {
+                        "_id": "$category",
+                        "total": {"$sum": "$amount"},
+                        "minimum": {"$min": "$amount"},
+                        "maximum": {"$max": "$amount"},
+                        "count": {"$sum": 1},
+                    }
+                },
+                {"$sort": {"_id": 1}},
+            ]
+        )
+    )
+
+    assert rows == [
+        {
+            "_id": 1,
+            "total": Decimal128("3.50"),
+            "minimum": Decimal128("1.00"),
+            "maximum": Decimal128("2.5"),
+            "count": 2,
+        },
+        {"_id": 2, "total": 4, "minimum": 4, "maximum": 4, "count": 1},
+    ]
+
+
+def test_decimal128_min_max_ties_and_literal_sum_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "amount": Decimal128("1.00")},
+            {"_id": 2, "amount": 1},
+            {"_id": 3, "amount": 1.0},
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": 1}},
+                {
+                    "$group": {
+                        "_id": None,
+                        "minimum": {"$min": "$amount"},
+                        "maximum": {"$max": "$amount"},
+                        "literal_total": {"$sum": Decimal128("1.25")},
+                    }
+                },
+            ]
+        )
+    ) == [
+        {
+            "_id": None,
+            "minimum": 1.0,
+            "maximum": 1.0,
+            "literal_total": Decimal128("3.75"),
+        }
+    ]
+
+
+def test_decimal128_inc_promotes_the_result(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "balance", "amount": Decimal128("1.00")})
+
+    result = collection.update_one(
+        {"_id": "balance"}, {"$inc": {"amount": Decimal128("2.5")}}
+    )
+
+    assert result.matched_count == 1
+    assert result.modified_count == 1
+    assert collection.find_one({"_id": "balance"})["amount"] == Decimal128("3.50")
+
+    collection.update_one({"_id": "balance"}, {"$set": {"amount": Decimal128("2")}})
+    collection.update_one({"_id": "balance"}, {"$inc": {"amount": 0.1}})
+    assert collection.find_one({"_id": "balance"})["amount"] == Decimal128(
+        "2.100000000000000"
+    )
+
+
+def test_decimal128_representation_changes_are_persisted(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "value", "amount": 1})
+
+    first = collection.update_one(
+        {"_id": "value"}, {"$set": {"amount": Decimal128("1.0")}}
+    )
+    assert first.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("1.0").bid
+
+    second = collection.update_one(
+        {"_id": "value"}, {"$set": {"amount": Decimal128("1.00")}}
+    )
+    assert second.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("1.00").bid
+
+    unchanged = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("0.000")}}
+    )
+    assert unchanged.modified_count == 0
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("1.00").bid
+
+    collection.update_one({"_id": "value"}, {"$set": {"amount": Decimal128("2")}})
+    rounded_noop = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("1E-300")}}
+    )
+    assert rounded_noop.modified_count == 0
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("2").bid
+
+    collection.update_one({"_id": "value"}, {"$set": {"amount": Decimal128("sNaN")}})
+    quieted = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("0")}}
+    )
+    assert quieted.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("NaN").bid
+
+    quiet_nan = collection.update_one(
+        {"_id": "value"}, {"$inc": {"amount": Decimal128("0")}}
+    )
+    assert quiet_nan.modified_count == 1
+    assert collection.find_one({"_id": "value"})["amount"].bid == Decimal128("NaN").bid
+
+
+def test_decimal128_sum_keeps_double_precision_until_promotion(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "mixed": 0.1, "cancellation": 1e16},
+            {"_id": 2, "mixed": 0.2, "cancellation": 1.0},
+            {
+                "_id": 3,
+                "mixed": Decimal128("1"),
+                "cancellation": -1e16,
+            },
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "mixed": {"$sum": "$mixed"},
+                        "cancellation": {"$sum": "$cancellation"},
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": None,
+            "mixed": Decimal128("1.300000000000000016653345369377348"),
+            "cancellation": 0.0,
+        }
+    ]
+
+
+def test_decimal128_projection_flags_and_stage_arguments(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "rank": 1, "keep": "first", "remove": "x"},
+            {"_id": 2, "rank": 2, "keep": "second", "remove": "y"},
+            {"_id": 3, "rank": 3, "keep": "third", "remove": "z"},
+            {"_id": 4, "rank": 4, "keep": "fourth", "remove": "w"},
+        ]
+    )
+
+    projected = collection.find_one({"_id": 1}, {"remove": Decimal128("0")})
+    assert projected == {"_id": 1, "rank": 1, "keep": "first"}
+    assert list(
+        collection.aggregate(
+            [
+                {"$sort": {"rank": Decimal128("1")}},
+                {"$skip": Decimal128("1")},
+                {"$limit": Decimal128("2.0")},
+                {
+                    "$project": {
+                        "_id": Decimal128("0"),
+                        "keep": Decimal128("NaN"),
+                    }
+                },
+            ]
+        )
+    ) == [{"keep": "second"}, {"keep": "third"}]
+
+
+def test_decimal128_array_updates_and_distinct_reuse_numeric_identity(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "values",
+            "members": [1, Decimal128("3.0")],
+            "amount": 1,
+        }
+    )
+    collection.insert_many(
+        [
+            {"_id": "same", "amount": Decimal128("1.00")},
+            {"_id": "decimal", "amount": Decimal128("0.1")},
+            {"_id": "double", "amount": 0.1},
+        ]
+    )
+
+    collection.update_one(
+        {"_id": "values"},
+        {"$addToSet": {"members": {"$each": [Decimal128("1.0"), 2]}}},
+    )
+    collection.update_one(
+        {"_id": "values"},
+        {
+            "$push": {
+                "members": {
+                    "$each": [Decimal128("-1.5")],
+                    "$position": Decimal128("-1"),
+                    "$sort": Decimal128("1.0"),
+                    "$slice": Decimal128("4.0"),
+                }
+            }
+        },
+    )
+    assert collection.find_one({"_id": "values"})["members"] == [
+        Decimal128("-1.5"),
+        1,
+        2,
+        Decimal128("3.0"),
+    ]
+
+    collection.update_one(
+        {"_id": "values"},
+        {"$pull": {"members": {"$gte": Decimal128("2")}}},
+    )
+    assert collection.find_one({"_id": "values"})["members"] == [
+        Decimal128("-1.5"),
+        1,
+    ]
+
+    distinct = collection.distinct("amount")
+    assert {bson_identity_key(value) for value in distinct} == {
+        bson_identity_key(1),
+        bson_identity_key(Decimal128("0.1")),
+        bson_identity_key(0.1),
+    }
+
+
+def test_decimal128_numeric_identity_is_enforced_by_ids_and_unique_indexes(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 1, "amount": 1})
+
+    duplicate_id = observe(
+        lambda: collection.insert_one(
+            {"_id": Decimal128("1.0"), "amount": Decimal128("2")}
+        )
+    )
+    assert duplicate_id.error == "duplicate_key"
+
+    collection.create_index("amount", unique=True)
+    if contract_target.name in ("postgres", "postgresql", "mysql", "mariadb"):
+        with pytest.raises(TinyMongoNotSupportedError, match="Decimal128 values"):
+            collection.insert_one({"_id": "decimal-tenth", "amount": Decimal128("0.1")})
+        return
+
+    collection.insert_one({"_id": "decimal-tenth", "amount": Decimal128("0.1")})
+    collection.insert_one({"_id": "double-tenth", "amount": 0.1})
+    collection.insert_one(
+        {
+            "_id": "precision-a",
+            "amount": Decimal128("1.234567890123456789012345678901234"),
+        }
+    )
+    collection.insert_one(
+        {
+            "_id": "precision-b",
+            "amount": Decimal128("1.234567890123456789012345678901235"),
+        }
+    )
+    collection.insert_one({"_id": "large-decimal", "amount": Decimal128("1E+23")})
+    collection.insert_one({"_id": "large-double", "amount": 1e23})
+    exact_double = observe(
+        lambda: collection.insert_one(
+            {
+                "_id": "large-double-exact-decimal",
+                "amount": Decimal128(str(int(1e23))),
+            }
+        )
+    )
+    assert exact_double.error == "duplicate_key"
+    exact_integer = 2**60
+    collection.insert_one({"_id": "exact-integer", "amount": exact_integer})
+    for identifier, equivalent in (
+        ("exact-integer-double", float(exact_integer)),
+        ("exact-integer-decimal", Decimal128(str(exact_integer))),
+    ):
+        duplicate_integer = observe(
+            lambda identifier=identifier, equivalent=equivalent: collection.insert_one(
+                {"_id": identifier, "amount": equivalent}
+            )
+        )
+        assert duplicate_integer.error == "duplicate_key"
+    duplicate_value = observe(
+        lambda: collection.insert_one(
+            {"_id": "duplicate", "amount": Decimal128("1.00")}
+        )
+    )
+    assert duplicate_value.error == "duplicate_key"

--- a/tests/contracts/test_talkpython_contract.py
+++ b/tests/contracts/test_talkpython_contract.py
@@ -314,6 +314,9 @@ def test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique(
         warning_messages = [str(item.message) for item in captured]
         assert any("newest_show" in message for message in warning_messages)
         assert any("published_show_priority" in message for message in warning_messages)
+        assert any(
+            "existing index 'is_published'" in message for message in warning_messages
+        )
         assert any("api_key_lookup" in message for message in warning_messages)
         assert any("optional_slug" in message for message in warning_messages)
         assert any("expire_geo_lookup" in message for message in warning_messages)
@@ -322,15 +325,17 @@ def test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique(
         lambda: collection.insert_one({"_id": 2, "email": "mike@example.com"})
     )
 
-    assert set(created) == {
+    expected_created = {
         "newest_show",
         "is_published",
-        "published_show_priority",
         "api_key_lookup",
         "optional_slug",
         "email_unique",
         "expire_geo_lookup",
     }
+    if contract_target.name == "mongodb":
+        expected_created.add("published_show_priority")
+    assert set(created) == expected_created
     assert duplicate.error == "duplicate_key"
 
 

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -493,3 +493,26 @@ def test_remote_sql_native_index_catalog_and_unique_enforcement(backend, env_nam
         multikey.drop()
         scalar.drop()
         client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_decimal128_unique_values_fail_closed(backend, env_name):
+    bson = pytest.importorskip("bson")
+    dsn, database, prefix = _remote_target(backend, env_name)
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    protected = client[database][prefix + "_decimal_protected"]
+    existing = client[database][prefix + "_decimal_existing"]
+
+    try:
+        protected.create_index("value", unique=True)
+        protected.insert_one({"_id": 1, "value": 1})
+        with pytest.raises(TinyMongoNotSupportedError, match="Decimal128 values"):
+            protected.insert_one({"_id": 2, "value": bson.Decimal128("1.00")})
+
+        existing.insert_one({"_id": 1, "value": bson.Decimal128("2.00")})
+        with pytest.raises(TinyMongoNotSupportedError, match="Decimal128 values"):
+            existing.create_index("value", unique=True)
+    finally:
+        existing.drop()
+        protected.drop()
+        client.close()

--- a/tests/test_array_update_modifiers.py
+++ b/tests/test_array_update_modifiers.py
@@ -266,6 +266,13 @@ def test_invalid_updates_are_preflighted_and_atomic_even_without_a_match(tmp_pat
         )
     with pytest.raises(TinyMongoNotSupportedError, match="Unsupported update operator"):
         collection.update_one({"_id": "missing"}, {"$unknown": {"value": 1}})
+    with pytest.raises(WriteError, match="numeric values") as invalid_inc:
+        collection.update_one({"_id": "missing"}, {"$inc": {"value": "one"}})
+    assert invalid_inc.value.code == 14
+
+    with pytest.raises(WriteError, match="numeric values") as invalid_target:
+        collection.update_one({"_id": 1}, {"$inc": {"status": 1}})
+    assert invalid_target.value.code == 14
 
     assert collection.find_one({"_id": 1}) == original
     client.close()

--- a/tests/test_bson_codec.py
+++ b/tests/test_bson_codec.py
@@ -12,6 +12,7 @@ from tinymongo.errors import InvalidDocument, TinyMongoError
 bson = pytest.importorskip("bson")
 ObjectId = bson.ObjectId
 Binary = bson.Binary
+Decimal128 = bson.Decimal128
 
 
 def test_invalid_document_matches_tinymongo_bson_and_pymongo_hierarchies():
@@ -116,6 +117,51 @@ def test_codec_tags_are_valid_readable_json():
         "__tinymongo_type_v1__": "datetime",
         "value": document["created"].isoformat(),
     }
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        Decimal128("1234567890.00100"),
+        Decimal128("-0"),
+        Decimal128("NaN"),
+        Decimal128("sNaN"),
+        Decimal128("Infinity"),
+    ],
+)
+def test_codec_round_trips_exact_decimal128_bid_values(value):
+    encoded = bson_codec.encode_value(value)
+    restored = bson_codec.decode_value(encoded)
+
+    assert encoded == {
+        "__tinymongo_type_v1__": "decimal128",
+        "value": value.bid.hex(),
+    }
+    assert isinstance(restored, Decimal128)
+    assert restored.bid == value.bid
+
+
+def test_decimal128_decode_explains_optional_dependency(monkeypatch):
+    value = Decimal128("19.95")
+    encoded = {
+        "__tinymongo_type_v1__": "decimal128",
+        "value": value.bid.hex(),
+    }
+    monkeypatch.setattr(bson_codec, "_Decimal128", None)
+
+    assert bson_codec.bson_available() is False
+    with pytest.raises(ImportError, match=r"pip install 'tinymongo\[bson\]'"):
+        bson_codec.decode_value(encoded)
+
+
+@pytest.mark.parametrize("payload", [None, 1, "short", "z" * 32, "00" * 17])
+def test_codec_preserves_malformed_decimal128_tags(payload):
+    tagged = {
+        "__tinymongo_type_v1__": "decimal128",
+        "value": payload,
+    }
+
+    assert bson_codec.decode_value(tagged) == tagged
 
 
 def test_codec_loads_legacy_plain_json_without_changing_it():
@@ -280,6 +326,7 @@ def test_codec_preserves_malformed_binary_tags(payload):
         b"raw",
         bytearray(b"mutable"),
         Binary(bytes(range(16)), subtype=4),
+        Decimal128("12.50"),
         {"nested": [b"raw"]},
     ],
 )

--- a/tests/test_bson_registry_hardening.py
+++ b/tests/test_bson_registry_hardening.py
@@ -69,6 +69,7 @@ def test_registry_is_the_encoding_metadata_source():
     values = [
         (datetime(2026, 7, 29, 12, 30), "datetime"),
         (bson.ObjectId("000000000000000000000001"), "objectid"),
+        (bson.Decimal128("19.950"), "decimal128"),
         (b"native", "binary"),
         (bytearray(b"mutable"), "binary"),
         (uuid_binary, "binary"),
@@ -100,6 +101,12 @@ def test_binary_and_numeric_identity_keys_follow_bson_equality():
     assert bson_types.bson_values_equal(generic_binary, b"same") is True
     assert bson_types.bson_values_equal(uuid_binary, bytes(uuid_binary)) is False
     assert bson_types.bson_identity_key(1) == bson_types.bson_identity_key(1.0)
+    assert bson_types.bson_identity_key(1) == bson_types.bson_identity_key(
+        bson.Decimal128("1.00")
+    )
+    assert bson_types.bson_identity_key(0.1) != bson_types.bson_identity_key(
+        bson.Decimal128("0.1")
+    )
     assert bson_types.bson_values_equal(1, 1.0) is True
     assert bson_types.bson_values_equal(True, 1) is False
     assert bson_types.bson_identity_key(float("nan")) == bson_types.bson_identity_key(
@@ -108,9 +115,11 @@ def test_binary_and_numeric_identity_keys_follow_bson_equality():
 
 
 def test_numeric_sort_places_nan_below_all_other_numbers():
+    bson = pytest.importorskip("bson")
     values = [
         ("one", 1.0),
         ("nan", float("nan")),
+        ("decimal-nan", bson.Decimal128("NaN")),
         ("negative", -1.0),
         ("negative-infinity", float("-inf")),
         ("zero", 0.0),
@@ -125,6 +134,7 @@ def test_numeric_sort_places_nan_below_all_other_numbers():
         )
     ] == [
         "nan",
+        "decimal-nan",
         "negative-infinity",
         "negative",
         "zero",
@@ -269,10 +279,12 @@ def test_fresh_process_without_pymongo_keeps_core_codec_available():
         assert bson_types.bson_capabilities() == {
             "objectid": False,
             "binary": False,
+            "decimal128": False,
         }
         assert bson_codec.bson_available() is False
         assert bson_codec.object_id_available() is False
         assert bson_codec.binary_available() is False
+        assert bson_codec.decimal128_available() is False
         assert bson_codec.loads(bson_codec.dumps(b"core")) == b"core"
         assert issubclass(InvalidDocument, TinyMongoError)
 
@@ -285,6 +297,12 @@ def test_fresh_process_without_pymongo_keeps_core_codec_available():
         assert type(result.inserted_id) is str
         assert len(result.inserted_id) == 32
         assert client.core.items.find_one({"_id": result.inserted_id}) is not None
+
+        totals = client.core.totals
+        totals.insert_many([{"value": 0.1}, {"value": 0.2}])
+        assert totals.aggregate(
+            [{"$group": {"_id": None, "total": {"$sum": "$value"}}}]
+        ).to_list() == [{"_id": None, "total": 0.30000000000000004}]
         client.close()
 
         invalid_document = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,6 +154,7 @@ def test_cli_export_import_and_migrate_preserve_supported_bson_values(tmp_path, 
     document = {
         "_id": object_id,
         "created": created,
+        "price": bson.Decimal128("19.950"),
         "raw": b"\x00\x01\xff",
         "buffer": bytearray(b"mutable"),
         "binary": bson.Binary(b"0123456789abcdef", subtype=4),
@@ -177,6 +178,7 @@ def test_cli_export_import_and_migrate_preserve_supported_bson_values(tmp_path, 
     exported_json = json.loads(export_file.read_text(encoding="utf-8"))
     assert exported_json[0]["_id"]["__tinymongo_type_v1__"] == "objectid"
     assert exported_json[0]["created"]["__tinymongo_type_v1__"] == "datetime"
+    assert exported_json[0]["price"]["__tinymongo_type_v1__"] == "decimal128"
     assert exported_json[0]["raw"]["__tinymongo_type_v1__"] == "binary"
     assert exported_json[0]["binary"]["value"]["subtype"] == 4
 
@@ -199,6 +201,7 @@ def test_cli_export_import_and_migrate_preserve_supported_bson_values(tmp_path, 
     assert imported == {
         "_id": object_id,
         "created": created,
+        "price": bson.Decimal128("19.950"),
         "raw": b"\x00\x01\xff",
         "buffer": b"mutable",
         "binary": bson.Binary(b"0123456789abcdef", subtype=4),

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -19,6 +19,7 @@ from tinymongo.errors import (
     DuplicateKeyError,
     OperationFailure,
     TinyMongoNotSupportedError,
+    WriteError,
 )
 from tinymongo.results import (
     DeleteResult,
@@ -741,10 +742,12 @@ def test_update_operator_error_edges(tmp_path):
         c.update_one({"_id": 1}, {"$set": {"x": 1}, "plain": 2})
     with pytest.raises(ValueError, match="requires a dict"):
         c.update_one({"_id": 1}, {"$set": "not-a-dict"})
-    with pytest.raises(TypeError):
+    with pytest.raises(WriteError, match="\\$inc requires numeric values") as one:
         c.update_one({"_id": 1}, {"$inc": {"count": 1}})
-    with pytest.raises(TypeError):
+    assert one.value.code == 14
+    with pytest.raises(WriteError, match="\\$inc requires numeric values") as many:
         c.update_many({"_id": 1}, {"$inc": {"count": 1}})
+    assert many.value.code == 14
     with pytest.raises(TypeError):
         c.replace_one({"_id": 1}, object())
 

--- a/tests/test_decimal_coverage_edges.py
+++ b/tests/test_decimal_coverage_edges.py
@@ -1,0 +1,143 @@
+"""Focused branch coverage for Decimal128 numeric integration."""
+
+from decimal import Decimal
+import operator
+
+import pytest
+
+from tinymongo import aggregation
+from tinymongo import bson_types
+from tinymongo import indexes
+from tinymongo import table_backends
+from tinymongo import tinymongo as core
+from tinymongo.errors import TinyMongoNotSupportedError
+
+
+def test_sum_accumulator_falls_back_cleanly_without_decimal128(monkeypatch):
+    monkeypatch.setattr(aggregation, "_DECIMAL128", None)
+    accumulator = aggregation._SumAccumulator()
+
+    accumulator.add(7)
+    accumulator.add(0.5)
+    accumulator.add(0.25)
+
+    assert accumulator.value() == 7.75
+
+
+def test_bson_numeric_helpers_reject_invalid_values_and_missing_dependency(
+    monkeypatch,
+):
+    with pytest.raises(TypeError, match="Boolean values"):
+        bson_types.bson_number_decimal(True)
+    with pytest.raises(TypeError, match="Unsupported BSON numeric type"):
+        bson_types.bson_number_decimal(object())
+
+    assert bson_types._decimal128_update_operand(float("inf")) == Decimal("Infinity")
+    for left, right in (("not-a-number", 1), (1, "not-a-number")):
+        with pytest.raises(TypeError, match="requires two numeric values"):
+            bson_types.add_bson_numbers(left, right)
+
+    monkeypatch.setattr(bson_types, "_create_decimal128_context", None)
+    with pytest.raises(RuntimeError, match="optional pymongo package"):
+        bson_types.decimal128_context()
+
+    monkeypatch.setattr(bson_types, "_Decimal128", None)
+    with pytest.raises(RuntimeError, match="optional pymongo package"):
+        bson_types.decimal128_from_decimal(Decimal("1"))
+
+
+def test_decimal128_index_tokens_cover_zero_exact_double_and_nonfinite_values():
+    bson = pytest.importorskip("bson")
+
+    assert indexes.index_tokens({"value": bson.Decimal128("0.00")}, "value") == (
+        "number:0",
+    )
+    assert indexes.index_tokens({"value": bson.Decimal128("0.5")}, "value") == (
+        "number:0.5",
+    )
+    exact_integer = 2**60
+    assert (
+        indexes.index_tokens({"value": exact_integer}, "value")
+        == indexes.index_tokens({"value": float(exact_integer)}, "value")
+        == indexes.index_tokens({"value": bson.Decimal128(str(exact_integer))}, "value")
+    )
+    large_double = 1e23
+    double_token = indexes.index_tokens({"value": large_double}, "value")
+    assert (
+        indexes.index_tokens(
+            {"value": bson.Decimal128(str(int(large_double)))}, "value"
+        )
+        == double_token
+    )
+    assert indexes.index_tokens(
+        {"value": bson.Decimal128("1E+23")}, "value"
+    ) == indexes.index_tokens({"value": 10**23}, "value")
+    assert (
+        indexes.index_tokens({"value": bson.Decimal128("1E+23")}, "value")
+        != double_token
+    )
+    with pytest.raises(TinyMongoNotSupportedError, match="Non-finite numbers"):
+        indexes.index_tokens({"value": bson.Decimal128("Infinity")}, "value")
+
+
+def test_extreme_decimal128_ids_use_safe_exact_ratio_keys():
+    bson = pytest.importorskip("bson")
+    extreme = bson.Decimal128("1E+6144")
+
+    canonical = table_backends._canonical_id_value(extreme)
+    assert canonical[1][1][0] == table_backends._ID_RATIO_HEX_TAG
+    assert table_backends._physical_id_key(extreme) == table_backends._physical_id_key(
+        bson.Decimal128.from_bid(extreme.bid)
+    )
+    candidates = table_backends._physical_id_candidates(extreme)
+    assert candidates[0].startswith(table_backends._PHYSICAL_ID_PREFIX)
+    assert candidates[1].startswith(table_backends._PHYSICAL_ID_PREFIX)
+    assert candidates[0] != candidates[1]
+    legacy_integer = table_backends._legacy_stringified_id(10**600)
+    assert len(legacy_integer) == 601
+    assert legacy_integer.startswith("1")
+
+
+def test_comparison_helpers_reject_unsupported_operands_and_comparison_errors():
+    assert table_backends._comparison_matches(1, object(), operator.eq) is False
+
+    def invalid_comparison(_left, _right):
+        raise ValueError("cannot compare")
+
+    assert table_backends._comparison_matches(1, 1, invalid_comparison) is False
+    assert core._pull_comparison_matches([float("nan"), 0], 1, operator.lt) is True
+
+
+def test_tinydb_parser_and_writes_cover_native_non_numeric_query_routes(tmp_path):
+    client = core.TinyMongoClient(str(tmp_path / "db"))
+    collection = client.app.people
+    collection.insert_one(
+        {"_id": 1, "name": "Ada", "state": "ready", "score": "middle"}
+    )
+
+    combined = collection.parse_query({"name": "Ada", "state": "ready"})
+    assert combined is not None
+    for operator_query in (
+        {"score": {"$gte": "first"}},
+        {"score": {"$lte": "zulu"}},
+        {"score": {"$lt": "zulu"}},
+    ):
+        assert collection.parse_query(operator_query) is not None
+
+    updated = collection.update_one(
+        {"score": {"$gte": "first"}},
+        {"$set": {"seen": True}},
+    )
+    replaced = collection.replace_one(
+        {"state": {"$lt": "zulu"}},
+        {"name": "Grace", "state": "ready"},
+    )
+
+    assert updated.matched_count == 1
+    assert replaced.matched_count == 1
+    assert collection.find_one({"_id": 1}) == {
+        "_id": 1,
+        "name": "Grace",
+        "state": "ready",
+    }
+    client.close()

--- a/tests/test_durable_indexes.py
+++ b/tests/test_durable_indexes.py
@@ -14,6 +14,7 @@ from tinymongo.errors import (
     OperationFailure,
     TinyMongoNotSupportedError,
 )
+from tinymongo.indexes import INDEX_CATALOG_TABLE, IndexSpec
 from tinymongo.storage_backends import clear_memory_namespace
 
 
@@ -364,13 +365,136 @@ def test_index_creation_is_idempotent_and_rejects_conflicts(
         == "login_email"
     )
 
-    assert users.create_index("email", name="other_name", unique=True) == "other_name"
+    with pytest.raises(OperationFailure, match="different name") as different_name:
+        users.create_index("email", name="other_name", unique=True)
+    assert different_name.value.code == 85
     with pytest.raises(OperationFailure, match="different options"):
         users.create_index("username", name="login_email", unique=True)
     with pytest.raises(OperationFailure, match="different options"):
         users.create_index("email", name="login_email", unique=False)
 
-    assert set(_indexes_by_name(users)) == {"_id_", "login_email", "other_name"}
+    assert set(_indexes_by_name(users)) == {"_id_", "login_email"}
+
+
+def test_legacy_equivalent_index_catalog_keeps_named_retry_idempotent(tmp_path):
+    client = tinymongo.TinyMongoClient(str(tmp_path / "legacy-equivalent"))
+    users = client.app.users
+    users.create_index("email", name="first")
+    duplicate = IndexSpec("email", name="second")
+    users.parent.tinydb.table(INDEX_CATALOG_TABLE).insert(
+        users._index_document(duplicate)
+    )
+
+    assert users.create_index("email", name="second") == "second"
+
+
+def test_degraded_batch_reuses_equivalent_indexes_and_preserves_unique_options(
+    durable_index_backend,
+):
+    client = durable_index_backend.open()
+    users = client.app.users
+    users.create_index("created", name="created_lookup")
+
+    with pytest.warns(UserWarning) as captured:
+        names = users.create_indexes(
+            [
+                {"key": {"created": -1}, "name": "newest_created"},
+                {"key": {"created": "hashed"}, "name": "hashed_created"},
+                {
+                    "key": {"created": -1},
+                    "name": "unique_created",
+                    "unique": True,
+                },
+            ]
+        )
+
+    assert names == ["created_lookup", "created_lookup", "unique_created"]
+    assert len(captured) == 3
+    assert "descending direction" in str(captured[0].message)
+    assert "existing index 'created_lookup'" in str(captured[0].message)
+    assert "hashed indexing" in str(captured[1].message)
+    assert "existing index 'created_lookup'" in str(captured[1].message)
+    assert "reused" not in str(captured[2].message)
+    assert set(_indexes_by_name(users)) == {
+        "_id_",
+        "created_lookup",
+        "unique_created",
+    }
+
+
+def test_degraded_batch_reuses_an_earlier_batch_entry(durable_index_backend):
+    client = durable_index_backend.open()
+    users = client.app.users
+
+    with pytest.warns(UserWarning) as captured:
+        names = users.create_indexes(
+            [
+                {"key": {"score": -1}, "name": "score_desc"},
+                {"key": {"score": "hashed"}, "name": "score_hashed"},
+            ]
+        )
+
+    assert names == ["score_desc", "score_desc"]
+    assert len(captured) == 2
+    assert "reused" not in str(captured[0].message)
+    assert "existing index 'score_desc'" in str(captured[1].message)
+    assert set(_indexes_by_name(users)) == {"_id_", "score_desc"}
+
+
+def test_degraded_id_batch_reuses_the_builtin_index(durable_index_backend):
+    client = durable_index_backend.open()
+    users = client.app.users
+
+    with pytest.warns(UserWarning) as captured:
+        names = users.create_indexes(
+            [
+                {"key": {"_id": -1}, "name": "id_desc"},
+                {"key": {"_id": "hashed"}, "name": "id_hash"},
+            ]
+        )
+
+    assert names == ["_id_", "_id_"]
+    assert len(captured) == 2
+    assert "existing index '_id_'" in str(captured[1].message)
+    assert users.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+
+
+def test_concurrent_degraded_batches_plan_under_one_storage_lock(
+    durable_index_backend, monkeypatch
+):
+    client = durable_index_backend.open()
+    users = client.app.users
+    original = users._current_index_specs
+    start = threading.Barrier(2)
+    observation_lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+
+    def observed_specs():
+        nonlocal active, maximum_active
+        with observation_lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+        try:
+            time.sleep(0.03)
+            return original()
+        finally:
+            with observation_lock:
+                active -= 1
+
+    monkeypatch.setattr(users, "_current_index_specs", observed_specs)
+
+    def create(name):
+        start.wait()
+        return users.create_indexes([{"key": {"score": -1}, "name": name}])[0]
+
+    with pytest.warns(UserWarning):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            names = list(executor.map(create, ("score_first", "score_second")))
+
+    assert len(set(names)) == 1
+    assert maximum_active == 1
+    assert set(_indexes_by_name(users)) == {"_id_", names[0]}
 
 
 def test_builtin_id_index_has_fixed_options(durable_index_backend):

--- a/tests/test_index_models.py
+++ b/tests/test_index_models.py
@@ -7,7 +7,9 @@ from tinymongo.indexes import (
     IndexBatchPlan,
     IndexSpec,
     TinyMongoUnsupportedWarning,
+    degraded_index_reuse_warning,
     emit_index_plan_warnings,
+    index_spec_signature,
     plan_index_model,
     plan_index_models,
 )
@@ -62,6 +64,57 @@ def test_existing_index_spec_passes_through_unchanged():
     assert plan.name == "login"
     assert plan.requested_keys == (("email", 1),)
     assert plan.outcome == "create"
+
+
+def test_index_signature_uses_keys_and_unique_options_but_not_name():
+    assert index_spec_signature(IndexSpec("email", name="first")) == (
+        "email",
+        1,
+        False,
+    )
+    assert index_spec_signature(IndexSpec("email", name="second")) == (
+        "email",
+        1,
+        False,
+    )
+    assert index_spec_signature(IndexSpec("email", name="unique", unique=True)) == (
+        "email",
+        1,
+        True,
+    )
+
+    with pytest.raises(TypeError, match="IndexSpec"):
+        index_spec_signature("email")
+
+
+def test_degraded_reuse_warning_combines_degradation_and_existing_name():
+    plan = plan_index_model({"key": {"created": -1}, "name": "newest_created"})
+    warning = degraded_index_reuse_warning(
+        plan,
+        IndexSpec("created", name="created_lookup"),
+    )
+
+    assert "newest_created" in warning
+    assert "descending direction" in warning
+    assert "existing index 'created_lookup'" in warning
+    assert "reused" in warning
+
+
+def test_degraded_reuse_warning_rejects_invalid_or_inequivalent_inputs():
+    degraded = plan_index_model({"key": {"created": -1}})
+    skipped = plan_index_model({"key": {"body": "text"}})
+    ordinary = plan_index_model({"key": {"created": 1}})
+
+    with pytest.raises(TypeError, match="effective index plan"):
+        degraded_index_reuse_warning(object(), IndexSpec("created"))
+    with pytest.raises(TypeError, match="effective index plan"):
+        degraded_index_reuse_warning(skipped, IndexSpec("body"))
+    with pytest.raises(TypeError, match="existing IndexSpec"):
+        degraded_index_reuse_warning(degraded, object())
+    with pytest.raises(ValueError, match="Only degraded"):
+        degraded_index_reuse_warning(ordinary, IndexSpec("created"))
+    with pytest.raises(ValueError, match="equivalent"):
+        degraded_index_reuse_warning(degraded, IndexSpec("other"))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_projection_memory.py
+++ b/tests/test_projection_memory.py
@@ -1,0 +1,227 @@
+"""TM-011 projection-pushdown regressions for SQLite collection sweeps."""
+
+import asyncio
+import gc
+from types import SimpleNamespace
+import tracemalloc
+
+import tinymongo as tm
+from tinymongo.tinymongo import TinyMongoCollection
+
+
+def _sqlite_collection(tmp_path, name="items"):
+    client = tm.TinyMongoClient(
+        str(tmp_path),
+        backend="sqlite",
+    )
+    return client, client.app[name]
+
+
+def test_sqlite_projection_scan_preserves_filter_sort_and_nested_semantics(tmp_path):
+    client, collection = _sqlite_collection(tmp_path)
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "score": 2,
+                "profile": {"name": "Ada", "secret": "a"},
+                "tags": ["python", "db"],
+            },
+            {
+                "_id": 2,
+                "score": 3,
+                "profile": {"name": "Grace", "secret": "b"},
+                "tags": ["compiler"],
+            },
+            {
+                "_id": 3,
+                "score": 1,
+                "profile": {"name": "Lin", "secret": "c"},
+                "tags": ["python"],
+            },
+        ]
+    )
+
+    try:
+        collection.create_index("tags")
+        assert list(
+            collection.find(
+                {"tags": "python"},
+                {"profile.name": 1, "_id": 0},
+            )
+        ) == [{"profile": {"name": "Ada"}}, {"profile": {"name": "Lin"}}]
+
+        # Both cursor styles must order by the complete source document, even
+        # though ``score`` is absent from the returned projection.
+        expected = [
+            {"_id": 2, "profile": {"name": "Grace"}},
+            {"_id": 1, "profile": {"name": "Ada"}},
+            {"_id": 3, "profile": {"name": "Lin"}},
+        ]
+        assert (
+            list(collection.find({}, {"profile.name": 1}).sort("score", -1)) == expected
+        )
+        assert (
+            list(collection.find({}, {"profile.name": 1}, sort=[("score", -1)]))
+            == expected
+        )
+        assert list(
+            collection.find(
+                {"profile.name": "Ada"},
+                {"profile.name": 1, "_id": 0},
+            )
+        ) == [{"profile": {"name": "Ada"}}]
+        assert list(
+            collection.find(
+                {"profile": {"$exists": True}},
+                {"profile.name": 1, "_id": 0},
+            )
+        ) == [
+            {"profile": {"name": "Ada"}},
+            {"profile": {"name": "Grace"}},
+            {"profile": {"name": "Lin"}},
+        ]
+    finally:
+        client.close()
+
+
+def test_sqlite_id_only_projection_keeps_lossless_identifier_types(tmp_path):
+    client, collection = _sqlite_collection(tmp_path)
+    identifiers = [
+        None,
+        False,
+        True,
+        1.25,
+        "text-id",
+        2**80,
+        b"binary-id",
+        {"nested": 1},
+        [1, "two"],
+    ]
+    collection.insert_many(
+        [{"_id": identifier, "payload": "large"} for identifier in identifiers]
+    )
+
+    try:
+        assert list(collection.find({}, {"_id": 1})) == [
+            {"_id": identifier} for identifier in identifiers
+        ]
+        assert collection.find_one(
+            {"_id": [1, "two"]},
+            {"payload": 1, "_id": 0},
+        ) == {"payload": "large"}
+        assert (
+            list(
+                collection.find(
+                    {"_id": ["missing"]},
+                    {"payload": 1, "_id": 0},
+                )
+            )
+            == []
+        )
+        assert list(
+            collection.find(
+                {"_id": {"$in": [[1, "two"]]}},
+                {"payload": 1, "_id": 0},
+            )
+        ) == [{"payload": "large"}]
+    finally:
+        client.close()
+
+
+def test_sqlite_projection_scan_falls_back_after_sql_compilation_error(
+    tmp_path, monkeypatch
+):
+    client, collection = _sqlite_collection(tmp_path)
+    collection.insert_one({"_id": 1, "name": "Ada", "body": "large"})
+    engine = collection.parent.engine
+    monkeypatch.setattr(
+        engine.compiler,
+        "compile",
+        lambda filter_doc: (_ for _ in ()).throw(ValueError("unsupported SQL")),
+    )
+
+    try:
+        assert list(collection.find({}, {"name": 1})) == [{"_id": 1, "name": "Ada"}]
+        assert engine._project_sqlite_id(None, None) == {}
+    finally:
+        client.close()
+
+
+def test_async_sqlite_projection_sweep_and_chained_sort(tmp_path):
+    async def scenario():
+        client = tm.AsyncTinyMongoClient(
+            str(tmp_path),
+            backend="sqlite",
+        )
+        collection = client.app.async_items
+        await collection.insert_many(
+            [
+                {"_id": 1, "rank": 2, "body": "a" * 1000},
+                {"_id": 2, "rank": 1, "body": "b" * 1000},
+            ]
+        )
+        try:
+            assert await collection.find({}, {"_id": 1}).to_list(None) == [
+                {"_id": 1},
+                {"_id": 2},
+            ]
+            assert await collection.find({}, {"_id": 1}).sort("rank", 1).to_list(
+                None
+            ) == [{"_id": 2}, {"_id": 1}]
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_projection_hook_is_optional_for_third_party_backends():
+    class LegacyBackend:
+        def __init__(self):
+            self.calls = []
+
+        def find(self, collection, filter_doc=None):
+            self.calls.append((collection, filter_doc))
+            return [{"_id": 1, "body": "kept in the backend result"}]
+
+    backend = LegacyBackend()
+    collection = TinyMongoCollection(
+        "items",
+        SimpleNamespace(engine=backend),
+    )
+
+    assert list(collection.find({}, {"_id": 1})) == [{"_id": 1}]
+    assert backend.calls == [("items", {})]
+
+
+def _read_peak(collection, projection):
+    gc.collect()
+    tracemalloc.start()
+    try:
+        documents = list(collection.find({}, projection))
+        _, peak = tracemalloc.get_traced_memory()
+        return documents, peak
+    finally:
+        tracemalloc.stop()
+
+
+def test_sqlite_id_projection_materially_reduces_public_sweep_peak_memory(tmp_path):
+    client, collection = _sqlite_collection(tmp_path, name="large_documents")
+    body = "x" * 100_000
+    count = 64
+    collection.insert_many(
+        [
+            {"_id": index, "title": "document {0}".format(index), "body": body}
+            for index in range(count)
+        ]
+    )
+
+    try:
+        projected, projected_peak = _read_peak(collection, {"_id": 1})
+        complete, complete_peak = _read_peak(collection, None)
+        assert projected == [{"_id": index} for index in range(count)]
+        assert len(complete) == count
+        assert complete_peak - projected_peak > 4_000_000
+        assert projected_peak * 5 < complete_peak
+    finally:
+        client.close()

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -15,15 +15,18 @@ def test_bson_capabilities_are_enabled_atomically(monkeypatch):
 
     monkeypatch.setattr(bson_types, "_ObjectId", marker)
     monkeypatch.setattr(bson_types, "_Binary", marker)
+    monkeypatch.setattr(bson_types, "_Decimal128", marker)
     assert bson_types.bson_capabilities() == {
         "objectid": True,
         "binary": True,
+        "decimal128": True,
     }
 
     monkeypatch.setattr(bson_types, "_Binary", None)
     assert bson_types.bson_capabilities() == {
         "objectid": False,
         "binary": False,
+        "decimal128": False,
     }
 
     monkeypatch.setattr(bson_types, "_ObjectId", None)
@@ -31,6 +34,7 @@ def test_bson_capabilities_are_enabled_atomically(monkeypatch):
     assert bson_types.bson_capabilities() == {
         "objectid": False,
         "binary": False,
+        "decimal128": False,
     }
 
 

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -1,5 +1,8 @@
 import os
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 
 import duckdb
 import pytest
@@ -31,7 +34,8 @@ from tinymongo.table_backends import (
     _json_dumps,
     _json_loads,
     _join_uri,
-    _reject_remote_unique_arrays,
+    _reject_remote_unique_values,
+    _SQLITE_UNIQUE_TOKEN_VERSION,
     matches_filter,
     requires_python_filter,
 )
@@ -436,10 +440,29 @@ def test_table_backend_abstract_methods(tmp_path):
     assert backend.all_docs("anything") == [{"_id": 1}]
     assert backend.create_index("anything", "field") == "field_1"
     assert backend.create_index("anything", "field") == "field_1"
+    legacy_first = parse_index_spec("legacy", name="legacy_first")
+    legacy_second = parse_index_spec("legacy", name="legacy_second")
+    backend._ephemeral_indexes["legacy"] = {
+        legacy_first.name: legacy_first,
+        legacy_second.name: legacy_second,
+    }
+    assert backend.create_index("legacy", legacy_second) == "legacy_second"
+    with pytest.raises(OperationFailure, match="different name") as different_name:
+        backend.create_index(
+            "anything", parse_index_spec("field", name="alternate_field")
+        )
+    assert different_name.value.code == 85
     assert (
         backend.create_index("anything", parse_index_spec("email", unique=True))
         == "email_1"
     )
+    assert (
+        backend.create_index(
+            "anything", parse_index_spec("email", name="email_nonunique")
+        )
+        == "email_nonunique"
+    )
+    assert backend.drop_index("anything", "email_nonunique") is None
     assert backend.drop_index("anything", "email") is None
     with pytest.raises(OperationFailure, match="Index not found"):
         backend.drop_index("anything", "missing")
@@ -589,6 +612,182 @@ def test_sqlite_unique_index_keeps_distinct_arbitrary_precision_integers(tmp_pat
         backend.insert_many("values", [{"_id": 3, "value": 2**63 + 1}])
 
 
+def test_sqlite_migrates_legacy_unique_float_tokens_before_decimal_writes(tmp_path):
+    bson = pytest.importorskip("bson")
+    path = str(tmp_path / "float-token-migration.sqlite")
+    backend = SQLiteTableBackend(path)
+    spec = parse_index_spec("value", unique=True)
+    backend.create_index("values", spec)
+    backend.insert_many("values", [{"_id": "double", "value": 1e23}])
+    physical_name = backend._physical_index_name("values", spec)
+
+    conn = sqlite3.connect(path)
+    try:
+        conn.create_function(
+            "tinymongo_unique_token",
+            2,
+            lambda _data, _field: '["number:1E+23"]',
+            deterministic=True,
+        )
+        conn.execute('REINDEX "{0}"'.format(physical_name))
+        conn.execute(
+            "UPDATE __tinymongo_indexes SET token_version = 2 "
+            "WHERE collection_name = 'values' AND index_name = 'value_1'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    reopened = SQLiteTableBackend(path)
+    reopened.insert_many(
+        "values", [{"_id": "decimal", "value": bson.Decimal128("1E+23")}]
+    )
+
+    assert {row["_id"] for row in reopened.find("values", {})} == {
+        "double",
+        "decimal",
+    }
+    conn = sqlite3.connect(path)
+    try:
+        version = conn.execute(
+            "SELECT token_version FROM __tinymongo_indexes "
+            "WHERE collection_name = 'values' AND index_name = 'value_1'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert version == _SQLITE_UNIQUE_TOKEN_VERSION
+
+
+def test_sqlite_numeric_token_migration_reports_existing_exact_duplicates(tmp_path):
+    path = str(tmp_path / "duplicate-token-migration.sqlite")
+    backend = SQLiteTableBackend(path)
+    spec = parse_index_spec("amount", unique=True)
+    physical_name = backend._physical_index_name("values", spec)
+    backend.insert_many(
+        "values",
+        [
+            {"_id": "integer", "amount": 2**60},
+            {"_id": "double", "amount": float(2**60)},
+        ],
+    )
+    conn = sqlite3.connect(path)
+    try:
+        conn.create_function(
+            "tinymongo_unique_token",
+            2,
+            lambda data, _field: data,
+            deterministic=True,
+        )
+        conn.execute(
+            "CREATE TABLE __tinymongo_indexes ("
+            "collection_name TEXT NOT NULL, index_name TEXT NOT NULL, "
+            "field_name TEXT NOT NULL, unique_flag INTEGER NOT NULL, "
+            "token_version INTEGER NOT NULL DEFAULT 2, "
+            "PRIMARY KEY (collection_name, index_name))"
+        )
+        conn.execute(
+            "INSERT INTO __tinymongo_indexes VALUES "
+            "('values', 'amount_1', 'amount', 1, 2)"
+        )
+        conn.execute(
+            'CREATE UNIQUE INDEX {0} ON "values" '
+            "(tinymongo_unique_token(data, 'amount'))".format(
+                '"{0}"'.format(physical_name)
+            )
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(DuplicateKeyError, match="exact BSON numeric identity"):
+        backend.get_index_specs("values")
+
+    conn = sqlite3.connect(path)
+    try:
+        version = conn.execute(
+            "SELECT token_version FROM __tinymongo_indexes"
+        ).fetchone()[0]
+        native_index = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+            (physical_name,),
+        ).fetchone()
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+    finally:
+        conn.close()
+    assert version == _SQLITE_UNIQUE_TOKEN_VERSION
+    assert native_index is None
+    assert integrity == "ok"
+    assert backend.get_index_specs("values") == [spec]
+
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many("values", [{"_id": "blocked", "amount": 3}])
+
+    backend.delete_ids("values", ["double"])
+    backend.drop_index("values", "amount_1")
+    assert backend.create_index("values", spec) == "amount_1"
+
+
+def test_sqlite_current_index_catalog_reads_do_not_take_the_write_lock(
+    tmp_path, monkeypatch
+):
+    backend = SQLiteTableBackend(str(tmp_path / "current-index-catalog.sqlite"))
+    backend.create_index("values", parse_index_spec("value", unique=True))
+
+    @contextmanager
+    def forbidden_write_lock():
+        raise AssertionError("a current catalog read must remain lock-free")
+        yield
+
+    monkeypatch.setattr(backend, "_write_lock", forbidden_write_lock)
+
+    assert backend.get_index_specs("values") == [parse_index_spec("value", unique=True)]
+
+
+def test_sqlite_upgrades_legacy_index_catalog_without_token_version(tmp_path):
+    path = str(tmp_path / "legacy-index-catalog.sqlite")
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE __tinymongo_indexes ("
+            "collection_name TEXT NOT NULL, index_name TEXT NOT NULL, "
+            "field_name TEXT NOT NULL, unique_flag INTEGER NOT NULL, "
+            "PRIMARY KEY (collection_name, index_name))"
+        )
+        conn.execute(
+            "INSERT INTO __tinymongo_indexes VALUES " "('ghost', 'value_1', 'value', 1)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    backends = [SQLiteTableBackend(path), SQLiteTableBackend(path)]
+    barrier = threading.Barrier(2)
+
+    def load_specs(backend):
+        barrier.wait()
+        return backend.get_index_specs("ghost")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(load_specs, backends))
+    assert results == [
+        [parse_index_spec("value", unique=True)],
+        [parse_index_spec("value", unique=True)],
+    ]
+    conn = sqlite3.connect(path)
+    try:
+        columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(__tinymongo_indexes)").fetchall()
+        }
+        version = conn.execute(
+            "SELECT token_version FROM __tinymongo_indexes"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "token_version" in columns
+    assert version == _SQLITE_UNIQUE_TOKEN_VERSION
+
+
 def test_sqlite_public_index_lookup_unions_scalar_and_array_matches(
     tmp_path, monkeypatch
 ):
@@ -619,7 +818,9 @@ def test_sqlite_public_index_lookup_unions_scalar_and_array_matches(
         2,
     ]
     assert any("json_type" in sql and "IN ('text'" in sql for sql in traced_sql)
-    assert any("json_type" in sql and "= 'array'" in sql for sql in traced_sql)
+    assert any(
+        "json_type" in sql and "IN ('array', 'object')" in sql for sql in traced_sql
+    )
 
     spec = parse_index_spec("email", name="email_lookup")
     where, params = backend.compiler.compile({"email": "ada@example.com"})
@@ -1229,7 +1430,7 @@ def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
 
 
 def test_remote_array_guard_ignores_nonunique_specs():
-    _reject_remote_unique_arrays(
+    _reject_remote_unique_values(
         [{"_id": 1, "tags": ["a", "b"]}],
         [parse_index_spec("tags")],
     )
@@ -1253,6 +1454,32 @@ def test_remote_unique_array_writes_fail_closed_across_clients(
 
     assert second.find_one("items", {"_id": 1}) == {"_id": 1, "tags": "a"}
     assert second.find_one("items", {"_id": 2}) is None
+
+
+@pytest.mark.parametrize("backend_name", ["postgres", "mysql"])
+def test_remote_unique_decimal128_values_fail_closed_across_clients(
+    monkeypatch, backend_name
+):
+    bson = pytest.importorskip("bson")
+    store = FakeRemoteStore()
+    factory = _postgres_backend if backend_name == "postgres" else _mysql_backend
+    first = factory(monkeypatch, store)
+    second = factory(monkeypatch, store)
+    first.create_index("items", parse_index_spec("value", unique=True))
+    first.insert_many("items", [{"_id": 1, "value": 1}])
+
+    with pytest.raises(TinyMongoNotSupportedError, match="Decimal128 values"):
+        second.insert_many("items", [{"_id": 2, "value": bson.Decimal128("1.00")}])
+    with pytest.raises(TinyMongoNotSupportedError, match="Decimal128 values"):
+        second.replace_one("items", 1, {"_id": 1, "value": bson.Decimal128("2.0")})
+
+    first.insert_many("existing", [{"_id": 1, "value": bson.Decimal128("3.00")}])
+    with pytest.raises(TinyMongoNotSupportedError, match="Decimal128 values"):
+        first.create_index("existing", parse_index_spec("value", unique=True))
+
+    first.create_index("ordinary", parse_index_spec("value"))
+    first.insert_many("ordinary", [{"_id": 1, "value": bson.Decimal128("4.00")}])
+    assert first.find_one("ordinary", {"_id": 1})["value"] == bson.Decimal128("4.00")
 
 
 def test_postgres_table_backend_with_fake_driver(monkeypatch):

--- a/tests/test_tinymongo_coverage_edges.py
+++ b/tests/test_tinymongo_coverage_edges.py
@@ -77,7 +77,7 @@ def test_create_indexes_skip_and_duplicate_field_drop_branches():
     assert collection.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
 
     collection.create_index("email", name="email_a")
-    collection.create_index("email", name="email_b")
+    collection.create_index("email", name="email_b", unique=True)
     collection.drop_index("email_a")
     assert "email" in collection._indexes
     assert {item["name"] for item in collection.list_indexes()} == {

--- a/tests/test_warning_attribution.py
+++ b/tests/test_warning_attribution.py
@@ -1,0 +1,185 @@
+"""Warning locations stay attached to application calls across async workers."""
+
+import asyncio
+from datetime import date
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+import warnings
+
+import pytest
+
+import tinymongo.warning_context as warning_context
+from tinymongo.aggregation import AggregationEngine
+from tinymongo.asyncio import AsyncTinyMongoClient
+from tinymongo.indexes import TinyMongoUnsupportedWarning
+from tinymongo.tinymongo import TinyMongoClient, TinyMongoCollection, TinyMongoCursor
+
+
+def run(coroutine):
+    return asyncio.run(coroutine)
+
+
+def _assert_origin(caught, expected_line):
+    assert len(caught) == 1
+    assert Path(caught[0].filename).resolve() == Path(__file__).resolve()
+    assert caught[0].lineno == expected_line
+
+
+def test_sync_cursor_sort_warning_points_to_application_call():
+    cursor = TinyMongoCursor([{"published": date(2026, 1, 1)}])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+        expected_line = inspect.currentframe().f_lineno + 1
+        cursor.sort("published")
+
+    _assert_origin(caught, expected_line)
+
+
+def test_sync_aggregation_sort_warning_points_to_application_call():
+    engine = AggregationEngine()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+        expected_line = inspect.currentframe().f_lineno + 1
+        engine.run(
+            [{"published": date(2026, 1, 1)}],
+            [{"$sort": {"published": 1}}],
+        )
+
+    _assert_origin(caught, expected_line)
+
+
+def test_sync_create_indexes_warning_keeps_application_call_origin():
+    client = TinyMongoClient(
+        "memory://warning-origin-sync-create-indexes",
+        backend="memory",
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+        expected_line = inspect.currentframe().f_lineno + 1
+        client.db.items.create_indexes([{"key": {"created": -1}}])
+
+    client.close()
+    _assert_origin(caught, expected_line)
+
+
+def test_async_create_indexes_warning_keeps_await_call_origin():
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            "memory://warning-origin-create-indexes",
+            backend="memory",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+            expected_line = inspect.currentframe().f_lineno + 1
+            await client.db.items.create_indexes([{"key": {"created": -1}}])
+        await client.close()
+        _assert_origin(caught, expected_line)
+
+    run(scenario())
+
+
+def test_async_find_cursor_sort_warning_keeps_sort_origin_through_clone(monkeypatch):
+    def find_with_unsupported_value(_collection, *args, **kwargs):
+        return TinyMongoCursor([{"published": date(2026, 1, 1)}])
+
+    monkeypatch.setattr(TinyMongoCollection, "find", find_with_unsupported_value)
+
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            "memory://warning-origin-find-sort",
+            backend="memory",
+        )
+        cursor = client.db.items.find({})
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+            expected_line = inspect.currentframe().f_lineno + 1
+            cursor.sort("published")
+            clone = cursor.clone()
+            await clone.to_list()
+        await client.close()
+        _assert_origin(caught, expected_line)
+
+    run(scenario())
+
+
+def test_async_aggregation_sort_warning_keeps_await_call_origin(monkeypatch):
+    def aggregate_with_unsupported_value(_collection, pipeline, *args, **kwargs):
+        documents = [{"published": date(2026, 1, 1)}]
+        return TinyMongoCursor(AggregationEngine().run(documents, pipeline))
+
+    monkeypatch.setattr(
+        TinyMongoCollection,
+        "aggregate",
+        aggregate_with_unsupported_value,
+    )
+
+    async def scenario():
+        client = AsyncTinyMongoClient(
+            "memory://warning-origin-aggregation-sort",
+            backend="memory",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+            expected_line = inspect.currentframe().f_lineno + 1
+            await client.db.items.aggregate([{"$sort": {"published": 1}}])
+        await client.close()
+        _assert_origin(caught, expected_line)
+
+    run(scenario())
+
+
+def test_warning_context_defensive_and_module_fallbacks(monkeypatch):
+    with warning_context.use_warning_origin(None):
+        pass
+
+    namespace = {"capture_warning_origin": warning_context.capture_warning_origin}
+    exec("origin = capture_warning_origin()", namespace)
+    moduleless_origin = namespace["origin"]
+    assert moduleless_origin.module is None
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+        with warning_context.use_warning_origin(moduleless_origin):
+            warning_context.emit_warning(
+                "moduleless warning",
+                TinyMongoUnsupportedWarning,
+            )
+        with warning_context.use_warning_origin(
+            warning_context.WarningOrigin(
+                filename=__file__,
+                lineno=1,
+                module="tinymongo.warning_origin_module_not_loaded",
+            )
+        ):
+            warning_context.emit_warning(
+                "unloaded module warning",
+                TinyMongoUnsupportedWarning,
+            )
+    assert len(caught) == 2
+
+    dotted_frame = SimpleNamespace(
+        f_globals={"__name__": "tinymongo.synthetic"},
+        f_back=None,
+    )
+    package_frame = SimpleNamespace(
+        f_globals={"__name__": "tinymongo"},
+        f_back=dotted_frame,
+    )
+    current_frame = SimpleNamespace(f_back=package_frame)
+    monkeypatch.setattr(
+        warning_context.inspect,
+        "currentframe",
+        lambda: current_frame,
+    )
+    assert warning_context.capture_warning_origin() is None
+
+    monkeypatch.setattr(warning_context, "capture_warning_origin", lambda: None)
+    with pytest.warns(TinyMongoUnsupportedWarning, match="fallback warning"):
+        warning_context.emit_warning(
+            "fallback warning",
+            TinyMongoUnsupportedWarning,
+        )

--- a/tinymongo/aggregation.py
+++ b/tinymongo/aggregation.py
@@ -9,26 +9,32 @@ from __future__ import absolute_import
 
 import copy
 from collections.abc import Mapping
+from decimal import Decimal, localcontext
 from itertools import islice
-import math
-from numbers import Number
-import warnings
 
 from .bson_types import (
     binary_components,
     binary_type,
+    bson_number_decimal,
+    bson_number_truth,
     bson_value_identity_key,
     bson_value_sort_key,
+    decimal128_context,
+    decimal128_from_decimal,
+    decimal128_type,
+    is_bson_number,
 )
 from .errors import OperationFailure, TinyMongoNotSupportedError
 from .indexes import TinyMongoUnsupportedWarning
 from .projection import normalize_projection, project_document
 from .sorting import sort_documents
 from .table_backends import matches_filter, validate_filter_operators
+from .warning_context import emit_warning
 
 
 _MISSING = object()
 _BINARY = binary_type()
+_DECIMAL128 = decimal128_type()
 _PROJECT_LEAF = object()
 _PROJECT_INCLUDE = object()
 _PROJECT_COMPUTED = object()
@@ -60,14 +66,61 @@ _SUPPORTED_STAGES = (
 )
 
 
-def _sum_value(value):
-    """Return the numeric contribution MongoDB's group ``$sum`` would use."""
+class _SumAccumulator(object):
+    """Preserve MongoDB's numeric promotion and mixed-double precision."""
 
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, (int, float)):
-        return value
-    return 0
+    __slots__ = (
+        "_decimal_total",
+        "_float_total",
+        "_has_decimal",
+        "_has_non_integer",
+        "_int_total",
+    )
+
+    def __init__(self):
+        self._int_total = 0
+        self._decimal_total = None
+        self._float_total = None
+        self._has_non_integer = False
+        self._has_decimal = False
+
+    def add(self, value):
+        if not is_bson_number(value):
+            return
+
+        if _DECIMAL128 is None:
+            if self._float_total is None and isinstance(value, int):
+                self._int_total += value
+                return
+            if self._float_total is None:
+                self._float_total = float(Decimal(self._int_total))
+            self._float_total += value
+            self._has_non_integer = True
+            return
+
+        is_decimal = _DECIMAL128 is not None and isinstance(value, _DECIMAL128)
+        if self._decimal_total is None and isinstance(value, int):
+            self._int_total += value
+            return
+
+        with localcontext(decimal128_context()):
+            if self._decimal_total is None:
+                self._decimal_total = Decimal(self._int_total)
+                # Decimal converts an oversized integer to infinity instead of
+                # raising OverflowError, matching MongoDB's double promotion.
+                self._float_total = float(self._decimal_total)
+            self._decimal_total += bson_number_decimal(value)
+        if not self._has_decimal and not is_decimal:
+            self._float_total += value
+        self._has_non_integer = True
+        self._has_decimal = self._has_decimal or is_decimal
+
+    def value(self):
+        if not self._has_non_integer:
+            return self._int_total
+        if self._has_decimal:
+            return decimal128_from_decimal(self._decimal_total)
+        return self._float_total
 
 
 def aggregation_capabilities():
@@ -150,8 +203,11 @@ def _flatten_stage_specification(specification, project, prefix=None):
                     "An empty sub-projection is not a valid $project expression",
                     code=51270,
                 )
-        if project and isinstance(value, Number):
-            flattened.append((path, "flag", bool(value)))
+        if project and (isinstance(value, bool) or is_bson_number(value)):
+            include = (
+                bool(value) if isinstance(value, bool) else bson_number_truth(value)
+            )
+            flattened.append((path, "flag", include))
         else:
             flattened.append((path, "computed", copy.deepcopy(value)))
     return flattened
@@ -596,20 +652,19 @@ class AggregationEngine(object):
                     "Aggregation $sort $meta expressions are not supported by "
                     "TinyMongo"
                 )
-            if isinstance(direction, bool) or not isinstance(direction, (int, float)):
+            if isinstance(direction, bool) or not is_bson_number(direction):
                 raise OperationFailure(
                     "Illegal key in $sort specification: {0}".format(field),
                     code=15974,
                 )
-            if (
-                isinstance(direction, float) and not math.isfinite(direction)
-            ) or direction not in (-1, 1):
+            numeric_direction = bson_number_decimal(direction)
+            if not numeric_direction.is_finite() or numeric_direction not in (-1, 1):
                 raise OperationFailure(
                     "$sort key ordering must be 1 (for ascending) or -1 "
                     "(for descending)",
                     code=15975,
                 )
-            prepared.append((field, int(direction)))
+            prepared.append((field, int(numeric_direction)))
         return tuple(prepared)
 
     def _warn_unsupported_sort_value(self, field, value):
@@ -617,7 +672,7 @@ class AggregationEngine(object):
         if warning_key in self._unsupported_sort_warnings:
             return
         self._unsupported_sort_warnings.add(warning_key)
-        warnings.warn(
+        emit_warning(
             "Sorting field '{0}' encountered unsupported value type '{1}'; "
             "values of this type compare as null.".format(
                 field,
@@ -636,20 +691,22 @@ class AggregationEngine(object):
 
     @staticmethod
     def _validate_integral_stage_number(value, stage, code):
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
+        if isinstance(value, bool) or not is_bson_number(value):
             raise OperationFailure(
                 "invalid argument to {0} stage: Expected a number".format(stage),
                 code=code,
             )
-        if isinstance(value, float) and (
-            not math.isfinite(value) or not value.is_integer()
+        numeric_value = bson_number_decimal(value)
+        if (
+            not numeric_value.is_finite()
+            or numeric_value != numeric_value.to_integral_value()
         ):
             raise OperationFailure(
                 "invalid argument to {0} stage: Expected an integer".format(stage),
                 code=code,
             )
 
-        normalized = int(value)
+        normalized = int(numeric_value)
         if normalized < 0 or normalized > (2**63 - 1):
             raise OperationFailure(
                 "invalid argument to {0} stage: Expected a non-negative "
@@ -880,7 +937,9 @@ class AggregationEngine(object):
                 group = {
                     "key": copy.deepcopy(group_value),
                     "states": {
-                        output_field: 0 if operator == "$sum" else _MISSING
+                        output_field: (
+                            _SumAccumulator() if operator == "$sum" else _MISSING
+                        )
                         for output_field, operator, _operand in accumulators
                     },
                 }
@@ -890,7 +949,7 @@ class AggregationEngine(object):
             for output_field, operator, operand in accumulators:
                 value = self.context.evaluate(document, operand)
                 if operator == "$sum":
-                    group["states"][output_field] += _sum_value(value)
+                    group["states"][output_field].add(value)
                     continue
 
                 # MongoDB ignores both null and missing values for min/max when
@@ -912,11 +971,12 @@ class AggregationEngine(object):
             result = {"_id": copy.deepcopy(group["key"])}
             for output_field, operator, _operand in accumulators:
                 value = group["states"][output_field]
-                result[output_field] = (
-                    None
-                    if operator != "$sum" and value is _MISSING
-                    else copy.deepcopy(value)
-                )
+                if operator == "$sum":
+                    result[output_field] = value.value()
+                else:
+                    result[output_field] = (
+                        None if value is _MISSING else copy.deepcopy(value)
+                    )
             results.append(result)
         return results
 
@@ -925,8 +985,8 @@ class AggregationEngine(object):
         candidate_key = bson_value_sort_key(candidate)
         current_key = bson_value_sort_key(current)
         if operator == "$min":
-            return candidate_key < current_key
-        return candidate_key > current_key
+            return candidate_key <= current_key
+        return candidate_key >= current_key
 
     def _validate_group(self, specification):
         if not isinstance(specification, Mapping):

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -22,6 +22,11 @@ from .tinymongo import (
     TinyMongoCollection,
     TinyMongoCursor,
 )
+from .warning_context import (
+    WarningOrigin,
+    capture_warning_origin,
+    use_warning_origin,
+)
 
 
 class _AsyncClientState:
@@ -64,7 +69,9 @@ class _AsyncClientState:
     async def call(self, operation: Callable[[TinyMongoClient], Any]) -> Any:
         """Run one complete synchronous operation outside the event loop."""
 
-        return await asyncio.to_thread(self._invoke, operation)
+        origin = capture_warning_origin()
+        with use_warning_origin(origin):
+            return await asyncio.to_thread(self._invoke, operation)
 
     def _close(self) -> None:
         with self._condition:
@@ -506,6 +513,7 @@ class AsyncTinyMongoCursor:
         self._find_args = tuple(find_args)
         self._find_kwargs = dict(find_kwargs or {})
         self._sort: Optional[Tuple[Any, Any]] = None
+        self._sort_warning_origin: Optional[WarningOrigin] = None
         self._skip = 0
         self._limit = 0
         self._documents: Optional[List[Dict[str, Any]]] = None
@@ -525,6 +533,7 @@ class AsyncTinyMongoCursor:
         # specifications fail at configuration time, like PyMongo's cursor.
         TinyMongoCursor([]).sort(key_or_list, direction)
         self._sort = (copy.deepcopy(key_or_list), direction)
+        self._sort_warning_origin = capture_warning_origin()
         return self
 
     def skip(self, count: int) -> "AsyncTinyMongoCursor":
@@ -575,6 +584,7 @@ class AsyncTinyMongoCursor:
             documents=self._seed_documents,
         )
         clone._sort = copy.deepcopy(self._sort)
+        clone._sort_warning_origin = self._sort_warning_origin
         clone._skip = self._skip
         clone._limit = self._limit
         return clone
@@ -589,7 +599,8 @@ class AsyncTinyMongoCursor:
         if self._seed_documents is not None:
             cursor = TinyMongoCursor(copy.deepcopy(self._seed_documents))
             if self._sort is not None:
-                cursor.sort(self._sort[0], self._sort[1])
+                with use_warning_origin(self._sort_warning_origin):
+                    cursor.sort(self._sort[0], self._sort[1])
             documents = list(cursor)
             if self._skip:
                 documents = documents[self._skip :]
@@ -615,7 +626,8 @@ class AsyncTinyMongoCursor:
                 **self._find_kwargs,
             )
             if self._sort is not None:
-                cursor.sort(self._sort[0], self._sort[1])
+                with use_warning_origin(self._sort_warning_origin):
+                    cursor.sort(self._sort[0], self._sort[1])
             documents = list(cursor)
             if self._skip:
                 documents = documents[self._skip :]

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -27,6 +27,7 @@ from .errors import InvalidDocument
 # ``bson_types``.
 _ObjectId = bson_types.object_id_type()
 _Binary = bson_types.binary_type()
+_Decimal128 = bson_types.decimal128_type()
 
 
 _TYPE_MARKER = "__tinymongo_type_v1__"
@@ -36,12 +37,13 @@ _BINARY_VALUE = "binary"
 _BINARY_DATA = "base64"
 _BINARY_SUBTYPE = "subtype"
 _NONFINITE_FLOAT = "float"
+_DECIMAL128_VALUE = "decimal128"
 _ROOT_UNSET = object()
 
 
 def bson_available():
     """Return whether the optional BSON implementation can be used."""
-    return object_id_available() and binary_available()
+    return object_id_available() and binary_available() and decimal128_available()
 
 
 def object_id_available():
@@ -54,6 +56,12 @@ def binary_available():
     """Return whether non-generic PyMongo ``Binary`` values can be restored."""
 
     return _Binary is not None
+
+
+def decimal128_available():
+    """Return whether PyMongo ``Decimal128`` values can be restored."""
+
+    return _Decimal128 is not None
 
 
 def _nested_path(path, key):
@@ -82,6 +90,10 @@ def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
     if storage_tag == _BINARY_VALUE:
         raw, subtype = bson_types.binary_components(value)
         return _encode_binary(raw, subtype)
+    if storage_tag == _DECIMAL128_VALUE:
+        # Store the raw IEEE-754 BID bytes. ``str(value)`` loses the distinction
+        # between quiet and signaling NaN and would not be an exact round trip.
+        return {_TYPE_MARKER: _DECIMAL128_VALUE, _VALUE_MARKER: value.bid.hex()}
     if isinstance(value, float) and not math.isfinite(value):
         if math.isnan(value):
             payload = "nan"
@@ -210,6 +222,16 @@ def decode_value(value):
                     # Preserve malformed or future-shaped tags just like an
                     # unknown tag rather than turning user data into a value.
                     return value
+            if kind == _DECIMAL128_VALUE:
+                raw = _decimal128_payload(payload)
+                if raw is not None:
+                    if _Decimal128 is None:
+                        raise ImportError(
+                            "Reading BSON Decimal128 values requires the optional "
+                            "'pymongo' package. Install it with: "
+                            "pip install 'tinymongo[bson]'"
+                        )
+                    return _Decimal128.from_bid(raw)
             if kind == _NONFINITE_FLOAT:
                 if payload == "nan":
                     return float("nan")
@@ -251,6 +273,19 @@ def clone(value):
     return loads(dumps(value, ensure_ascii=False))
 
 
+def storage_values_equal(left, right):
+    """Compare the exact representations TinyMongo would persist.
+
+    Query equality intentionally treats numeric BSON types as one family. A
+    write decision cannot: replacing integer ``1`` with double ``1.0`` or with
+    ``Decimal128('1.00')`` changes the stored BSON representation and must not
+    be optimized away.
+    """
+
+    options = {"ensure_ascii": False, "separators": (",", ":")}
+    return dumps(left, **options) == dumps(right, **options)
+
+
 def contains_extended_value(value):
     """Return whether a filter contains a value requiring Python comparison."""
     if isinstance(value, float) and not math.isfinite(value):
@@ -275,3 +310,15 @@ def _valid_object_id_payload(payload):
     except ValueError:
         return False
     return len(decoded) == 12
+
+
+def _decimal128_payload(payload):
+    """Return a valid 16-byte Decimal128 BID payload, or ``None``."""
+
+    if not isinstance(payload, str) or len(payload) != 32:
+        return None
+    try:
+        decoded = bytes.fromhex(payload)
+    except ValueError:
+        return None
+    return decoded if len(decoded) == 16 else None

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -3,7 +3,7 @@
 The JSON codec, query comparison, and cursor sorting all consume this registry
 so type recognition and subclass precedence cannot drift between them. PyMongo
 is optional: its bundled :mod:`bson` implementation is enabled atomically only
-when both ``ObjectId`` and ``Binary`` can be imported.
+when ``ObjectId``, ``Binary``, and ``Decimal128`` can all be imported.
 """
 
 from __future__ import absolute_import
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from decimal import Decimal, localcontext
 import math
 from typing import Any, Callable, Optional
 
@@ -19,12 +20,18 @@ try:
     import pymongo as _pymongo  # noqa: F401 - proves this is PyMongo's bson
     from bson import ObjectId as _ObjectId
     from bson.binary import Binary as _Binary
+    from bson.decimal128 import (
+        Decimal128 as _Decimal128,
+        create_decimal128_context as _create_decimal128_context,
+    )
 except ImportError:  # pragma: no cover - environment without optional bson
     # Treat the optional implementation as one capability. This avoids
     # accidentally accepting the unrelated third-party ``bson`` distribution
     # or reporting partial BSON support from a broken installation.
     _ObjectId = None  # type: ignore[misc,assignment]
     _Binary = None  # type: ignore[misc,assignment]
+    _Decimal128 = None  # type: ignore[misc,assignment]
+    _create_decimal128_context = None  # type: ignore[misc,assignment]
 
 
 @dataclass(frozen=True)
@@ -51,18 +58,115 @@ def _number_identity_key(value):
     # MongoDB considers numeric values across integer/double representations by
     # numeric value. Python already supplies that equality/hash behavior except
     # for NaN, which MongoDB treats as one comparable numeric value.
-    if isinstance(value, float) and math.isnan(value):
+    decimal_value = bson_number_decimal(value)
+    if decimal_value.is_nan():
         return "nan"
-    return value
+    if decimal_value.is_infinite():
+        return "-infinity" if decimal_value.is_signed() else "infinity"
+    # A reduced ratio gives int, float, and Decimal128 one exact, JSON-safe
+    # identity without confusing a binary float such as 0.1 with Decimal128
+    # ("0.1"). This also preserves the physical-ID encoding used by earlier
+    # int/float releases.
+    return decimal_value.as_integer_ratio()
 
 
 def _number_sort_key(value):
     # MongoDB gives NaN a stable position below every other numeric value.
     # Python's raw NaN comparisons are unordered and can leave surrounding
     # ordinary numbers unsorted.
-    if isinstance(value, float) and math.isnan(value):
+    decimal_value = bson_number_decimal(value)
+    if decimal_value.is_nan():
         return 0, 0
-    return 1, value
+    return 1, decimal_value
+
+
+def bson_number_decimal(value):
+    """Return the exact :class:`Decimal` value of a supported BSON number."""
+
+    if isinstance(value, bool):
+        raise TypeError("Boolean values are not BSON numbers")
+    if _Decimal128 is not None and isinstance(value, _Decimal128):
+        return value.to_decimal()
+    if isinstance(value, int):
+        return Decimal(value)
+    if isinstance(value, float):
+        return Decimal.from_float(value)
+    raise TypeError("Unsupported BSON numeric type: {0}".format(type(value).__name__))
+
+
+def is_bson_number(value):
+    """Return whether ``value`` belongs to TinyMongo's BSON numeric family."""
+
+    return not isinstance(value, bool) and (
+        isinstance(value, (int, float))
+        or (_Decimal128 is not None and isinstance(value, _Decimal128))
+    )
+
+
+def _decimal128_update_operand(value):
+    """Convert one update operand using MongoDB's double-to-decimal rule."""
+
+    if isinstance(value, float):
+        if math.isfinite(value):
+            # MongoDB promotes a double used with Decimal128 to 15 significant
+            # decimal digits. Scientific notation retains the scale needed for
+            # results such as Decimal128("2") + 0.1 -> 2.100000000000000.
+            return Decimal(format(value, ".14e"))
+        return Decimal(str(value))
+    return bson_number_decimal(value)
+
+
+def add_bson_numbers(left, right):
+    """Add two update operands with MongoDB-style Decimal128 promotion."""
+
+    if not is_bson_number(left) or not is_bson_number(right):
+        raise TypeError("BSON numeric addition requires two numeric values")
+    if _Decimal128 is not None and (
+        isinstance(left, _Decimal128) or isinstance(right, _Decimal128)
+    ):
+        # PyMongo exposes the same IEEE-754 Decimal128 context MongoDB uses.
+        # Its traps are disabled, so sNaN and opposite infinities become NaN
+        # instead of leaking decimal.InvalidOperation into application code.
+        with localcontext(_create_decimal128_context()):
+            result = _decimal128_update_operand(left) + _decimal128_update_operand(
+                right
+            )
+        if (
+            isinstance(left, _Decimal128)
+            and not result.is_nan()
+            and result == left.to_decimal()
+        ):
+            # Preserve the existing BID, including scale and signed zero, when
+            # Decimal128 rounding makes the increment a storage-level no-op.
+            return left
+        return _Decimal128(result)
+    return left + right
+
+
+def decimal128_context():
+    """Return PyMongo's IEEE-754 Decimal128 arithmetic context."""
+
+    if _create_decimal128_context is None:
+        raise RuntimeError(
+            "Decimal128 arithmetic requires the optional pymongo package"
+        )
+    return _create_decimal128_context()
+
+
+def decimal128_from_decimal(value):
+    """Wrap a :class:`Decimal` in the installed BSON ``Decimal128`` type."""
+
+    if _Decimal128 is None:
+        raise RuntimeError(
+            "Decimal128 arithmetic requires the optional pymongo package"
+        )
+    return _Decimal128(value)
+
+
+def bson_number_truth(value):
+    """Return MongoDB's truth value for a numeric projection flag."""
+
+    return not bson_number_decimal(value).is_zero()
 
 
 def binary_components(value):
@@ -120,6 +224,14 @@ def _datetime_identity_key(value):
 # comparison order for the scalar families TinyMongo currently supports.
 _NULL = BSONTypeSpec("null", 0, _null_key, _null_key)
 _NUMBER = BSONTypeSpec("number", 1, _number_sort_key, _number_identity_key)
+_DECIMAL_NUMBER = BSONTypeSpec(
+    "number",
+    1,
+    _number_sort_key,
+    _number_identity_key,
+    storage_tag="decimal128",
+    requires_python_comparison=True,
+)
 _STRING = BSONTypeSpec("string", 2, _identity, _identity)
 _BINARY = BSONTypeSpec(
     "binary",
@@ -151,8 +263,14 @@ _DATETIME = BSONTypeSpec(
 def bson_capabilities():
     """Return the optional PyMongo BSON capabilities available at import time."""
 
-    available = _ObjectId is not None and _Binary is not None
-    return {"objectid": available, "binary": available}
+    available = (
+        _ObjectId is not None and _Binary is not None and _Decimal128 is not None
+    )
+    return {
+        "objectid": available,
+        "binary": available,
+        "decimal128": available,
+    }
 
 
 def object_id_type():
@@ -165,6 +283,12 @@ def binary_type():
     """Return PyMongo's ``Binary`` class, or ``None`` when unavailable."""
 
     return _Binary
+
+
+def decimal128_type():
+    """Return PyMongo's ``Decimal128`` class, or ``None`` when unavailable."""
+
+    return _Decimal128
 
 
 def bson_type_spec(value) -> Optional[BSONTypeSpec]:
@@ -182,11 +306,13 @@ def bson_type_spec(value) -> Optional[BSONTypeSpec]:
         return _BINARY
     if _ObjectId is not None and isinstance(value, _ObjectId):
         return _OBJECT_ID
+    if _Decimal128 is not None and isinstance(value, _Decimal128):
+        return _DECIMAL_NUMBER
     if isinstance(value, datetime):
         return _DATETIME
     if isinstance(value, bool):
         return _BOOLEAN
-    if isinstance(value, (int, float)):
+    if is_bson_number(value):
         return _NUMBER
     if isinstance(value, str):
         return _STRING

--- a/tinymongo/indexes.py
+++ b/tinymongo/indexes.py
@@ -2,12 +2,16 @@
 
 import json
 import math
-import warnings
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from typing import Mapping, Optional
 
 from .errors import DuplicateKeyError, TinyMongoNotSupportedError
+from .bson_types import bson_number_decimal, decimal128_type
+from .warning_context import emit_warning
+
+
+_Decimal128 = decimal128_type()
 
 
 INDEX_METADATA_VERSION = 1
@@ -120,6 +124,13 @@ class IndexSpec:
             name=metadata["name"],
             unique=metadata["unique"],
         )
+
+
+def index_spec_signature(spec):
+    """Return the key-and-options identity used to detect equivalent indexes."""
+    if not isinstance(spec, IndexSpec):
+        raise TypeError("Index signatures require an IndexSpec")
+    return (spec.field, spec.direction, spec.unique)
 
 
 def parse_index_spec(key, **options):
@@ -283,6 +294,27 @@ def _plan_warning(name, features):
     return "Index {0!r} was created with reduced behavior: {1}.".format(name, details)
 
 
+def degraded_index_reuse_warning(plan, existing):
+    """Describe one degraded declaration being satisfied by an existing index."""
+    if not isinstance(plan, IndexModelPlan) or plan.spec is None:
+        raise TypeError("Degraded index reuse requires an effective index plan")
+    if not isinstance(existing, IndexSpec):
+        raise TypeError("Degraded index reuse requires an existing IndexSpec")
+    if not plan.degraded_features:
+        raise ValueError("Only degraded index plans may reuse an equivalent index")
+    if index_spec_signature(plan.spec) != index_spec_signature(existing):
+        raise ValueError("A degraded index may only reuse an equivalent index")
+
+    details = "; ".join(
+        _degraded_feature_message(item) for item in plan.degraded_features
+    )
+    return (
+        "Index {0!r} was accepted with reduced behavior: {1}. Its effective "
+        "specification matches existing index {2!r}, so TinyMongo reused that "
+        "index instead of creating a duplicate."
+    ).format(plan.name, details, existing.name)
+
+
 def plan_index_model(model):
     """Plan one duck-typed PyMongo ``IndexModel`` declaration.
 
@@ -372,7 +404,7 @@ def emit_index_plan_warnings(plan, stacklevel=2):
     if not isinstance(plan, IndexBatchPlan):
         raise TypeError("Index warning emission requires an IndexBatchPlan")
     for message in plan.warnings:
-        warnings.warn(
+        emit_warning(
             message,
             TinyMongoUnsupportedWarning,
             stacklevel=stacklevel,
@@ -399,6 +431,20 @@ def _nested_value(document, path):
     return current
 
 
+def _exact_decimal_text(value):
+    """Normalize a Decimal without rounding its coefficient to 28 digits."""
+
+    with localcontext() as context:
+        context.prec = max(1, len(value.as_tuple().digits))
+        return str(value.normalize())
+
+
+def _float_token(value):
+    """Return a token for the double's exact numeric value."""
+
+    return "number:{0}".format(_exact_decimal_text(Decimal.from_float(value)))
+
+
 def _scalar_token(value):
     if value is MISSING or value is None:
         return "null:"
@@ -407,13 +453,20 @@ def _scalar_token(value):
     if isinstance(value, int):
         if value == 0:
             return "number:0"
-        return "number:{0}".format(Decimal(value).normalize())
+        return "number:{0}".format(_exact_decimal_text(Decimal(value)))
     if isinstance(value, float):
         if not math.isfinite(value):
             _unsupported("Non-finite numbers cannot be indexed")
         if value == 0:
             return "number:0"
-        return "number:{0}".format(Decimal(str(value)).normalize())
+        return _float_token(value)
+    if _Decimal128 is not None and isinstance(value, _Decimal128):
+        decimal_value = bson_number_decimal(value)
+        if not decimal_value.is_finite():
+            _unsupported("Non-finite numbers cannot be indexed")
+        if decimal_value == 0:
+            return "number:0"
+        return "number:{0}".format(_exact_decimal_text(decimal_value))
     if isinstance(value, str):
         return "string:{0}".format(
             json.dumps(value, ensure_ascii=False, separators=(",", ":"))
@@ -477,8 +530,10 @@ __all__ = [
     "IndexSpec",
     "MISSING",
     "TinyMongoUnsupportedWarning",
+    "degraded_index_reuse_warning",
     "emit_index_plan_warnings",
     "index_catalog_id",
+    "index_spec_signature",
     "index_tokens",
     "parse_index_spec",
     "plan_index_model",

--- a/tinymongo/projection.py
+++ b/tinymongo/projection.py
@@ -2,8 +2,8 @@
 
 import copy
 from collections.abc import Mapping, Sequence, Set
-from numbers import Number
 
+from .bson_types import bson_number_truth, is_bson_number
 from .errors import OperationFailure, TinyMongoNotSupportedError
 
 
@@ -55,8 +55,11 @@ def _flatten_mapping(mapping, prefix=None):
                     "Empty and expression projection mappings are not supported"
                 )
             flattened.extend(_flatten_mapping(value, path))
-        elif isinstance(value, Number):
-            flattened.append((path, bool(value)))
+        elif isinstance(value, bool) or is_bson_number(value):
+            include = (
+                bool(value) if isinstance(value, bool) else bson_number_truth(value)
+            )
+            flattened.append((path, include))
         else:
             raise TinyMongoNotSupportedError(
                 "Only numeric inclusion and exclusion projection flags are supported"

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 from collections.abc import Mapping
 from contextlib import contextmanager
+from decimal import Decimal
 from functools import wraps
 from urllib.parse import parse_qs, unquote, urlparse
 from typing import Optional
@@ -18,7 +19,15 @@ from typing import Optional
 from .bson_codec import contains_extended_value
 from .bson_codec import dumps as bson_json_dumps
 from .bson_codec import loads as bson_json_loads
-from .bson_types import bson_identity_key, bson_values_equal
+from .bson_codec import storage_values_equal
+from .bson_types import (
+    bson_identity_key,
+    bson_number_decimal,
+    bson_scalar_sort_key,
+    bson_values_equal,
+    decimal128_type,
+    is_bson_number,
+)
 from .errors import (
     DuplicateKeyError,
     OperationFailure,
@@ -29,14 +38,20 @@ from .indexes import (
     INDEX_CATALOG_TABLE,
     IndexSpec,
     index_catalog_id,
+    index_spec_signature,
     index_tokens,
     parse_index_spec,
     validate_unique_documents,
 )
 from .parquet_storage import _acquire_rlock, _local_rlocks, portalocker
+from .projection import project_document
 
 
 _MISSING = object()
+_DECIMAL128 = decimal128_type()
+_ID_RATIO_HEX_TAG = "exact-ratio-hex-v1"
+_SAFE_JSON_INTEGER_BITS = 1800
+_SQLITE_UNIQUE_TOKEN_VERSION = 3
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
 _PHYSICAL_ID_PREFIX = "__tinymongo_id_v2__:"
 _LOGICAL_FILTER_OPERATORS = frozenset(("$and", "$or", "$nor"))
@@ -59,19 +74,64 @@ _FIELD_FILTER_OPERATORS = frozenset(
 )
 
 
+def _large_numeric_ratio(key):
+    """Return an exact ratio that is unsafe for bounded int-to-text runtimes."""
+
+    if (
+        isinstance(key, tuple)
+        and len(key) == 2
+        and all(isinstance(part, int) for part in key)
+        and any(abs(part).bit_length() > _SAFE_JSON_INTEGER_BITS for part in key)
+    ):
+        return key
+    return None
+
+
+def _signed_hex(value):
+    sign = "-" if value < 0 else ""
+    return sign + format(abs(value), "x")
+
+
+def _safe_registered_key(family, key):
+    ratio = _large_numeric_ratio(key) if family == "number" else None
+    if ratio is None:
+        return key
+    return [_ID_RATIO_HEX_TAG, _signed_hex(ratio[0]), _signed_hex(ratio[1])]
+
+
+def _legacy_large_ratio_physical_id_key(value):
+    """Recreate the pre-safe typed key without Python's decimal digit limit."""
+
+    identity = bson_identity_key(value)
+    if identity is None or identity[0] != "number":
+        return None
+    ratio = _large_numeric_ratio(identity[1])
+    if ratio is None:
+        return None
+    numerator = format(Decimal(ratio[0]), "f")
+    denominator = format(Decimal(ratio[1]), "f")
+    canonical = (
+        '["registered-scalar",["number",[' + numerator + "," + denominator + "]]]"
+    ).encode("ascii")
+    return _PHYSICAL_ID_PREFIX + hashlib.sha256(canonical).hexdigest()
+
+
+def _legacy_stringified_id(value):
+    if (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and abs(value).bit_length() > _SAFE_JSON_INTEGER_BITS
+    ):
+        return format(Decimal(value), "f")
+    return str(value)
+
+
 def _canonical_id_value(value):
     """Build a stable serialization of the registry's BSON identity key."""
     identity = bson_identity_key(value)
     if identity is not None:
         family, key = identity
-        if family == "number":
-            if isinstance(key, float):
-                if math.isinf(key):
-                    key = "-infinity" if key < 0 else "infinity"
-                else:
-                    key = list(key.as_integer_ratio())
-            elif isinstance(key, int):
-                key = [key, 1]
+        key = _safe_registered_key(family, key)
         return [
             "registered-scalar",
             json.loads(
@@ -121,7 +181,10 @@ def _physical_id_candidates(value):
     """Return the v2 key followed by compatible legacy stringified keys."""
 
     current = _physical_id_key(value)
-    legacy = [str(value)]
+    legacy = [_legacy_stringified_id(value)]
+    old_typed = _legacy_large_ratio_physical_id_key(value)
+    if old_typed is not None:
+        legacy.insert(0, old_typed)
     if not isinstance(value, bool) and isinstance(value, int):
         try:
             float_value = float(value)
@@ -442,8 +505,8 @@ def _simple_scalar_equality(filter_doc):
     return field, expected
 
 
-def _reject_remote_unique_arrays(documents, specs):
-    """Fail closed where remote native constraints cannot protect multikey races."""
+def _reject_remote_unique_values(documents, specs):
+    """Fail closed where remote constraints cannot protect Mongo uniqueness."""
     for spec in specs:
         if not spec.unique:
             continue
@@ -456,15 +519,43 @@ def _reject_remote_unique_arrays(documents, specs):
                         spec.name
                     )
                 )
+            if _DECIMAL128 is not None and isinstance(value, _DECIMAL128):
+                raise TinyMongoNotSupportedError(
+                    "Remote SQL unique index {0!r} does not support Decimal128 "
+                    "values; its native JSON constraint cannot guarantee "
+                    "cross-process MongoDB numeric uniqueness".format(spec.name)
+                )
 
 
 def _comparison_matches(actual, operand, comparison):
+    operand_identity = bson_identity_key(operand)
+    operand_order = bson_scalar_sort_key(operand)
+    if operand_identity is None or operand_order is None:
+        return False
     values = actual if isinstance(actual, list) else [actual]
     for value in values:
+        value_identity = bson_identity_key(value)
+        value_order = bson_scalar_sort_key(value)
         try:
-            if comparison(value, operand):
+            if (
+                value_identity is not None
+                and value_identity[0] == "number"
+                and is_bson_number(value)
+                and is_bson_number(operand)
+                and (
+                    bson_number_decimal(value).is_nan()
+                    != bson_number_decimal(operand).is_nan()
+                )
+            ):
+                continue
+            if (
+                value_identity is not None
+                and value_order is not None
+                and value_identity[0] == operand_identity[0]
+                and comparison(value_order[1], operand_order[1])
+            ):
                 return True
-        except (TypeError, ValueError):
+        except (ArithmeticError, TypeError, ValueError):
             continue
     return False
 
@@ -750,6 +841,14 @@ def requires_python_filter(filter_doc):
                     )
                 ):
                     return True
+                if any(
+                    operator in expected and is_bson_number(expected[operator])
+                    for operator in ("$gt", "$gte", "$lt", "$lte")
+                ):
+                    # Tagged Decimal128 values live in JSON objects, so native
+                    # numeric predicates cannot provide a complete candidate
+                    # set when the query operand is an int or double.
+                    return True
     return False
 
 
@@ -978,7 +1077,7 @@ class TableBackend(object):
         updated_ids = []
         for doc in matches:
             updated = self.apply_update(doc, update_doc)
-            if not bson_values_equal(updated, doc):
+            if not storage_values_equal(updated, doc):
                 self.replace_one(collection, doc["_id"], updated)
                 updated_ids.append(doc["_id"])
         return updated_ids
@@ -1010,15 +1109,34 @@ class TableBackend(object):
 
     def _check_index_compatibility(self, collection, spec):
         specs = self.get_index_specs(collection)
-        existing = next(
+        by_name = next(
             (current for current in specs if current.name == spec.name),
             None,
         )
-        if existing is not None and existing != spec:
+        if by_name is not None and by_name != spec:
             raise OperationFailure(
                 "An index with the same name or key has different options"
             )
-        return existing
+        if by_name is not None:
+            # Older releases allowed equivalent specs under different names.
+            # An exact name/spec retry remains idempotent even when that legacy
+            # duplicate is still present elsewhere in the catalog.
+            return by_name
+        equivalent = next(
+            (
+                current
+                for current in specs
+                if index_spec_signature(current) == index_spec_signature(spec)
+            ),
+            None,
+        )
+        if equivalent is not None and equivalent.name != spec.name:
+            raise OperationFailure(
+                "An index with the same key and options already exists under "
+                "a different name",
+                code=85,
+            )
+        return None
 
     def create_index(self, collection, spec):
         spec = self._coerce_index_spec(spec)
@@ -1070,16 +1188,20 @@ class SQLiteTableBackend(TableBackend):
         digest = hashlib.sha256(identity.encode("utf8")).hexdigest()[:32]
         return "__tm_idx_{0}".format(digest)
 
-    def _connect(self):
-        conn = sqlite3.connect(self.path)
+    def _read_connect(self):
+        conn = sqlite3.connect(self.path, timeout=30)
         conn.create_function(
             "tinymongo_unique_token",
             2,
             _sqlite_unique_token,
             deterministic=True,
         )
-        conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=30000")
+        return conn
+
+    def _connect(self):
+        conn = self._read_connect()
+        conn.execute("PRAGMA journal_mode=WAL")
         return conn
 
     def _ensure_index_catalog(self, conn):
@@ -1087,15 +1209,130 @@ class SQLiteTableBackend(TableBackend):
             "CREATE TABLE IF NOT EXISTS {0} ("
             "collection_name TEXT NOT NULL, index_name TEXT NOT NULL, "
             "field_name TEXT NOT NULL, unique_flag INTEGER NOT NULL, "
+            "token_version INTEGER NOT NULL DEFAULT {1}, "
             "PRIMARY KEY (collection_name, index_name))".format(
-                _quote_identifier(self.index_catalog_table)
+                _quote_identifier(self.index_catalog_table),
+                _SQLITE_UNIQUE_TOKEN_VERSION,
             )
         )
+        columns = {
+            row[1]
+            for row in conn.execute(
+                "PRAGMA table_info({0})".format(
+                    _quote_identifier(self.index_catalog_table)
+                )
+            ).fetchall()
+        }
+        migrated = False
+        if "token_version" not in columns:
+            conn.execute(
+                "ALTER TABLE {0} ADD COLUMN token_version INTEGER NOT NULL "
+                "DEFAULT 1".format(_quote_identifier(self.index_catalog_table))
+            )
+            migrated = True
+
+        stale = conn.execute(
+            "SELECT collection_name, index_name, field_name FROM {0} "
+            "WHERE unique_flag = 1 AND token_version < ?".format(
+                _quote_identifier(self.index_catalog_table)
+            ),
+            (_SQLITE_UNIQUE_TOKEN_VERSION,),
+        ).fetchall()
+        for collection, index_name, field in stale:
+            spec = IndexSpec(field=field, name=index_name, unique=True)
+            physical_name = self._physical_index_name(collection, spec)
+            exists = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+                (physical_name,),
+            ).fetchone()
+            if exists is not None:
+                try:
+                    conn.execute("REINDEX {0}".format(_quote_identifier(physical_name)))
+                except sqlite3.IntegrityError as exc:
+                    # An older token format could admit values which MongoDB
+                    # considers equal (for example int/float ``2**60``). The
+                    # old expression index is unsafe once this connection has
+                    # registered the exact-token function, so remove only its
+                    # native constraint and retain the unique catalog entry.
+                    # Store-wide write locking plus Python post-image
+                    # validation keeps the catalog fail-closed while the user
+                    # removes the conflicting row and recreates the index.
+                    conn.execute(
+                        "DROP INDEX IF EXISTS {0}".format(
+                            _quote_identifier(physical_name)
+                        )
+                    )
+                    conn.execute(
+                        "UPDATE {0} SET token_version = ? "
+                        "WHERE collection_name = ? AND index_name = ?".format(
+                            _quote_identifier(self.index_catalog_table)
+                        ),
+                        (_SQLITE_UNIQUE_TOKEN_VERSION, collection, index_name),
+                    )
+                    conn.commit()
+                    raise DuplicateKeyError(
+                        "Cannot upgrade unique index {0!r} on collection {1!r}: "
+                        "existing values conflict under exact BSON numeric "
+                        "identity. Its native constraint was disabled, but "
+                        "TinyMongo will continue enforcing the catalog entry; "
+                        "remove the conflict, then drop and recreate the "
+                        "index".format(index_name, collection)
+                    ) from exc
+            conn.execute(
+                "UPDATE {0} SET token_version = ? WHERE collection_name = ? "
+                "AND index_name = ?".format(
+                    _quote_identifier(self.index_catalog_table)
+                ),
+                (_SQLITE_UNIQUE_TOKEN_VERSION, collection, index_name),
+            )
+            migrated = True
+        if migrated:
+            conn.commit()
+
+    def _index_catalog_state(self, conn):
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (self.index_catalog_table,),
+        ).fetchone()
+        if exists is None:
+            return "absent"
+
+        columns = {
+            row[1]
+            for row in conn.execute(
+                "PRAGMA table_info({0})".format(
+                    _quote_identifier(self.index_catalog_table)
+                )
+            ).fetchall()
+        }
+        if "token_version" not in columns:
+            return "stale"
+
+        stale = conn.execute(
+            "SELECT 1 FROM {0} WHERE unique_flag = 1 AND token_version < ? "
+            "LIMIT 1".format(_quote_identifier(self.index_catalog_table)),
+            (_SQLITE_UNIQUE_TOKEN_VERSION,),
+        ).fetchone()
+        return "stale" if stale is not None else "ready"
 
     def get_index_specs(self, collection):
-        conn = self._connect()
+        conn = self._read_connect()
         try:
-            self._ensure_index_catalog(conn)
+            state = self._index_catalog_state(conn)
+            if state == "absent":
+                return []
+            if state == "stale":
+                # Index-token migrations change persisted expression-index
+                # keys. Serialize only this one-time upgrade, then leave normal
+                # catalog reads lock-free so SQLite WAL readers stay concurrent.
+                conn.close()
+                with self._write_lock():
+                    migration_conn = self._connect()
+                    try:
+                        self._ensure_index_catalog(migration_conn)
+                    finally:
+                        migration_conn.close()
+                conn = self._read_connect()
             rows = conn.execute(
                 "SELECT index_name, field_name, unique_flag FROM {0} "
                 "WHERE collection_name = ? ORDER BY index_name".format(
@@ -1243,7 +1480,169 @@ class SQLiteTableBackend(TableBackend):
                 if matches_filter(doc, filter_doc)
             ]
 
-    def _find_indexed_scalar_with_array_union(self, collection, filter_doc):
+    def find_projected(self, collection, filter_doc, projection):
+        """Scan SQLite rows while retaining only each projected post-image.
+
+        ``TinyMongoCollection`` discovers this optional backend hook at runtime,
+        which leaves the established ``find()`` signature intact for third-party
+        table backends.  Sorting deliberately does not use this path because its
+        keys must be read from the complete source documents first.
+        """
+
+        self.create_collection(collection)
+        indexed = self._find_indexed_scalar_with_array_union(
+            collection,
+            filter_doc,
+            projection=projection,
+        )
+        if indexed is not None:
+            return indexed
+
+        if requires_python_filter(filter_doc):
+            return self._scan_projected(
+                collection,
+                projection,
+                predicate=lambda document: matches_filter(document, filter_doc),
+            )
+
+        try:
+            where, params = self.compiler.compile(filter_doc)
+            if self._is_id_only_projection(projection) and not _filter_references_id(
+                filter_doc
+            ):
+                return self._scan_projected_ids(collection, where, params)
+
+            documents = self._scan_projected(
+                collection,
+                projection,
+                where=where,
+                params=params,
+                predicate=(
+                    (lambda document: matches_filter(document, filter_doc))
+                    if _filter_references_id(filter_doc)
+                    else None
+                ),
+            )
+            direct_id_equality = (
+                isinstance(filter_doc, dict)
+                and set(filter_doc) == {"_id"}
+                and not isinstance(filter_doc["_id"], dict)
+            )
+            if direct_id_equality and documents:
+                return documents
+            if _filter_requires_legacy_id_scan(filter_doc):
+                return self._scan_projected(
+                    collection,
+                    projection,
+                    predicate=lambda document: matches_filter(document, filter_doc),
+                )
+            return documents
+        except Exception:
+            return self._scan_projected(
+                collection,
+                projection,
+                predicate=lambda document: matches_filter(document, filter_doc),
+            )
+
+    @staticmethod
+    def _is_id_only_projection(projection):
+        return (
+            projection.mode == "include"
+            and projection.include_id
+            and not projection.tree
+        )
+
+    @staticmethod
+    def _project_sqlite_id(kind, value):
+        """Decode one SQLite JSON scalar without reading its document payload."""
+
+        if kind is None:
+            return {}
+        if kind == "null":
+            return {"_id": None}
+        if kind in ("true", "false"):
+            return {"_id": kind == "true"}
+        if kind == "integer":
+            # SQLite promotes JSON integers outside its signed 64-bit range to
+            # a REAL.  The caller must read just that one complete row instead
+            # of accepting a lossy identifier.
+            if isinstance(value, float):
+                return None
+            return {"_id": value}
+        if kind in ("object", "array"):
+            return _json_loads(
+                json.dumps(
+                    {"_id": json.loads(value)},
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+            )
+        return {"_id": value}
+
+    def _scan_projected_ids(self, collection, where, params):
+        """Return ``_id`` documents without transferring large JSON payloads."""
+
+        table = _quote_identifier(collection)
+        path = _sql_literal("$._id")
+        sql = (
+            "SELECT _id, json_type(data, {path}), "
+            "json_extract(data, {path}) FROM {table}{where}"
+        ).format(path=path, table=table, where=where)
+        conn = self._connect()
+        try:
+            documents = []
+            cursor = conn.execute(sql, params)
+            for physical_id, kind, value in cursor:
+                document = self._project_sqlite_id(kind, value)
+                if document is None:
+                    row = conn.execute(
+                        "SELECT data FROM {0} WHERE _id = ?".format(table),
+                        (physical_id,),
+                    ).fetchone()
+                    source_document = _json_loads(row[0])
+                    document = (
+                        {"_id": source_document["_id"]}
+                        if "_id" in source_document
+                        else {}
+                    )
+                documents.append(document)
+            return documents
+        finally:
+            conn.close()
+
+    def _scan_projected(
+        self,
+        collection,
+        projection,
+        where="",
+        params=None,
+        predicate=None,
+    ):
+        """Decode, filter, and release one source row at a time."""
+
+        sql = "SELECT data FROM {0}{1}".format(
+            _quote_identifier(collection),
+            where,
+        )
+        conn = self._connect()
+        try:
+            documents = []
+            cursor = conn.execute(sql, params or [])
+            for row in cursor:
+                document = _json_loads(row[0])
+                if predicate is not None and not predicate(document):
+                    continue
+                documents.append(project_document(document, projection))
+            return documents
+        finally:
+            conn.close()
+
+    def _find_indexed_scalar_with_array_union(
+        self,
+        collection,
+        filter_doc,
+        projection=None,
+    ):
         equality = _simple_scalar_equality(filter_doc)
         if equality is None:
             return None
@@ -1263,17 +1662,24 @@ class SQLiteTableBackend(TableBackend):
             path=path,
         )
         array_sql = (
-            "SELECT data FROM {table} WHERE json_type(data, {path}) = 'array'"
+            "SELECT data FROM {table} WHERE json_type(data, {path}) "
+            "IN ('array', 'object')"
         ).format(table=_quote_identifier(collection), path=path)
         conn = self._connect()
         try:
-            scalar_rows = conn.execute(scalar_sql, params).fetchall()
-            array_rows = conn.execute(array_sql).fetchall()
+            documents = []
+            for sql, sql_params in ((scalar_sql, params), (array_sql, [])):
+                for row in conn.execute(sql, sql_params):
+                    document = _json_loads(row[0])
+                    if matches_filter(document, filter_doc):
+                        documents.append(
+                            project_document(document, projection)
+                            if projection is not None
+                            else document
+                        )
+            return documents
         finally:
             conn.close()
-
-        candidates = [_json_loads(row[0]) for row in scalar_rows + array_rows]
-        return [doc for doc in candidates if matches_filter(doc, filter_doc)]
 
     def _all_docs_unfiltered(self, collection):
         self.create_collection(collection)
@@ -1381,11 +1787,17 @@ class SQLiteTableBackend(TableBackend):
                         )
                     )
                 conn.execute(
-                    "INSERT INTO {0} (collection_name, index_name, field_name, unique_flag) "
-                    "VALUES (?, ?, ?, ?)".format(
+                    "INSERT INTO {0} (collection_name, index_name, field_name, "
+                    "unique_flag, token_version) VALUES (?, ?, ?, ?, ?)".format(
                         _quote_identifier(self.index_catalog_table)
                     ),
-                    (collection, spec.name, spec.field, int(spec.unique)),
+                    (
+                        collection,
+                        spec.name,
+                        spec.field,
+                        int(spec.unique),
+                        _SQLITE_UNIQUE_TOKEN_VERSION,
+                    ),
                 )
                 conn.commit()
             except sqlite3.IntegrityError as exc:
@@ -2188,7 +2600,7 @@ class RemoteSQLTableBackend(TableBackend):
     def validate_unique_post_image(self, collection, documents):
         documents = list(documents)
         specs = self.get_index_specs(collection)
-        _reject_remote_unique_arrays(documents, specs)
+        _reject_remote_unique_values(documents, specs)
         validate_unique_documents(documents, specs)
 
     def _drop_native_index(self, conn, collection, spec):
@@ -2510,7 +2922,7 @@ class RemoteSQLTableBackend(TableBackend):
             return existing.name
         if spec.unique:
             documents = self.find(collection, {})
-            _reject_remote_unique_arrays(documents, [spec])
+            _reject_remote_unique_values(documents, [spec])
             validate_unique_documents(documents, [spec])
 
         conn = self._connect()

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -6,26 +6,31 @@ from __future__ import absolute_import
 
 import copy
 from collections.abc import Iterable, Mapping, MutableMapping
+from dataclasses import replace
 from functools import reduce, wraps
 import logging
 import operator as comparison_operator
 import os
 import shutil
 import threading
-import warnings
 from uuid import uuid4
 
 from tinydb import Query, TinyDB, where  # type: ignore[attr-defined]
-from .bson_codec import bson_available
+from .bson_codec import bson_available, storage_values_equal
 from .bson_types import (
+    add_bson_numbers,
     bson_identity_key,
+    bson_number_decimal,
     bson_scalar_sort_key,
     bson_value_sort_key,
     bson_values_equal,
+    decimal128_type,
+    is_bson_number,
     object_id_type,
 )
 from .aggregation import AggregationEngine, aggregation_capabilities
 from .sorting import bson_document_sort_value_key, sort_documents
+from .warning_context import emit_warning
 from .storage_backends import (
     clear_memory_database,
     clear_memory_namespace,
@@ -52,10 +57,13 @@ from .errors import (
 )
 from .indexes import (
     INDEX_CATALOG_TABLE,
+    IndexBatchPlan,
     IndexSpec,
     TinyMongoUnsupportedWarning,
+    degraded_index_reuse_warning,
     emit_index_plan_warnings,
     index_catalog_id,
+    index_spec_signature,
     parse_index_spec,
     plan_index_models,
     validate_unique_documents,
@@ -89,6 +97,7 @@ def Q(query, key):
 
 
 _MISSING = object()
+_DECIMAL128 = decimal128_type()
 
 
 def _generate_document_id():
@@ -288,10 +297,10 @@ _PULL_FIELD_OPERATORS = frozenset(("$eq",) + tuple(_PULL_COMPARISON_OPERATORS))
 _PULL_LOGICAL_OPERATORS = frozenset(("$and", "$or", "$nor"))
 
 
-def _raise_write_error(message):
+def _raise_write_error(message, code=2):
     """Raise a Mongo-shaped write error that remains a TinyMongoError."""
 
-    raise WriteError(message, code=2)
+    raise WriteError(message, code=code)
 
 
 def _is_modifier_document(value):
@@ -301,14 +310,18 @@ def _is_modifier_document(value):
 
 
 def _is_modifier_integer(value):
-    return isinstance(value, int) and not isinstance(value, bool)
+    if isinstance(value, bool) or not is_bson_number(value):
+        return False
+    numeric = bson_number_decimal(value)
+    return numeric.is_finite() and numeric == numeric.to_integral_value()
 
 
 def _is_sort_direction(value):
     return (
         not isinstance(value, bool)
-        and isinstance(value, (int, float))
-        and value in (-1, 1)
+        and is_bson_number(value)
+        and bson_number_decimal(value).is_finite()
+        and bson_number_decimal(value) in (-1, 1)
     )
 
 
@@ -438,6 +451,10 @@ def _validate_update_operators(update_doc):
         elif operator == "$pull":
             for value in changes.values():
                 _validate_pull_condition(value)
+        elif operator == "$inc":
+            for value in changes.values():
+                if not is_bson_number(value):
+                    _raise_write_error("$inc requires numeric values", code=14)
 
 
 def _sort_pushed_values(values, sort_spec):
@@ -445,7 +462,7 @@ def _sort_pushed_values(values, sort_spec):
 
     order = TinyMongoCursor([])._order
     if _is_sort_direction(sort_spec):
-        values.sort(key=order, reverse=sort_spec < 0)
+        values.sort(key=order, reverse=bson_number_decimal(sort_spec) < 0)
         return
 
     # Stable passes from the least-significant field implement a compound
@@ -453,7 +470,7 @@ def _sort_pushed_values(values, sort_spec):
     for field, direction in reversed(list(sort_spec.items())):
         values.sort(
             key=lambda item, path=field: order(_get_nested(item, path, None)),
-            reverse=direction < 0,
+            reverse=bson_number_decimal(direction) < 0,
         )
 
 
@@ -466,7 +483,7 @@ def _apply_push(current, value):
     if "$position" not in value:
         current.extend(additions)
     else:
-        position = value["$position"]
+        position = int(bson_number_decimal(value["$position"]))
         if position < 0:
             position = max(len(current) + position, 0)
         else:
@@ -477,7 +494,7 @@ def _apply_push(current, value):
         _sort_pushed_values(current, value["$sort"])
 
     if "$slice" in value:
-        limit = value["$slice"]
+        limit = int(bson_number_decimal(value["$slice"]))
         if limit > 0:
             current = current[:limit]
         elif limit < 0:
@@ -502,6 +519,17 @@ def _pull_comparison_matches(actual, operand, comparison):
     for value in values:
         value_identity = bson_identity_key(value)
         value_order = bson_scalar_sort_key(value)
+        if (
+            value_identity is not None
+            and value_identity[0] == "number"
+            and is_bson_number(value)
+            and is_bson_number(operand)
+            and (
+                bson_number_decimal(value).is_nan()
+                != bson_number_decimal(operand).is_nan()
+            )
+        ):
+            continue
         if (
             value_identity is not None
             and value_order is not None
@@ -583,7 +611,9 @@ def _apply_update_document(item, update_doc):
         elif operator == "$inc":
             for path, value in changes.items():
                 current = _get_nested(updated, path, 0)
-                _set_nested(updated, path, current + value)
+                if not is_bson_number(current) or not is_bson_number(value):
+                    _raise_write_error("$inc requires numeric values", code=14)
+                _set_nested(updated, path, add_bson_numbers(current, value))
         elif operator == "$push":
             for path, value in changes.items():
                 current = _get_nested(updated, path, [])
@@ -613,6 +643,23 @@ def _apply_update_document(item, update_doc):
 
     updated["_id"] = item["_id"]
     return updated
+
+
+def _update_document_modified(original, updated, update_doc):
+    """Report MongoDB's write result for one applied update document."""
+
+    if not storage_values_equal(updated, original):
+        return True
+    if _DECIMAL128 is None or "$inc" not in update_doc:
+        return False
+
+    # MongoDB reports an executed arithmetic update on a quiet Decimal128 NaN
+    # as modified even though the resulting BID is byte-for-byte unchanged.
+    return any(
+        isinstance(current, _DECIMAL128) and current.to_decimal().is_qnan()
+        for path in update_doc["$inc"]
+        for current in (_get_nested(original, path),)
+    )
 
 
 def _tinydb_replace_document(replacement):
@@ -1387,12 +1434,43 @@ class TinyMongoCollection(object):
 
     def _validate_index_compatibility(self, spec):
         by_name = self._index_specs.get(spec.name)
-        existing = by_name
-        if existing is not None and existing != spec:
+        if by_name is not None and by_name != spec:
             raise OperationFailure(
                 "An index with the same name or key has different options"
             )
-        return existing
+        if by_name is not None:
+            # Preserve idempotent retries for legacy catalogs which may still
+            # contain an equivalent index under another name.
+            return by_name
+        equivalent = next(
+            (
+                current
+                for current in self._index_specs.values()
+                if index_spec_signature(current) == index_spec_signature(spec)
+            ),
+            None,
+        )
+        if equivalent is not None and equivalent.name != spec.name:
+            raise OperationFailure(
+                "An index with the same key and options already exists under "
+                "a different name",
+                code=85,
+            )
+        return None
+
+    def _current_index_specs(self):
+        """Return refreshed user-created index specs for batch planning."""
+        if self.parent.engine is not None:
+            return tuple(self.parent.engine.get_index_specs(self.tablename))
+
+        rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            if self.table is None:
+                self.build_table()
+            self._refresh_table()
+            return tuple(self._index_specs.values())
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
 
     def _validate_unique_post_image(self, documents, extra_specs=()):
         specs = list(self._index_specs.values()) + list(extra_specs)
@@ -1436,21 +1514,61 @@ class TinyMongoCollection(object):
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
+    @_engine_write_locked
     def create_indexes(self, indexes, *args, **kwargs):
         """Create a validated batch of PyMongo-style index models."""
         if args:
             raise TypeError("create_indexes accepts one iterable of index models")
         _reject_session(kwargs)
         batch = plan_index_models(indexes)
+        if self.parent.engine is not None:
+            return self._create_indexes_locked(batch)
+
+        rlock, portalocker_lock = self._acquire_collection_lock()
+        try:
+            return self._create_indexes_locked(batch)
+        finally:
+            self._release_collection_lock(rlock, portalocker_lock)
+
+    def _create_indexes_locked(self, batch):
+        """Plan and create a validated batch while holding its storage lock."""
+        effective = {
+            index_spec_signature(spec): spec for spec in self._current_index_specs()
+        }
+        resolved_entries = []
+        names = []
         for entry in batch:
             if entry.spec is None:
+                resolved_entries.append(entry)
+                names.append(entry.name)
+                continue
+            signature = index_spec_signature(entry.spec)
+            existing = effective.get(signature)
+            if (
+                existing is not None
+                and existing.name != entry.spec.name
+                and entry.degraded_features
+            ):
+                resolved_entries.append(
+                    replace(
+                        entry,
+                        warning=degraded_index_reuse_warning(entry, existing),
+                    )
+                )
+                names.append(existing.name)
                 continue
             options = {"name": entry.spec.name}
             if entry.spec.unique:
                 options["unique"] = True
-            self.create_index([(entry.spec.field, ASCENDING)], **options)
-        emit_index_plan_warnings(batch, stacklevel=3)
-        return list(batch.names)
+            name = self.create_index([(entry.spec.field, ASCENDING)], **options)
+            effective[signature] = replace(entry.spec, name=name)
+            resolved_entries.append(entry)
+            names.append(name)
+        emit_index_plan_warnings(
+            IndexBatchPlan(tuple(resolved_entries)),
+            stacklevel=3,
+        )
+        return names
 
     @_engine_write_locked
     def drop_index(self, key):
@@ -2056,7 +2174,7 @@ class TinyMongoCollection(object):
                 return UpdateResult(raw_result=[], matched_count=0, modified_count=0)
             updated = self.parent.engine.apply_update(matches[0], doc)
             self._validate_storage_document(updated)
-            modified = not bson_values_equal(updated, matches[0])
+            modified = _update_document_modified(matches[0], updated, doc)
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
                 [
@@ -2124,7 +2242,7 @@ class TinyMongoCollection(object):
 
             updated = _apply_update_document(item, doc)
             self._validate_storage_document(updated)
-            modified = not bson_values_equal(updated, item)
+            modified = _update_document_modified(item, updated, doc)
             if modified:
                 post_image = [
                     (
@@ -2189,7 +2307,8 @@ class TinyMongoCollection(object):
             for _original, updated in updates:
                 self._validate_storage_document(updated)
             modified_count = sum(
-                not bson_values_equal(updated, item) for item, updated in updates
+                _update_document_modified(item, updated, doc)
+                for item, updated in updates
             )
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
@@ -2272,7 +2391,7 @@ class TinyMongoCollection(object):
             result = []
             modified_count = 0
             for item, updated in updates:
-                if not bson_values_equal(updated, item):
+                if _update_document_modified(item, updated, doc):
                     modified_count += 1
                     result.extend(
                         self.table.update(
@@ -2320,10 +2439,14 @@ class TinyMongoCollection(object):
                         upserted_id=inserted["_id"],
                     )
                 return UpdateResult(raw_result=[])
-            updated = copy.deepcopy(replacement)
+            # MongoDB stores ``_id`` first even when the replacement omitted it.
+            # Keep that canonical order so a later equivalent replacement is
+            # not misreported as a field-order-only modification.
+            updated = {"_id": item["_id"]}
+            updated.update(copy.deepcopy(replacement))
             updated["_id"] = item["_id"]
             self._validate_storage_document(updated)
-            modified = updated != item
+            modified = not storage_values_equal(updated, item)
             if modified:
                 self.parent.engine.validate_unique_post_image(
                     self.tablename,
@@ -2387,10 +2510,11 @@ class TinyMongoCollection(object):
                     )
                 return UpdateResult(raw_result=[])
 
-            updated = copy.deepcopy(replacement)
+            updated = {"_id": item["_id"]}
+            updated.update(copy.deepcopy(replacement))
             updated["_id"] = item["_id"]
             self._validate_storage_document(updated)
-            modified = updated != item
+            modified = not storage_values_equal(updated, item)
             if modified:
                 post_image = [
                     (
@@ -2523,7 +2647,14 @@ class TinyMongoCollection(object):
         projection = normalize_projection(projection)
         sort = kwargs.get("sort")
         if self.parent.engine is not None:
-            result = self.parent.engine.find(self.tablename, _filter)
+            projected_find = getattr(self.parent.engine, "find_projected", None)
+            projection_applied = (
+                projection is not None and not sort and callable(projected_find)
+            )
+            if projection_applied:
+                result = projected_find(self.tablename, _filter, projection)
+            else:
+                result = self.parent.engine.find(self.tablename, _filter)
             return TinyMongoCursor(
                 result,
                 sort=sort,
@@ -2532,6 +2663,7 @@ class TinyMongoCollection(object):
                 collection=self,
                 projection=projection,
                 query=_filter,
+                source_projected=projection_applied,
             )
 
         rlock, portalocker_lock = self._acquire_collection_lock()
@@ -2727,6 +2859,7 @@ class TinyMongoCursor(object):
         collection=None,
         projection=None,
         query=None,
+        source_projected=False,
     ):
         """Initialize the mongo iterable cursor with data"""
         self._source_data = list(cursordat)
@@ -2734,6 +2867,7 @@ class TinyMongoCursor(object):
         self.collection = collection
         self.projection = projection
         self.query = copy.deepcopy(query)
+        self._source_projected = source_projected
         self._sort_spec = None
         self._skip = 0
         self._limit = 0
@@ -2793,7 +2927,7 @@ class TinyMongoCursor(object):
         if warning_key in self._unsupported_sort_warnings:
             return
         self._unsupported_sort_warnings.add(warning_key)
-        warnings.warn(
+        emit_warning(
             "Sorting field '{0}' encountered unsupported value type '{1}'; "
             "values of this type compare as null.".format(
                 field,
@@ -2876,6 +3010,14 @@ class TinyMongoCursor(object):
             )
 
         self._sort_spec = (copy.deepcopy(key_or_list), direction)
+
+        if self._source_projected:
+            # A chained sort can name a field omitted by the projection.  Load
+            # complete post-filter documents before ordering so projection
+            # pushdown never changes cursor semantics.
+            source = self.collection.find(copy.deepcopy(self.query))
+            self._source_data = list(source._source_data)
+            self._source_projected = False
 
         self._source_data = sort_documents(
             self._source_data,

--- a/tinymongo/warning_context.py
+++ b/tinymongo/warning_context.py
@@ -1,0 +1,109 @@
+"""Preserve application warning locations across async worker threads."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+import inspect
+import sys
+from typing import Iterator, Optional, Type
+import warnings
+
+
+@dataclass(frozen=True)
+class WarningOrigin:
+    """The external source location responsible for a TinyMongo operation."""
+
+    filename: str
+    lineno: int
+    module: Optional[str]
+
+
+_WARNING_ORIGIN: ContextVar[Optional[WarningOrigin]] = ContextVar(
+    "tinymongo_warning_origin",
+    default=None,
+)
+
+
+def capture_warning_origin() -> Optional[WarningOrigin]:
+    """Return the first caller frame outside the :mod:`tinymongo` package."""
+
+    frame = inspect.currentframe()
+    if frame is None:  # pragma: no cover - supported interpreters provide frames
+        return None
+    frame = frame.f_back
+    try:
+        while frame is not None:
+            module = frame.f_globals.get("__name__")
+            if not isinstance(module, str) or not (
+                module == "tinymongo" or module.startswith("tinymongo.")
+            ):
+                return WarningOrigin(
+                    filename=frame.f_code.co_filename,
+                    lineno=frame.f_lineno,
+                    module=module if isinstance(module, str) else None,
+                )
+            frame = frame.f_back
+        return None
+    finally:
+        # Frames retain their locals and callers, so never keep this reference
+        # alive after reducing it to immutable source metadata.
+        del frame
+
+
+@contextmanager
+def use_warning_origin(origin: Optional[WarningOrigin]) -> Iterator[None]:
+    """Make ``origin`` available to warning emitters in the current context."""
+
+    if origin is None:
+        yield
+        return
+    token = _WARNING_ORIGIN.set(origin)
+    try:
+        yield
+    finally:
+        _WARNING_ORIGIN.reset(token)
+
+
+def emit_warning(message: str, category: Type[Warning], stacklevel: int = 2) -> None:
+    """Emit a warning at a captured async origin or the synchronous caller."""
+
+    origin = _WARNING_ORIGIN.get() or capture_warning_origin()
+    if origin is None:
+        # This is only a fallback for runtimes which do not expose frames.
+        # Account for this helper so a supplied legacy stacklevel keeps the
+        # same meaning it had when the call site used ``warnings.warn``.
+        warnings.warn(message, category, stacklevel=stacklevel + 1)
+        return
+
+    registry = None
+    if origin.module is not None:
+        loaded_module = sys.modules.get(origin.module)
+        if loaded_module is not None:
+            registry = loaded_module.__dict__.setdefault("__warningregistry__", {})
+    if origin.module is None:
+        warnings.warn_explicit(
+            message,
+            category,
+            filename=origin.filename,
+            lineno=origin.lineno,
+            registry=registry,
+        )
+    else:
+        warnings.warn_explicit(
+            message,
+            category,
+            filename=origin.filename,
+            lineno=origin.lineno,
+            module=origin.module,
+            registry=registry,
+        )
+
+
+__all__ = [
+    "WarningOrigin",
+    "capture_warning_origin",
+    "emit_warning",
+    "use_warning_origin",
+]


### PR DESCRIPTION
## Summary

This PR adds full `Decimal128` behavior alongside the existing synchronous and asynchronous APIs, then closes the concrete compatibility and performance findings from Mike's latest Talk Python testing.

The work is shared across TinyMongo's storage and query layers so JSON, memory, SQLite, DuckDB, Parquet, PostgreSQL, and MariaDB/MySQL clients keep the same observable API wherever the backend can provide the required guarantees.

## Decimal128 support

- Preserves the exact BSON Decimal128 BID representation during storage round trips.
- Adds MongoDB-style numeric equality, range queries, ordering, sorting, and `distinct()` behavior.
- Supports Decimal128 in `$inc`, `$sum`, `$min`, and `$max`, including precision, ties, infinities, and NaN cases.
- Accepts Decimal128 projection flags, aggregation-stage numeric arguments, and array-modifier numeric arguments where MongoDB does.
- Uses BSON-exact stored-value comparison for update results, so `modified_count` reflects representation changes correctly.
- Handles extreme Decimal128 values and IDs without depending on Python's integer-string digit limit.
- Preserves exact numeric identity for embedded unique indexes across integers, floats, and Decimal128 values.
- Raises a clear optional-dependency error when Decimal128 is used without PyMongo's BSON package.
- Applies the same behavior to sync and async clients.

Remote SQL backends now fail closed when asked to create a Decimal128 unique index. Their native constraints cannot yet guarantee TinyMongo's exact cross-type numeric identity under concurrent writers, so silently promising uniqueness would be unsafe.

## SQLite migration and recovery

SQLite's exact-value token format moves to version 3. Existing stores are migrated and reindexed once under the write lock, while normal reads remain lock-free after migration.

If an older unique index contains integer/float values that become equivalent under the corrected rules, TinyMongo reports the conflicting values with `DuplicateKeyError`, removes the unsafe native expression index, and preserves serialized catalog enforcement. The conflict can then be repaired and the index dropped or recreated without stranding the store.

The migration was exercised with 1,000 threaded races and 75 process races, including readers opening databases while another process upgrades the token format.

## Talk Python follow-ups

- **TM-001 — degraded indexes:** equivalent degraded indexes are reused with a warning; batch creation is planned under one lock; legacy same-name retries are idempotent; built-in `_id_` behavior is preserved; differently named equivalents raise MongoDB-style code 85.
- **TM-002 — patch/import order:** the README now explains why module-attribute patching is preferred and why `from pymongo import ...` imports made before `tinymongo.patch()` cannot be replaced.
- **TM-005 — warning attribution:** warnings now point to application call sites for both sync calls and work executed through async worker threads.
- **TM-011 — SQLite projection memory:** unsorted projected scans shape and release each row as it is read, and an `_id`-only path avoids transferring the payload column. Mike's 400-document × 200,000-character reproduction dropped from **160.26 MB to 0.26 MB** peak memory locally, a **99.84% reduction**.
- **TM-012 — lock scope:** documentation now states the exact read/write lock behavior for SQLite, TinyDB/JSON, DuckDB, and Parquet.

Sorted SQLite cursors still need complete documents before sorting, and non-SQLite backends retain their documented projection behavior.

## Documentation

The README, changelog, and roadmap now describe the supported Decimal128 behavior, optional BSON dependency, backend uniqueness boundary, projection optimization, patching limitation, warning attribution, and storage lock scopes.

## Validation

- Full non-integration suite: **2,163 passed, 281 deselected**
- Coverage: **100% statements and branches** (6,183 statements; 2,484 branches)
- Live MongoDB Decimal128 sync/async contract: **22 passed**
- PostgreSQL and MariaDB:
  - Decimal128 contract: **44/44 passed**
  - Remote integration: **16/16 passed**
  - Extreme-ID checks: **4/4 passed**
- Python 3.13 focused checks: **12/12 passed**
- Python 3.13, 3.14, and 3.14t extreme Decimal128 ID checks: passed
- Adversarial numeric token differential: **13,351 values, zero mismatches**
- Mike's projection reproduction: **160.26 MB → 0.26 MB**
- Ruff: passed
- Black: passed
- mypy: passed
- Package build and Twine validation: passed

## Remaining boundaries

This advances the broader BSON compatibility work in #75. UUID and regular-expression persistence remain separate roadmap work, and exact cross-type Decimal128 uniqueness for native remote-SQL constraints remains deferred until those databases can enforce the same identity rules safely.
