### PR TITLE
Add UUID, regex, and remaining group accumulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - A shared, backend-independent aggregation engine for `$match`, `$sort`,
   `$skip`, `$limit`, `$count`, `$project`, `$set`, `$addFields`, `$unset`, and
   `$group`, with `$ifNull`, `$literal`, and `$size` projection expressions,
-  `$$REMOVE`, field-path or null group keys, and `$min`, `$max`, and `$sum`
-  accumulators across synchronous and asynchronous clients.
+  `$$REMOVE`, field-path or null group keys, and `$addToSet`, `$avg`, `$first`,
+  `$last`, `$max`, `$min`, `$push`, and `$sum` accumulators across synchronous
+  and asynchronous clients.
 - Cross-backend and real-MongoDB aggregation contracts based on production
   application pipelines, including full inclusion/exclusion and computed
   projection modes, dotted array writes and sorts, BSON ordering, pagination,
@@ -18,6 +19,11 @@
 - Exact optional Decimal128 persistence plus numeric equality, range queries,
   sorting, embedded unique indexes, `$inc`, and `$group` accumulators across
   backends.
+- Native UUID and compiled-regex persistence plus optional `bson.Regex`
+  round trips, BSON-aware querying, sorting, distinct values, IDs, and embedded
+  unique-index identity across synchronous and asynchronous backends. UUIDs
+  use standard subtype-4 BinData identity, and native or BSON regex values use
+  their pattern plus canonical MongoDB options.
 
 ### Changed
 - Aggregation capability reporting now describes the exact supported stages,
@@ -28,6 +34,9 @@
 - Remote SQL unique indexes fail closed for Decimal128 values, as they already
   do for arrays, when their native JSON constraints cannot guarantee exact
   MongoDB numeric identity across concurrent writers.
+- Remote SQL unique indexes also fail closed for Binary, UUID, and regex values
+  whose exact cross-process BSON identity cannot be enforced by the native JSON
+  constraint.
 
 ### Fixed
 - Aggregation field references no longer cross a raw array nested directly

--- a/README.md
+++ b/README.md
@@ -480,13 +480,14 @@ leading-field prefix. Sparse membership is not honored and TTL expiration is
 not performed; both are reported explicitly. A semantically unsafe unique
 declaration is rejected before any batch entry is created.
 
-Unique indexes support scalar values and flat arrays on embedded backends;
-missing and `null` share one unique key. Object values, nested arrays,
-non-finite numbers, and array traversal inside a dotted index path are not
-supported for unique indexes yet. Remote SQL uses native constraints for
-ordinary JSON scalar races. It rejects array and `Decimal128` values under
-unique indexes because its native JSON indexes cannot yet guarantee
-cross-process MongoDB multikey or exact numeric uniqueness.
+Unique indexes support JSON scalar values, Decimal128, UUID/Binary, regex, and
+flat arrays on embedded backends; missing and `null` share one unique key.
+Object values, ObjectId, datetime, nested arrays, non-finite numbers, and array
+traversal inside a dotted index path are not supported for unique indexes yet.
+Remote SQL uses native constraints for ordinary JSON scalar races. It rejects
+array, Decimal128, UUID/Binary, and regex values under unique indexes because
+its native JSON indexes cannot yet guarantee cross-process MongoDB multikey,
+numeric, or BSON identity.
 
 SQL, DuckDB, and Parquet storage uses typed physical `_id` keys for new rows.
 Existing databases with older stringified keys remain readable and mutable.
@@ -509,7 +510,8 @@ supports inclusion, exclusion, renamed or computed fields, nested
 specifications, dotted output paths through arrays, and MongoDB's special
 `_id` rules. The available projection expressions are `$ifNull`, `$literal`,
 and `$size`; `$$REMOVE` conditionally omits or removes a field. `$group` accepts
-a field-path or `None` `_id` and the `$min`, `$max`, and `$sum` accumulators:
+a field-path or `None` `_id` and the `$addToSet`, `$avg`, `$first`, `$last`,
+`$max`, `$min`, `$push`, and `$sum` accumulators:
 
 ```python
 activity = events.aggregate(
@@ -549,8 +551,16 @@ list of field names and follows exclusion projection behavior. Numeric
 array-index paths remain unsupported for projection output.
 
 `$min` and `$max` ignore null and missing inputs unless every input is null or
-missing, in which case they return null. `$sum` ignores missing and nonnumeric
-values, and an empty input produces no groups, including for `_id: None`.
+missing, in which case they return null. `$sum` and `$avg` ignore missing and
+nonnumeric values; `$avg` returns null when it sees no numbers and returns a
+`Decimal128` result when any input is Decimal128. `$first` and `$last` follow
+the incoming document order and turn a selected missing value into null.
+`$push` retains input order, skips missing values, and keeps explicit nulls;
+`$addToSet` applies recursive BSON equality while making no output-order
+promise. Accumulator operands may use TinyMongo's supported expressions; wrap
+a literal array in `$literal` because a direct array is parsed as an invalid
+argument list, matching MongoDB. An empty input produces no groups, including
+for `_id: None`.
 TinyMongo keeps first-seen group order for repeatable local results, but—as with
 MongoDB—`$group` output order is not a public guarantee.
 
@@ -562,12 +572,13 @@ any aggregation subset is available. In particular, `$replaceRoot`,
 `$replaceWith`, `$meta` sort expressions, variables other than `$$REMOVE`, and
 MongoDB's broader expression language are not part of this slice yet.
 
-## ObjectId, datetime, binary, and Decimal128 values
+## ObjectId, datetime, binary, Decimal128, UUID, and regex values
 
-`datetime` and `bytes` values round-trip through every backend. `bytearray` is
-accepted and reads back as `bytes`. Install the optional BSON extra to use
-`bson.ObjectId`, `bson.Decimal128`, or non-generic `bson.Binary` subtypes
-without making PyMongo a core dependency:
+`datetime`, `bytes`, native `uuid.UUID`, and compiled `re.Pattern` values
+round-trip through every backend. `bytearray` is accepted and reads back as
+`bytes`. Install the optional BSON extra to use `bson.ObjectId`,
+`bson.Decimal128`, `bson.Regex`, or non-generic `bson.Binary` subtypes without
+making PyMongo a core dependency:
 
 ```bash
 pip install "tinymongo[bson]"
@@ -583,7 +594,10 @@ string and integer IDs remain readable and are never rewritten.
 
 ```python
 from datetime import datetime
-from bson import Binary, Decimal128, ObjectId
+import re
+from uuid import UUID
+
+from bson import Binary, Decimal128, ObjectId, Regex
 
 episode_id = ObjectId()
 episodes.insert_one(
@@ -593,6 +607,9 @@ episodes.insert_one(
         "price": Decimal128("19.95"),
         "image": b"\x89PNG\r\n\x1a\n",
         "asset_id": Binary(bytes(range(16)), subtype=4),
+        "session_id": UUID("00112233-4455-6677-8899-aabbccddeeff"),
+        "topic_pattern": Regex("python|mongodb", "i"),
+        "local_pattern": re.compile("async", re.IGNORECASE),
         "title": "Async Python",
     }
 )
@@ -608,9 +625,23 @@ subtypes preserve `bson.Binary.subtype`. The exact two-key mapping shape using
 codec; new user mappings with that shape are escaped automatically. If an
 older database already contains that valid tag shape as ordinary data, whether
 written through an earlier API or edited manually, rename one of those keys
-before upgrading so it is not interpreted as the tagged value. UUID and
-regular-expression round trips remain
-tracked in [#75](https://github.com/schapman1974/tinymongo/issues/75).
+before upgrading so it is not interpreted as the tagged value. UUID values use
+the RFC-4122 byte order and share BSON identity with subtype-4 `Binary` values.
+TinyMongo consistently uses this standard UUID representation; unlike a
+default PyMongo client, it does not require a per-client UUID representation
+setting for native UUID values.
+Native compiled patterns retain their Python representation; `bson.Regex`
+values retain their BSON representation, pattern, and flags. Regex identity is
+the pattern plus MongoDB's canonical option string. Preserving a native
+`re.Pattern` on read is a TinyMongo convenience extension; PyMongo decodes the
+same wire value as `bson.Regex`. An implicit regex filter,
+`$regex`, `$in`, `$nin`, `$all`, or `$not` pattern-matches strings and exact
+stored regex values, while explicit `$eq` compares only stored regex identity.
+TinyMongo evaluates patterns with Python's `re` engine rather than MongoDB's
+PCRE2 engine, so a pattern must be valid Python syntax and some advanced syntax
+or matching details can differ between the two engines. A stored BSON regex
+using the locale flag can still be retrieved by exact regex identity even when
+Python cannot apply that flag to a Unicode string predicate.
 Non-finite floats (`NaN`, positive infinity, and negative infinity) also use
 strict JSON-safe tags. Remote SQL keeps the encoded document as a normal,
 indexable object in its existing JSON/JSONB `data` column and stores a second
@@ -619,10 +650,11 @@ field order. Older rows without that copy remain readable through `data`;
 rewriting one populates its ordered copy.
 
 Sorts normalize naive datetimes as UTC and convert aware datetimes to UTC.
-BinData sorts by length, subtype, and then unsigned bytes, matching MongoDB.
-Numeric `NaN` sorts below every other numeric value, matching MongoDB.
-TinyMongo retains Python microseconds, so it can distinguish two datetimes that
-MongoDB would store in the same millisecond.
+BinData—including UUID—sorts by length, subtype, and then unsigned bytes,
+matching MongoDB. Regex values sort by pattern and canonical options after the
+other supported scalar families. Numeric `NaN` sorts below every other numeric
+value, matching MongoDB. TinyMongo retains Python microseconds, so it can
+distinguish two datetimes that MongoDB would store in the same millisecond.
 
 Decimal128 values retain their exact BSON representation and participate in
 numeric equality and range queries, sorting, embedded-backend unique indexes,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,10 +161,10 @@ Application-compatibility work:
   - [x] Complete the write-heavy admin and multi-worker SQLite follow-up: all
     21 admin checks passed with no errors, lost writes, or torn reads.
 - [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
-- [ ] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
+- [x] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
   - [x] Milestone 1 ObjectId, datetime, and Binary storage/query support.
   - [x] **TM-014:** Add Decimal128 round trips and numeric behavior.
-  - [ ] Add UUID and regular-expression round trips.
+  - [x] Add UUID and regular-expression round trips.
 - [ ] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
   - [x] Talk Python query slice: scalar-to-array equality, combined `$nin`,
     `$not`, `$regex`, case-insensitive `$options`, and Mongo-correct
@@ -201,7 +201,7 @@ Exit criteria:
 
 [View milestone](https://github.com/schapman1974/tinymongo/milestone/2)
 
-- [ ] [#82: Shared aggregation pipeline engine](https://github.com/schapman1974/tinymongo/issues/82)
+- [x] [#82: Shared aggregation pipeline engine](https://github.com/schapman1974/tinymongo/issues/82)
   - [x] Land the first shared sync/async engine slice with pipeline validation,
     compatible cursors, structured capability reporting, and clear unsupported
     feature errors.
@@ -213,10 +213,11 @@ Exit criteria:
   - [x] Add the application-required `$project`, `$size`, and `$ifNull` slice.
   - [x] Complete the initial projection scope with full `$project` modes,
     `$set`, `$addFields`, `$unset`, `$literal`, and `$$REMOVE`.
-- [ ] [#91: Grouping and accumulators](https://github.com/schapman1974/tinymongo/issues/91)
+- [x] [#91: Grouping and accumulators](https://github.com/schapman1974/tinymongo/issues/91)
   - [x] Support field-path and `None` group keys with `$min`, `$max`, and
     `$sum`.
-  - [ ] Complete the remaining accumulator scope.
+  - [x] Complete the remaining accumulator scope with `$avg`, `$first`,
+    `$last`, `$push`, and `$addToSet`.
 
 Exit criteria:
 
@@ -384,7 +385,7 @@ Exit criteria:
    - [x] Add deterministic reporting and an external application test runner.
    - [x] Complete the real application run with Mike and record every difference.
    - [ ] Rerun the three follow-up cases and publish the dimensioned baseline.
-5. [ ] Build aggregation core after the real-application acceptance path works.
+5. [x] Build aggregation core after the real-application acceptance path works.
    - [x] Deliver the shared `$match` plus `$group`/`$min`/`$max`/`$sum` slice
      across synchronous and asynchronous APIs.
    - [x] Add the measured `$project`/`$size`/`$ifNull` slice.

--- a/tests/contracts/test_group_accumulators_contract.py
+++ b/tests/contracts/test_group_accumulators_contract.py
@@ -1,0 +1,329 @@
+"""Common ``$group`` accumulator behavior shared by every target."""
+
+import math
+
+import pytest
+from bson import Decimal128
+
+from tinymongo.bson_types import bson_value_identity_key
+
+from .support import observe
+
+
+pytestmark = pytest.mark.contract
+
+
+def _by_id(rows):
+    return {row["_id"]: row for row in rows}
+
+
+def test_avg_ignores_non_numeric_values_and_promotes_decimal(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "bucket": "decimal", "value": 1},
+            {"_id": 2, "bucket": "decimal", "value": 2.0},
+            {"_id": 3, "bucket": "decimal", "value": Decimal128("3.00")},
+            {"_id": 4, "bucket": "decimal", "value": True},
+            {"_id": 5, "bucket": "decimal", "value": "ignored"},
+            {"_id": 6, "bucket": "decimal", "value": None},
+            {"_id": 7, "bucket": "decimal"},
+            {"_id": 8, "bucket": "double", "value": 1},
+            {"_id": 9, "bucket": "double", "value": 2},
+            {"_id": 10, "bucket": "empty", "value": False},
+            {"_id": 11, "bucket": "empty", "value": [100]},
+            {"_id": 12, "bucket": "mixed-exact", "value": Decimal128("1.00")},
+            {"_id": 13, "bucket": "mixed-exact", "value": 2.1},
+        ]
+    )
+
+    rows = _by_id(
+        collection.aggregate(
+            [{"$group": {"_id": "$bucket", "average": {"$avg": "$value"}}}]
+        )
+    )
+
+    assert rows["decimal"] == {
+        "_id": "decimal",
+        "average": Decimal128("2.00"),
+    }
+    assert rows["double"] == {"_id": "double", "average": 1.5}
+    assert isinstance(rows["double"]["average"], float)
+    assert rows["empty"] == {"_id": "empty", "average": None}
+    assert rows["mixed-exact"] == {
+        "_id": "mixed-exact",
+        "average": Decimal128("1.550000000000000044408920985006262"),
+    }
+
+
+def test_avg_preserves_cancellation_and_nonfinite_values(contract_target):
+    collection = contract_target.collection
+    grouped_values = {
+        "cancel-middle": [1e16, 1.0, -1e16],
+        "cancel-last": [1e16, -1e16, 1.0],
+        "large-integers": [2**60, (2**60) + 2],
+        "large-negative-integers": [-(2**60), -(2**60) + 2],
+        "int64-cancellation": [
+            7900154101625246752,
+            -1259608310039654329,
+            -6593466016263951012,
+        ],
+        "int64-cancellation-with-double": [
+            7900154101625246752,
+            -1259608310039654329,
+            float(-6593466016263951012),
+        ],
+        "decimal-cancel": [
+            Decimal128("1E+34"),
+            1.0,
+            Decimal128("-1E+34"),
+        ],
+        "nan": [float("nan"), 1.0],
+        "infinity": [float("inf"), 1.0],
+        "opposite-infinities": [float("inf"), float("-inf")],
+        "decimal-infinity": [Decimal128("Infinity"), 1.0],
+        "decimal-opposite-infinities": [Decimal128("Infinity"), float("-inf")],
+    }
+    documents = []
+    document_id = 0
+    for bucket, values in grouped_values.items():
+        for value in values:
+            documents.append({"_id": document_id, "bucket": bucket, "value": value})
+            document_id += 1
+    collection.insert_many(documents)
+
+    rows = _by_id(
+        collection.aggregate(
+            [
+                {"$sort": {"_id": 1}},
+                {"$group": {"_id": "$bucket", "average": {"$avg": "$value"}}},
+            ]
+        )
+    )
+
+    assert rows["cancel-middle"]["average"] == 0.0
+    assert rows["cancel-last"]["average"] == 1.0 / 3.0
+    assert rows["large-integers"]["average"] == float((2**60) + 1)
+    assert rows["large-negative-integers"]["average"] == float(-(2**60) + 1)
+    assert rows["int64-cancellation"]["average"] == 1.5693258440547136e16
+    assert rows["int64-cancellation-with-double"]["average"] == 1.5693258440546986e16
+    assert rows["decimal-cancel"]["average"] == Decimal128(
+        "0.3333333333333333333333333333333333"
+    )
+    assert math.isnan(rows["nan"]["average"])
+    assert rows["infinity"]["average"] == float("inf")
+    assert math.isnan(rows["opposite-infinities"]["average"])
+    assert rows["decimal-infinity"]["average"] == Decimal128("Infinity")
+    assert rows["decimal-opposite-infinities"]["average"].to_decimal().is_nan()
+
+
+def test_first_last_and_push_follow_sorted_input_and_missing_rules(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "bucket": "first-missing", "rank": 2, "value": "last"},
+            {"_id": 2, "bucket": "first-missing", "rank": 1},
+            {"_id": 3, "bucket": "first-missing", "rank": 3, "value": None},
+            {"_id": 4, "bucket": "last-missing", "rank": 1, "value": "first"},
+            {"_id": 5, "bucket": "last-missing", "rank": 2, "value": None},
+            {"_id": 6, "bucket": "last-missing", "rank": 3},
+        ]
+    )
+
+    rows = _by_id(
+        collection.aggregate(
+            [
+                {"$sort": {"rank": 1}},
+                {
+                    "$group": {
+                        "_id": "$bucket",
+                        "first_rank": {"$first": "$rank"},
+                        "last_rank": {"$last": "$rank"},
+                        "first_value": {"$first": "$value"},
+                        "last_value": {"$last": "$value"},
+                        "values": {"$push": "$value"},
+                    }
+                },
+            ]
+        )
+    )
+
+    assert rows["first-missing"] == {
+        "_id": "first-missing",
+        "first_rank": 1,
+        "last_rank": 3,
+        "first_value": None,
+        "last_value": None,
+        "values": ["last", None],
+    }
+    assert rows["last-missing"] == {
+        "_id": "last-missing",
+        "first_rank": 1,
+        "last_rank": 3,
+        "first_value": "first",
+        "last_value": None,
+        "values": ["first", None],
+    }
+
+
+def test_add_to_set_uses_recursive_bson_identity(contract_target):
+    collection = contract_target.collection
+    values = [
+        1,
+        1.0,
+        Decimal128("1.00"),
+        True,
+        None,
+        {"a": 1, "b": 2},
+        {"a": 1.0, "b": 2},
+        {"b": 2, "a": 1},
+        [1, 2],
+        [1.0, 2],
+        [2, 1],
+        float("nan"),
+        Decimal128("NaN"),
+    ]
+    collection.insert_many(
+        [{"_id": index, "value": value} for index, value in enumerate(values)]
+        + [{"_id": len(values)}, {"_id": len(values) + 1}]
+    )
+
+    result = list(
+        collection.aggregate(
+            [{"$group": {"_id": None, "values": {"$addToSet": "$value"}}}]
+        )
+    )[0]["values"]
+    actual_keys = {bson_value_identity_key(value) for value in result}
+    expected_values = [
+        1,
+        True,
+        None,
+        {"a": 1, "b": 2},
+        {"b": 2, "a": 1},
+        [1, 2],
+        [2, 1],
+        float("nan"),
+    ]
+    expected_keys = {bson_value_identity_key(value) for value in expected_values}
+
+    assert len(result) == len(expected_values)
+    assert actual_keys == expected_keys
+    assert any(isinstance(value, float) and math.isnan(value) for value in result)
+
+
+def test_array_values_remain_whole_accumulator_values(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": [1, 2]},
+            {"_id": 2, "value": [1, 2]},
+            {"_id": 3, "value": [3, 4]},
+        ]
+    )
+
+    result = list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "first": {"$first": "$value"},
+                        "last": {"$last": "$value"},
+                        "pushed": {"$push": "$value"},
+                        "unique": {"$addToSet": "$value"},
+                    }
+                }
+            ]
+        )
+    )[0]
+    unique = result.pop("unique")
+    assert result == {
+        "_id": None,
+        "first": [1, 2],
+        "last": [3, 4],
+        "pushed": [[1, 2], [1, 2], [3, 4]],
+    }
+    assert {tuple(value) for value in unique} == {(1, 2), (3, 4)}
+
+
+def test_accumulators_accept_the_supported_expression_subset(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "items": [1, 2]},
+            {"_id": 2, "items": []},
+        ]
+    )
+
+    assert list(
+        collection.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": None,
+                        "literal": {"$first": {"$literal": "$not-a-path"}},
+                        "arrays": {"$push": {"$literal": [1, 2]}},
+                        "sizes": {"$push": {"$size": "$items"}},
+                        "fallbacks": {
+                            "$addToSet": {"$ifNull": ["$missing", "fallback"]}
+                        },
+                    }
+                }
+            ]
+        )
+    ) == [
+        {
+            "_id": None,
+            "literal": "$not-a-path",
+            "arrays": [[1, 2], [1, 2]],
+            "sizes": [2, 0],
+            "fallbacks": ["fallback"],
+        }
+    ]
+
+
+def test_missing_only_arrays_and_empty_inputs_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many([{"_id": 1}, {"_id": 2}])
+
+    pipeline = [
+        {
+            "$group": {
+                "_id": None,
+                "average": {"$avg": "$missing"},
+                "first": {"$first": "$missing"},
+                "last": {"$last": "$missing"},
+                "pushed": {"$push": "$missing"},
+                "unique": {"$addToSet": "$missing"},
+            }
+        }
+    ]
+    assert list(collection.aggregate(pipeline)) == [
+        {
+            "_id": None,
+            "average": None,
+            "first": None,
+            "last": None,
+            "pushed": [],
+            "unique": [],
+        }
+    ]
+
+    collection.delete_many({})
+    assert list(collection.aggregate(pipeline)) == []
+
+
+@pytest.mark.parametrize(
+    "operator",
+    ["$addToSet", "$avg", "$first", "$last", "$max", "$min", "$push", "$sum"],
+)
+def test_group_accumulators_reject_array_argument_lists(contract_target, operator):
+    outcome = observe(
+        lambda: list(
+            contract_target.collection.aggregate(
+                [{"$group": {"_id": None, "value": {operator: [1, 2]}}}]
+            )
+        )
+    )
+
+    assert outcome.error == "operation_failure"

--- a/tests/contracts/test_uuid_regex_contract.py
+++ b/tests/contracts/test_uuid_regex_contract.py
@@ -1,0 +1,217 @@
+"""UUID and regular-expression contracts shared by every backend and API."""
+
+import re
+from uuid import UUID
+
+import pytest
+
+from tinymongo.bson_types import bson_identity_key
+
+
+pytestmark = pytest.mark.contract
+bson = pytest.importorskip("bson")
+pymongo_errors = pytest.importorskip("pymongo.errors")
+Binary = bson.Binary
+Regex = bson.Regex
+
+
+def _ids(cursor):
+    return [document["_id"] for document in cursor]
+
+
+def _standard_uuid_collection(contract_target):
+    """Opt real MongoDB into the standard UUID representation for this test."""
+
+    collection = contract_target.collection
+    if contract_target.name != "mongodb":
+        return collection
+
+    codec_options = pytest.importorskip("bson.codec_options").CodecOptions(
+        uuid_representation=pytest.importorskip(
+            "bson.binary"
+        ).UuidRepresentation.STANDARD
+    )
+    if contract_target.api == "sync":
+        return collection.with_options(codec_options=codec_options)
+
+    configured = collection._collection.with_options(codec_options=codec_options)
+    return collection.__class__(configured, collection._runner)
+
+
+def test_uuid_round_trip_uses_standard_binary_identity(contract_target):
+    collection = _standard_uuid_collection(contract_target)
+    first = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    second = UUID("00112233-4455-6677-8899-aabbccddeefe")
+    first_binary = Binary(first.bytes, subtype=4)
+
+    collection.insert_many(
+        [
+            {"_id": "second", "value": second},
+            {"_id": "first", "value": first},
+        ]
+    )
+
+    restored = collection.find_one({"value": first_binary})["value"]
+    assert restored == first
+    assert type(restored) is UUID
+    assert _ids(collection.find({}).sort("value", 1)) == ["second", "first"]
+    collection.insert_one({"_id": "binary-equivalent", "value": first_binary})
+    distinct = collection.distinct("value")
+    assert len(distinct) == 2
+    assert {bson_identity_key(value) for value in distinct} == {
+        bson_identity_key(first),
+        bson_identity_key(second),
+    }
+
+    collection.insert_one({"_id": first, "kind": "uuid-id"})
+    assert collection.find_one({"_id": first_binary})["kind"] == "uuid-id"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": first_binary, "kind": "duplicate-id"})
+
+
+def test_uuid_and_subtype_four_binary_share_unique_identity(contract_target):
+    collection = _standard_uuid_collection(contract_target)
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    collection.create_index("value", unique=True)
+    collection.insert_one({"_id": "uuid", "value": value})
+
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one(
+            {"_id": "binary", "value": Binary(value.bytes, subtype=4)}
+        )
+
+    collection.insert_one(
+        {"_id": "legacy-binary", "value": Binary(value.bytes, subtype=3)}
+    )
+    assert collection.count_documents({}) == 2
+
+
+def test_regex_predicates_and_exact_equality_follow_mongodb(contract_target):
+    collection = contract_target.collection
+    native = re.compile("Ab.c", re.IGNORECASE)
+    bson_i = Regex("Ab.c", "i")
+    documents = [
+        {"_id": "string", "value": "Abxc"},
+        {"_id": "array", "value": ["no", "Abxc"]},
+        {"_id": "native", "value": native},
+        {"_id": "bson", "value": bson_i},
+        {"_id": "other", "value": Regex("Z", 0)},
+    ]
+    collection.insert_many(documents)
+
+    assert sorted(_ids(collection.find({"value": bson_i}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert sorted(_ids(collection.find({"value": native}))) == [
+        "array",
+        "native",
+        "string",
+    ]
+    assert sorted(_ids(collection.find({"value": {"$regex": bson_i}}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert sorted(
+        _ids(collection.find({"value": {"$regex": "Ab.c", "$options": "i"}}))
+    ) == ["array", "bson", "string"]
+    assert sorted(
+        _ids(collection.find({"value": {"$regex": "Ab.c", "$options": "iu"}}))
+    ) == ["array", "native", "string"]
+    assert _ids(collection.find({"value": {"$eq": bson_i}})) == ["bson"]
+    assert sorted(_ids(collection.find({"value": {"$in": [bson_i]}}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert sorted(_ids(collection.find({"value": {"$nin": [bson_i]}}))) == [
+        "native",
+        "other",
+    ]
+    assert sorted(_ids(collection.find({"value": {"$all": [bson_i]}}))) == [
+        "array",
+        "bson",
+        "string",
+    ]
+    assert _ids(collection.find({"value": {"$all": []}})) == []
+    assert sorted(_ids(collection.find({"value": {"$not": bson_i}}))) == [
+        "native",
+        "other",
+    ]
+
+    restored_native = collection.find_one({"_id": "native"})["value"]
+    restored_bson = collection.find_one({"_id": "bson"})["value"]
+    if contract_target.name == "mongodb":
+        assert isinstance(restored_native, Regex)
+    else:
+        assert isinstance(restored_native, type(native))
+        assert restored_native.pattern == native.pattern
+        assert restored_native.flags == native.flags
+    assert isinstance(restored_bson, Regex)
+    assert bson_identity_key(restored_native) == bson_identity_key(native)
+    assert bson_identity_key(restored_bson) == bson_identity_key(bson_i)
+
+
+def test_regex_sort_distinct_and_unique_index_identity(contract_target):
+    collection = contract_target.collection
+    values = [
+        ("u", Regex("same", "u")),
+        ("iu", Regex("same", "iu")),
+        ("imu", Regex("same", "imu")),
+        ("im", Regex("same", "im")),
+        ("i", Regex("same", "i")),
+        ("none", Regex("same", "")),
+    ]
+    collection.insert_many(
+        {"_id": label, "value": value} for label, value in reversed(values)
+    )
+
+    assert _ids(collection.find({}).sort("value", 1)) == [
+        "none",
+        "i",
+        "im",
+        "imu",
+        "iu",
+        "u",
+    ]
+    collection.insert_many(
+        [
+            {"_id": "duplicate-im", "value": Regex("same", "mi")},
+            {
+                "_id": "native-iu",
+                "value": re.compile("same", re.IGNORECASE),
+            },
+        ]
+    )
+    assert len(collection.distinct("value")) == len(values)
+
+    collection.delete_many({})
+    collection.create_index("value", unique=True)
+    native = re.compile("unique", re.IGNORECASE)
+    collection.insert_one({"_id": "native", "value": native})
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": "bson", "value": Regex("unique", "iu")})
+
+
+def test_local_regex_ids_use_exact_identity_for_duplicate_detection(contract_target):
+    if contract_target.name == "mongodb":
+        pytest.skip(
+            "MongoDB forbids Regex values in _id; TinyMongo retains this extension"
+        )
+    collection = contract_target.collection
+    regex_id = Regex("^alpha$", "i")
+
+    collection.insert_one({"_id": "ALPHA", "kind": "string"})
+    collection.insert_one({"_id": regex_id, "kind": "regex"})
+
+    assert collection.count_documents({}) == 2
+    assert collection.find_one({"_id": {"$eq": regex_id}})["kind"] == "regex"
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": Regex("^alpha$", "i"), "kind": "duplicate"})
+
+    native_identity = re.compile("native", re.IGNORECASE)
+    collection.insert_one({"_id": native_identity, "kind": "native"})
+    with pytest.raises(pymongo_errors.DuplicateKeyError):
+        collection.insert_one({"_id": Regex("native", "iu"), "kind": "duplicate"})

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -2,7 +2,8 @@ import asyncio
 from collections import UserDict
 import os
 import math
-from uuid import uuid4
+import re
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -104,6 +105,80 @@ def test_remote_sql_backend_round_trip(backend, env_name):
 
 
 @pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_uuid_regex_roundtrip_query_and_unique_fail_closed(
+    backend, env_name
+):
+    bson = pytest.importorskip("bson")
+    dsn, database, prefix = _remote_target(backend, env_name)
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][prefix + "_bson_values"]
+    protected = client[database][prefix + "_bson_unique"]
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    native = re.compile("remote", re.IGNORECASE)
+    try:
+        docs.insert_many(
+            [
+                {"_id": "uuid", "value": value},
+                {"_id": "native", "value": native},
+                {"_id": "bson", "value": bson.Regex("remote", "i")},
+                {"_id": "text", "value": "REMOTE"},
+            ]
+        )
+
+        assert docs.find_one({"value": bson.Binary(value.bytes, 4)})["_id"] == "uuid"
+        assert {item["_id"] for item in docs.find({"value": native})} == {
+            "native",
+            "text",
+        }
+        assert type(docs.find_one({"_id": "uuid"})["value"]) is UUID
+        assert isinstance(docs.find_one({"_id": "native"})["value"], type(native))
+        assert isinstance(docs.find_one({"_id": "bson"})["value"], bson.Regex)
+
+        protected.create_index("value", unique=True)
+        for extended in (value, native):
+            with pytest.raises(TinyMongoNotSupportedError, match="Remote SQL"):
+                protected.insert_one({"value": extended})
+        assert protected.count_documents({}) == 0
+    finally:
+        docs.drop()
+        protected.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_async_uuid_regex_roundtrip_and_query(backend, env_name):
+    bson = pytest.importorskip("bson")
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_async_bson_values"
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    native = re.compile("remote", re.IGNORECASE)
+
+    async def scenario():
+        client = AsyncTinyMongoClient(backend=backend, dsn=dsn)
+        docs = client[database][collection]
+        try:
+            await docs.insert_many(
+                [
+                    {"_id": "uuid", "value": value},
+                    {"_id": "native", "value": native},
+                    {"_id": "text", "value": "REMOTE"},
+                ]
+            )
+            assert (await docs.find_one({"value": bson.Binary(value.bytes, 4)}))[
+                "_id"
+            ] == "uuid"
+            rows = await docs.find({"value": native}).to_list()
+            assert {item["_id"] for item in rows} == {"native", "text"}
+            restored = await docs.find_one({"_id": "native"})
+            assert isinstance(restored["value"], type(native))
+        finally:
+            await docs.drop()
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
 def test_remote_sql_aggregation_core(backend, env_name):
     dsn, database, prefix = _remote_target(backend, env_name)
     collection = prefix + "_aggregation"
@@ -135,11 +210,17 @@ def test_remote_sql_aggregation_core(backend, env_name):
                         "item_count": 1,
                     }
                 },
+                {"$sort": {"_id": 1}},
                 {
                     "$group": {
                         "_id": "$team",
+                        "average": {"$avg": "$score"},
+                        "first": {"$first": "$score"},
+                        "last": {"$last": "$score"},
                         "minimum": {"$min": "$score"},
                         "maximum": {"$max": "$score"},
+                        "pushed": {"$push": "$score"},
+                        "unique": {"$addToSet": "$score"},
                         "total": {"$sum": "$score"},
                         "items": {"$sum": "$item_count"},
                     }
@@ -147,11 +228,17 @@ def test_remote_sql_aggregation_core(backend, env_name):
             ]
         ).to_list()
 
+        unique = rows[0].pop("unique")
+        assert set(unique) == {2, 5}
         assert rows == [
             {
                 "_id": "alpha",
+                "average": 3.5,
+                "first": 2,
+                "last": 5,
                 "minimum": 2,
                 "maximum": 5,
+                "pushed": [2, 5],
                 "total": 7,
                 "items": 2,
             }
@@ -209,15 +296,33 @@ def test_remote_sql_async_aggregation_projection(backend, env_name):
                             "count": 1,
                         }
                     },
+                    {"$sort": {"_id": 1}},
                     {
                         "$group": {
                             "_id": "$course_id",
+                            "average": {"$avg": "$count"},
+                            "first": {"$first": "$count"},
+                            "last": {"$last": "$count"},
+                            "pushed": {"$push": "$count"},
+                            "unique": {"$addToSet": "$count"},
                             "total": {"$sum": "$count"},
                         }
                     },
                 ]
             )
-            assert await cursor.to_list() == [{"_id": "python", "total": 2}]
+            rows = await cursor.to_list()
+            unique = rows[0].pop("unique")
+            assert set(unique) == {0, 2}
+            assert rows == [
+                {
+                    "_id": "python",
+                    "average": 2.0 / 3.0,
+                    "first": 2,
+                    "last": 0,
+                    "pushed": [2, 0, 0],
+                    "total": 2,
+                }
+            ]
 
             page = await docs.aggregate(
                 [

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -354,12 +354,12 @@ def test_project_size_rejects_non_array_runtime_values(document):
                 {
                     "$group": {
                         "_id": None,
-                        "total": {"$sum": {"$size": "$items"}},
+                        "total": {"$sum": {"$add": [1, 2]}},
                     }
                 }
             ],
             TinyMongoNotSupportedError,
-            r"\$size",
+            r"\$add",
         ),
         (
             [{"$group": {"_id": "$a.", "total": {"$sum": 1}}}],
@@ -389,7 +389,10 @@ def test_project_validation_fails_before_storage_read(pipeline, error, message):
     ("pipeline", "message"),
     [
         ([{"$lookup": {}}], r"\$lookup"),
-        ([{"$group": {"_id": "$key", "mean": {"$avg": "$value"}}}], r"\$avg"),
+        (
+            [{"$group": {"_id": "$key", "value": {"$madeUp": "$value"}}}],
+            r"\$madeUp",
+        ),
         ([{"$group": {"_id": "literal"}}], "field path or None"),
         ([{"$group": {"_id": "$$ROOT"}}], "field path or None"),
         (
@@ -485,6 +488,36 @@ def test_supported_stage_arguments_are_validated(pipeline):
         _collection("aggregation-stage-arguments").aggregate(pipeline)
 
 
+@pytest.mark.parametrize(
+    ("group", "code"),
+    [
+        ({"_id": None, "value": []}, 40234),
+        ({"_id": None, "value": {}}, 40234),
+        ({"_id": None, "value": {"notAnAccumulator": 1}}, 40234),
+        ({"_id": None, "value": {1: 1}}, 40234),
+        ({"_id": None, "bad.name": {"$sum": 1}}, 40235),
+        ({"_id": None, "value": {"$sum": 1, "$max": 1}}, 40238),
+        ({"_id": None, "$value": {"$sum": 1}}, 40236),
+        ({"_id": None, "$value": []}, 40234),
+        ({"_id": None, "bad.name": []}, 40234),
+        ({"_id": None, "value": {"$sum": [1, 2]}}, 40237),
+        ({"_id": None, "value": {"$madeUp": [1, 2]}}, 40237),
+    ],
+)
+def test_group_validation_reports_mongodb_error_codes(group, code):
+    with pytest.raises(OperationFailure) as caught:
+        _collection("aggregation-group-validation-codes").aggregate([{"$group": group}])
+
+    assert caught.value.code == code
+
+
+def test_group_rejects_non_string_output_fields():
+    with pytest.raises(OperationFailure, match="plain strings"):
+        _collection("aggregation-group-non-string-output").aggregate(
+            [{"$group": {"_id": None, 1: {"$sum": 1}}}]
+        )
+
+
 def test_sessions_options_and_unsupported_comparison_values_fail_loudly():
     collection = _collection("aggregation-options")
     collection.insert_one({"_id": 1, "value": 2})
@@ -523,6 +556,16 @@ def test_capability_descriptions_are_fresh_and_supports_is_true():
         "$group",
     )
     assert second["expressions"] == ("$ifNull", "$literal", "$size")
+    assert second["accumulators"] == (
+        "$addToSet",
+        "$avg",
+        "$first",
+        "$last",
+        "$max",
+        "$min",
+        "$push",
+        "$sum",
+    )
     assert client.capabilities()["aggregation"]["stages"] == (
         "$match",
         "$sort",
@@ -607,6 +650,14 @@ def test_sum_ignores_every_supported_non_numeric_value():
     assert collection.aggregate(
         [{"$group": {"_id": None, "total": {"$sum": "$value"}}}]
     ).to_list() == [{"_id": None, "total": 0}]
+
+
+def test_add_to_set_rejects_values_without_a_bson_identity():
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$addToSet.*object"):
+        AggregationEngine().run(
+            [{"_id": 1}],
+            [{"$group": {"_id": None, "values": {"$addToSet": object()}}}],
+        )
 
 
 def test_async_aggregate_returns_async_cursor():

--- a/tests/test_bson_codec.py
+++ b/tests/test_bson_codec.py
@@ -1,6 +1,7 @@
 import json
+import re
 from datetime import datetime, timedelta, timezone
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -13,6 +14,7 @@ bson = pytest.importorskip("bson")
 ObjectId = bson.ObjectId
 Binary = bson.Binary
 Decimal128 = bson.Decimal128
+Regex = bson.Regex
 
 
 def test_invalid_document_matches_tinymongo_bson_and_pymongo_hierarchies():
@@ -141,6 +143,62 @@ def test_codec_round_trips_exact_decimal128_bid_values(value):
     assert restored.bid == value.bid
 
 
+def test_codec_round_trips_uuid_without_pymongo_specific_state():
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+
+    encoded = bson_codec.encode_value(value)
+    restored = bson_codec.decode_value(encoded)
+
+    assert encoded == {
+        "__tinymongo_type_v1__": "uuid",
+        "value": "00112233-4455-6677-8899-aabbccddeeff",
+    }
+    assert restored == value
+    assert type(restored) is UUID
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        re.compile("Ab.c", re.IGNORECASE | re.MULTILINE),
+        re.compile(b"bytes", re.IGNORECASE),
+        Regex("Ab.c", "im"),
+        Regex(b"bytes", "i"),
+    ],
+)
+def test_codec_round_trips_regex_representation_pattern_and_flags(value):
+    encoded = bson_codec.encode_value(value)
+    restored = bson_codec.decode_value(encoded)
+
+    assert encoded["__tinymongo_type_v1__"] == "regex"
+    assert encoded["value"]["pattern"] in ("Ab.c", "bytes")
+    assert restored.pattern == value.pattern
+    assert int(restored.flags) == int(value.flags)
+    assert type(restored) is type(value)
+
+
+def test_bson_regex_decode_explains_optional_dependency(monkeypatch):
+    encoded = bson_codec.encode_value(Regex("optional", "im"))
+    monkeypatch.setattr(bson_codec, "_Regex", None)
+
+    assert bson_codec.bson_available() is False
+    with pytest.raises(ImportError, match=r"Regex values.*tinymongo\[bson\]"):
+        bson_codec.decode_value(encoded)
+
+
+def test_uuid_and_native_regex_decode_without_optional_bson(monkeypatch):
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    expression = re.compile("native", re.IGNORECASE)
+    encoded_uuid = bson_codec.encode_value(value)
+    encoded_regex = bson_codec.encode_value(expression)
+    monkeypatch.setattr(bson_codec, "_Regex", None)
+
+    assert bson_codec.decode_value(encoded_uuid) == value
+    restored = bson_codec.decode_value(encoded_regex)
+    assert restored.pattern == expression.pattern
+    assert restored.flags == expression.flags
+
+
 def test_decimal128_decode_explains_optional_dependency(monkeypatch):
     value = Decimal128("19.95")
     encoded = {
@@ -162,6 +220,92 @@ def test_codec_preserves_malformed_decimal128_tags(payload):
     }
 
     assert bson_codec.decode_value(tagged) == tagged
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        1,
+        "00112233445566778899aabbccddeeff",
+        "00112233-4455-6677-8899-aabbccddeezz",
+        "{00112233-4455-6677-8899-aabbccddeeff}",
+    ],
+)
+def test_codec_preserves_malformed_uuid_tags(payload):
+    tagged = {"__tinymongo_type_v1__": "uuid", "value": payload}
+
+    assert bson_codec.decode_value(tagged) == tagged
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        "not-a-mapping",
+        {"pattern": "x", "flags": 0},
+        {
+            "pattern": 1,
+            "flags": 0,
+            "representation": "python",
+            "pattern_type": "string",
+        },
+        {
+            "pattern": "x",
+            "flags": True,
+            "representation": "python",
+            "pattern_type": "string",
+        },
+        {
+            "pattern": "x\x00y",
+            "flags": 0,
+            "representation": "python",
+            "pattern_type": "string",
+        },
+        {
+            "pattern": "x",
+            "flags": 0,
+            "representation": "future",
+            "pattern_type": "string",
+        },
+        {
+            "pattern": "x",
+            "flags": 0,
+            "representation": "python",
+            "pattern_type": "future",
+        },
+        {
+            "pattern": "x",
+            "flags": int(re.LOCALE),
+            "representation": "python",
+            "pattern_type": "string",
+        },
+        {
+            "pattern": "x",
+            "flags": 1 << 100,
+            "representation": "python",
+            "pattern_type": "string",
+        },
+    ],
+)
+def test_codec_preserves_malformed_regex_tags(payload):
+    tagged = {"__tinymongo_type_v1__": "regex", "value": payload}
+
+    assert bson_codec.decode_value(tagged) == tagged
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        Regex("nul\x00pattern"),
+        Regex(b"\xff"),
+    ],
+)
+def test_codec_rejects_regex_patterns_bson_cannot_encode(value):
+    with pytest.raises(InvalidDocument, match="regular expression") as caught:
+        bson_codec.dumps({"value": value})
+
+    assert caught.value.document == {"value": value}
 
 
 def test_codec_loads_legacy_plain_json_without_changing_it():
@@ -200,7 +344,17 @@ def test_codec_preserves_malformed_escaped_mapping_tags(payload):
 
 
 @pytest.mark.parametrize(
-    "kind", ["datetime", "objectid", "binary", "mapping", "future-type"]
+    "kind",
+    [
+        "datetime",
+        "objectid",
+        "binary",
+        "decimal128",
+        "uuid",
+        "regex",
+        "mapping",
+        "future-type",
+    ],
 )
 def test_codec_escapes_user_mappings_that_look_like_internal_tags(kind):
     tagged = {
@@ -327,6 +481,9 @@ def test_codec_preserves_malformed_binary_tags(payload):
         bytearray(b"mutable"),
         Binary(bytes(range(16)), subtype=4),
         Decimal128("12.50"),
+        UUID("00112233-4455-6677-8899-aabbccddeeff"),
+        re.compile("extended"),
+        Regex("extended"),
         {"nested": [b"raw"]},
     ],
 )

--- a/tests/test_bson_registry_hardening.py
+++ b/tests/test_bson_registry_hardening.py
@@ -2,10 +2,11 @@
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import re
 import subprocess
 import sys
 import textwrap
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -73,6 +74,9 @@ def test_registry_is_the_encoding_metadata_source():
         (b"native", "binary"),
         (bytearray(b"mutable"), "binary"),
         (uuid_binary, "binary"),
+        (UUID("00112233-4455-6677-8899-aabbccddeeff"), "uuid"),
+        (re.compile("native"), "regex"),
+        (bson.Regex("bson", "im"), "regex"),
     ]
 
     for value, expected_tag in values:
@@ -112,6 +116,60 @@ def test_binary_and_numeric_identity_keys_follow_bson_equality():
     assert bson_types.bson_identity_key(float("nan")) == bson_types.bson_identity_key(
         float("nan")
     )
+
+
+def test_uuid_and_regex_identity_keys_match_their_bson_wire_values():
+    bson = pytest.importorskip("bson")
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+
+    assert bson_types.bson_identity_key(value) == bson_types.bson_identity_key(
+        bson.Binary(value.bytes, subtype=4)
+    )
+    assert bson_types.bson_values_equal(
+        re.compile("same", re.IGNORECASE),
+        bson.Regex("same", "iu"),
+    )
+    assert not bson_types.bson_values_equal(
+        re.compile("same", re.IGNORECASE),
+        bson.Regex("same", "i"),
+    )
+    assert bson_types.bson_identity_key(bson.Regex("same", "iz")) == (
+        "regex",
+        ("same", "i"),
+    )
+    assert bson_types.bson_identity_key(bson.Regex(b"same", "im")) == (
+        "regex",
+        ("same", "im"),
+    )
+    assert bson_types.regex_components(bson.Regex("flags", "ilmsux")) == (
+        "flags",
+        "ilmsux",
+    )
+
+    with pytest.raises(TypeError, match="Unsupported BSON regular-expression"):
+        bson_types.regex_components("not-regex")
+    with pytest.raises(TypeError, match="Unsupported BSON regular-expression"):
+        bson_types.regex_compile_components("not-regex")
+
+
+def test_uuid_and_regex_follow_mongodb_scalar_sort_order():
+    bson = pytest.importorskip("bson")
+    first = UUID("00112233-4455-6677-8899-aabbccddeefe")
+    second = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    values = [
+        bson.Regex("same", "u"),
+        bson.Regex("same", "iu"),
+        bson.Regex("same", "im"),
+        bson.Regex("same", "i"),
+        bson.Regex("same", ""),
+    ]
+
+    assert bson_types.bson_scalar_sort_key(first) < bson_types.bson_scalar_sort_key(
+        second
+    )
+    assert [
+        value.flags for value in sorted(values, key=bson_types.bson_scalar_sort_key)
+    ] == [bson.Regex("same", flags).flags for flags in ("", "i", "im", "iu", "u")]
 
 
 def test_numeric_sort_places_nan_below_all_other_numbers():
@@ -280,11 +338,13 @@ def test_fresh_process_without_pymongo_keeps_core_codec_available():
             "objectid": False,
             "binary": False,
             "decimal128": False,
+            "regex": False,
         }
         assert bson_codec.bson_available() is False
         assert bson_codec.object_id_available() is False
         assert bson_codec.binary_available() is False
         assert bson_codec.decimal128_available() is False
+        assert bson_codec.regex_available() is False
         assert bson_codec.loads(bson_codec.dumps(b"core")) == b"core"
         assert issubclass(InvalidDocument, TinyMongoError)
 
@@ -327,6 +387,30 @@ def test_fresh_process_without_pymongo_keeps_core_codec_available():
         moment = datetime(2026, 7, 29, 12, 30)
         assert bson_codec.loads(bson_codec.dumps(moment)) == moment
 
+        from uuid import UUID
+        import re
+
+        native_uuid = UUID("00112233-4455-6677-8899-aabbccddeeff")
+        assert bson_codec.loads(bson_codec.dumps(native_uuid)) == native_uuid
+        native_regex = re.compile("native", re.IGNORECASE)
+        restored_regex = bson_codec.loads(bson_codec.dumps(native_regex))
+        assert restored_regex.pattern == native_regex.pattern
+        assert restored_regex.flags == native_regex.flags
+
+        client = tinymongo.TinyMongoClient(backend="memory")
+        values = client.core.native_values
+        values.insert_many(
+            [
+                {"_id": native_uuid, "value": native_regex},
+                {"_id": "text", "value": "NATIVE"},
+            ]
+        )
+        assert values.find_one({"_id": native_uuid})["value"].pattern == "native"
+        assert {
+            item["_id"] for item in values.find({"value": native_regex})
+        } == {native_uuid, "text"}
+        client.close()
+
         generic = {
             "__tinymongo_type_v1__": "binary",
             "value": {"base64": "Y29yZQ==", "subtype": 0},
@@ -362,6 +446,92 @@ def test_fresh_process_without_pymongo_keeps_core_codec_available():
 
     completed = subprocess.run(
         [sys.executable, "-c", script],
+        cwd=str(Path(__file__).resolve().parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_sync_and_async_sqlite_uuid_regex_work_without_pymongo(tmp_path):
+    script = textwrap.dedent(
+        """
+        import asyncio
+        import builtins
+        import re
+        import sys
+        from uuid import UUID
+
+        real_import = builtins.__import__
+
+        def without_pymongo(name, *args, **kwargs):
+            if name == "pymongo" or name.startswith("pymongo."):
+                raise ModuleNotFoundError("No module named 'pymongo'", name="pymongo")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = without_pymongo
+
+        import tinymongo
+        from tinymongo.asyncio import AsyncTinyMongoClient
+
+        value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+        expression = re.compile("native", re.IGNORECASE)
+
+        client = tinymongo.TinyMongoClient(sys.argv[1], backend="sqlite")
+        collection = client.app.values
+        collection.insert_many(
+            [
+                {"_id": value, "value": expression},
+                {"_id": "text", "value": "NATIVE"},
+            ]
+        )
+        client.close()
+
+        client = tinymongo.TinyMongoClient(sys.argv[1], backend="sqlite")
+        collection = client.app.values
+        restored = collection.find_one({"_id": value})
+        assert restored["value"].pattern == expression.pattern
+        assert restored["value"].flags == expression.flags
+        assert {item["_id"] for item in collection.find({"value": expression})} == {
+            value,
+            "text",
+        }
+        client.close()
+
+        async def async_scenario():
+            client = AsyncTinyMongoClient(sys.argv[2], backend="sqlite")
+            collection = client.app.values
+            await collection.insert_many(
+                [
+                    {"_id": value, "value": expression},
+                    {"_id": "text", "value": "NATIVE"},
+                ]
+            )
+            await client.close()
+
+            client = AsyncTinyMongoClient(sys.argv[2], backend="sqlite")
+            collection = client.app.values
+            restored = await collection.find_one({"_id": value})
+            assert restored["value"].pattern == expression.pattern
+            assert restored["value"].flags == expression.flags
+            rows = await collection.find({"value": expression}).to_list()
+            assert {item["_id"] for item in rows} == {value, "text"}
+            await client.close()
+
+        asyncio.run(async_scenario())
+        """
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(tmp_path / "sync"),
+            str(tmp_path / "async"),
+        ],
         cwd=str(Path(__file__).resolve().parents[1]),
         check=False,
         capture_output=True,

--- a/tests/test_index_helpers.py
+++ b/tests/test_index_helpers.py
@@ -1,4 +1,6 @@
 import json
+import re
+from uuid import UUID
 
 import pytest
 
@@ -169,6 +171,48 @@ def test_scalar_tokens_are_deterministic_and_type_aware():
     assert tokens[-1] == 'string:"café"'
 
 
+def test_uuid_binary_and_regex_tokens_follow_bson_identity():
+    bson = pytest.importorskip("bson")
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+
+    assert index_tokens({"value": value}, "value") == index_tokens(
+        {"value": bson.Binary(value.bytes, subtype=4)}, "value"
+    )
+    assert index_tokens({"value": value}, "value") != index_tokens(
+        {"value": bson.Binary(value.bytes, subtype=3)}, "value"
+    )
+    assert index_tokens(
+        {"value": re.compile("same", re.IGNORECASE)}, "value"
+    ) == index_tokens({"value": bson.Regex("same", "iu")}, "value")
+    assert index_tokens({"value": bson.Regex("same", "iz")}, "value") == (
+        'regex:["same","i"]',
+    )
+
+
+def test_unique_validation_uses_uuid_and_regex_bson_identity():
+    bson = pytest.importorskip("bson")
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    spec = parse_index_spec("value", unique=True)
+
+    with pytest.raises(DuplicateKeyError):
+        validate_unique_documents(
+            [
+                {"_id": 1, "value": value},
+                {"_id": 2, "value": bson.Binary(value.bytes, subtype=4)},
+            ],
+            [spec],
+        )
+
+    with pytest.raises(DuplicateKeyError):
+        validate_unique_documents(
+            [
+                {"_id": 1, "value": re.compile("same", re.IGNORECASE)},
+                {"_id": 2, "value": bson.Regex("same", "iu")},
+            ],
+            [spec],
+        )
+
+
 def test_arrays_fan_out_and_deduplicate_within_one_document():
     assert index_tokens({"tags": ["a", "b", "a", None]}, "tags") == (
         'string:"a"',
@@ -198,7 +242,7 @@ def test_unique_validation_treats_equivalent_numbers_as_duplicates():
         {"nested": "object"},
         [["nested", "array"]],
         ("tuple",),
-        b"bytes",
+        object(),
         float("inf"),
         float("nan"),
     ],

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -143,7 +143,16 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
             "$unset",
             "$group",
         ),
-        "accumulators": ("$max", "$min", "$sum"),
+        "accumulators": (
+            "$addToSet",
+            "$avg",
+            "$first",
+            "$last",
+            "$max",
+            "$min",
+            "$push",
+            "$sum",
+        ),
         "expressions": ("$ifNull", "$literal", "$size"),
     }
     assert capabilities["sessions"] is False

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -1,5 +1,6 @@
 """Focused coverage for small compatibility and backend branches."""
 
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -16,17 +17,23 @@ def test_bson_capabilities_are_enabled_atomically(monkeypatch):
     monkeypatch.setattr(bson_types, "_ObjectId", marker)
     monkeypatch.setattr(bson_types, "_Binary", marker)
     monkeypatch.setattr(bson_types, "_Decimal128", marker)
+    monkeypatch.setattr(bson_types, "_Regex", marker)
     assert bson_types.bson_capabilities() == {
         "objectid": True,
         "binary": True,
         "decimal128": True,
+        "regex": True,
     }
 
+    monkeypatch.setattr(bson_types, "_Regex", None)
+    assert not any(bson_types.bson_capabilities().values())
+    monkeypatch.setattr(bson_types, "_Regex", marker)
     monkeypatch.setattr(bson_types, "_Binary", None)
     assert bson_types.bson_capabilities() == {
         "objectid": False,
         "binary": False,
         "decimal128": False,
+        "regex": False,
     }
 
     monkeypatch.setattr(bson_types, "_ObjectId", None)
@@ -35,6 +42,7 @@ def test_bson_capabilities_are_enabled_atomically(monkeypatch):
         "objectid": False,
         "binary": False,
         "decimal128": False,
+        "regex": False,
     }
 
 
@@ -254,6 +262,9 @@ def test_persistent_native_insert_rejection_returns_bulk_errors(ordered):
 def test_direct_id_and_cached_match_helpers_cover_operator_routes():
     assert core._direct_id_equality({"_id": {"$eq": 1}}) == 1
     assert core._direct_id_equality({"_id": {"$in": [1]}}) is core._MISSING
+    expression = re.compile("id")
+    assert core._direct_id_equality({"_id": expression}) is core._MISSING
+    assert core._direct_id_equality({"_id": {"$eq": expression}}) is core._MISSING
     assert core._cached_value_matches(1.0, 1, ("number", 1)) is True
 
 

--- a/tests/test_uuid_regex.py
+++ b/tests/test_uuid_regex.py
@@ -1,0 +1,193 @@
+"""Focused UUID and BSON regular-expression behavior."""
+
+import re
+from uuid import UUID
+
+import pytest
+
+import tinymongo
+from tinymongo.errors import OperationFailure, TinyMongoNotSupportedError
+from tinymongo.indexes import parse_index_spec
+from tinymongo.table_backends import (
+    _reject_remote_unique_values,
+    matches_filter,
+    validate_filter_operators,
+    validate_regex_filter,
+)
+from tinymongo.tinymongo import TinyMongoCollection
+
+
+bson = pytest.importorskip("bson")
+
+
+def test_regex_query_forms_distinguish_predicates_from_explicit_equality():
+    stored = bson.Regex("Ab.c", "i")
+    documents = [
+        {"value": "Abxc"},
+        {"value": ["no", "Abxc"]},
+        {"value": stored},
+        {"value": bson.Regex("Ab.c", "iu")},
+    ]
+
+    assert [
+        matches_filter(document, {"value": {"$regex": "Ab.c", "$options": "i"}})
+        for document in documents
+    ] == [True, True, True, False]
+    assert [matches_filter(document, {"value": stored}) for document in documents] == [
+        True,
+        True,
+        True,
+        False,
+    ]
+    assert [
+        matches_filter(document, {"value": {"$eq": stored}}) for document in documents
+    ] == [False, False, True, False]
+
+
+def test_regex_in_nin_all_not_and_empty_all_semantics():
+    expression = bson.Regex("^a", "i")
+
+    assert matches_filter({"value": "Alpha"}, {"value": {"$in": [expression]}})
+    assert not matches_filter({"value": "Alpha"}, {"value": {"$nin": [expression]}})
+    assert matches_filter({"value": "Alpha"}, {"value": {"$all": [expression]}})
+    assert matches_filter(
+        {"value": ["other", "Alpha"]}, {"value": {"$all": [expression]}}
+    )
+    assert not matches_filter({"value": "Alpha"}, {"value": {"$all": []}})
+    assert not matches_filter({"value": "Alpha"}, {"value": {"$not": expression}})
+    assert matches_filter({"value": "other"}, {"value": {"$not": expression}})
+
+
+def test_regex_options_validation_accepts_u_and_rejects_invalid_combinations():
+    validate_filter_operators({"value": {"$regex": "x", "$options": "imsxu"}})
+    validate_filter_operators(
+        {"value": {"$regex": bson.Regex("x", 0), "$options": "i"}}
+    )
+
+    for options in ("l", "z", 1):
+        with pytest.raises(OperationFailure, match="supports only"):
+            validate_filter_operators({"value": {"$regex": "x", "$options": options}})
+
+    with pytest.raises(OperationFailure, match="embedded"):
+        validate_filter_operators(
+            {"value": {"$regex": bson.Regex("x", "i"), "$options": "m"}}
+        )
+    with pytest.raises(OperationFailure, match="supports only"):
+        matches_filter({"value": "x"}, {"value": {"$regex": "x", "$options": "z"}})
+    with pytest.raises(OperationFailure, match="embedded"):
+        matches_filter(
+            {"value": "x"},
+            {
+                "value": {
+                    "$regex": bson.Regex("x", "i"),
+                    "$options": "m",
+                }
+            },
+        )
+
+
+def test_regex_locale_flag_can_still_match_an_exact_stored_regex():
+    expression = bson.Regex("exact", "l")
+
+    assert matches_filter({"value": expression}, {"value": expression})
+    assert not matches_filter({"value": "exact"}, {"value": expression})
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"value": {"$regex": 42}},
+        {"value": {"$regex": b"bytes"}},
+        {"value": {"$regex": "["}},
+        {"value": {"$regex": "nul\x00pattern"}},
+        {"value": bson.Regex("[")},
+        {"value": bson.Regex("nul\x00pattern")},
+        {"value": bson.Regex(b"\xff")},
+        {"value": {"$in": [bson.Regex("[")]}},
+        {"value": {"$nin": [bson.Regex("[")]}},
+        {"value": {"$all": [bson.Regex("[")]}},
+        {"value": {"$not": bson.Regex("[")}},
+        {"value": {"$not": {"$regex": None}}},
+        {"value": {"$in": [{"$regex": "valid"}]}},
+        {"value": {"$nin": [{"$regex": "valid"}]}},
+        {"value": {"$all": [{"$regex": "valid"}]}},
+    ],
+)
+def test_malformed_regex_queries_fail_before_persistent_storage_reads(tmp_path, query):
+    client = tinymongo.TinyMongoClient(str(tmp_path / "invalid"), backend="sqlite")
+    collection = client.app.items
+
+    with pytest.raises(OperationFailure, match="(?i)regex|regular.expression"):
+        collection.find(query)
+
+    assert client.app.list_collection_names() == []
+    client.close()
+
+
+def test_public_queries_preserve_exact_locale_regex_identity():
+    client = tinymongo.TinyMongoClient(backend="memory")
+    collection = client.app.items
+    expression = bson.Regex("exact", "l")
+    collection.insert_many(
+        [
+            {"_id": "regex", "value": expression},
+            {"_id": "string", "value": "exact"},
+        ]
+    )
+
+    assert [item["_id"] for item in collection.find({"value": expression})] == ["regex"]
+    assert [
+        item["_id"] for item in collection.find({"value": {"$regex": expression}})
+    ] == ["regex"]
+    client.close()
+
+
+def test_regex_only_preflight_ignores_non_query_documents():
+    assert validate_regex_filter(None) is None
+
+
+def test_full_filter_validation_rejects_operator_documents_inside_regex_arrays():
+    with pytest.raises(OperationFailure, match="accepts regex values"):
+        validate_filter_operators({"value": {"$in": [{"$regex": "valid"}]}})
+
+
+def test_remote_unique_indexes_fail_closed_for_extended_binary_identities():
+    value = UUID("00112233-4455-6677-8899-aabbccddeeff")
+    spec = parse_index_spec("value", unique=True)
+
+    for extended in (value, bson.Binary(value.bytes, 4), re.compile("x")):
+        with pytest.raises(TinyMongoNotSupportedError, match="Remote SQL.*UUID"):
+            _reject_remote_unique_values([{"value": extended}], [spec])
+
+
+def test_distinct_uses_recursive_bson_identity_and_keeps_unsupported_type_rules():
+    class EqualValue:
+        def __eq__(self, _other):
+            return True
+
+    class OtherEqualValue:
+        def __eq__(self, _other):
+            return True
+
+    first = EqualValue()
+    second = EqualValue()
+    other_type = OtherEqualValue()
+
+    class Collection:
+        @staticmethod
+        def find(_filter):
+            return [
+                {"value": {"number": 1}},
+                {"value": {"number": 1.0}},
+                {"value": {"number": True}},
+                {"value": first},
+                {"value": second},
+                {"value": other_type},
+            ]
+
+    values = TinyMongoCollection.distinct(Collection(), "value")
+
+    assert values[:2] == [{"number": 1}, {"number": True}]
+    assert len(values) == 4
+    assert type(values[2]) is EqualValue
+    assert type(values[3]) is OtherEqualValue

--- a/tinymongo/aggregation.py
+++ b/tinymongo/aggregation.py
@@ -11,6 +11,7 @@ import copy
 from collections.abc import Mapping
 from decimal import Decimal, localcontext
 from itertools import islice
+import math
 
 from .bson_types import (
     binary_components,
@@ -50,7 +51,16 @@ _ALLOWED_DOLLAR_PREFIXED_FIELDS = frozenset(
         "$sortKey",
     )
 )
-_SUPPORTED_ACCUMULATORS = ("$max", "$min", "$sum")
+_SUPPORTED_ACCUMULATORS = (
+    "$addToSet",
+    "$avg",
+    "$first",
+    "$last",
+    "$max",
+    "$min",
+    "$push",
+    "$sum",
+)
 _SUPPORTED_EXPRESSIONS = ("$ifNull", "$literal", "$size")
 _SUPPORTED_STAGES = (
     "$match",
@@ -121,6 +131,140 @@ class _SumAccumulator(object):
         if self._has_decimal:
             return decimal128_from_decimal(self._decimal_total)
         return self._float_total
+
+
+class _AverageAccumulator(object):
+    """Average values with MongoDB's compensated numeric promotion."""
+
+    __slots__ = (
+        "_count",
+        "_decimal_total",
+        "_has_decimal",
+        "_has_double",
+        "_non_decimal_total",
+    )
+
+    def __init__(self):
+        self._count = 0
+        self._decimal_total = Decimal(0)
+        self._has_decimal = False
+        self._has_double = False
+        self._non_decimal_total = _DoubleDoubleSummation()
+
+    def add(self, value):
+        if not is_bson_number(value):
+            return
+
+        if _DECIMAL128 is not None and isinstance(value, _DECIMAL128):
+            with localcontext(decimal128_context()):
+                self._decimal_total += value.to_decimal()
+            self._has_decimal = True
+        elif isinstance(value, int):
+            self._non_decimal_total.add_int(value)
+        else:
+            self._non_decimal_total.add_double(value)
+            self._has_double = True
+        self._count += 1
+
+    def value(self):
+        if not self._count:
+            return None
+
+        if self._has_decimal:
+            with localcontext(decimal128_context()) as context:
+                average = (
+                    self._decimal_total + self._non_decimal_total.decimal_value(context)
+                ) / Decimal(self._count)
+            return decimal128_from_decimal(average)
+        return self._non_decimal_total.value(
+            include_addend=not self._has_double
+        ) / float(self._count)
+
+
+class _DoubleDoubleSummation(object):
+    """Port MongoDB's two-double accumulator for accurate numeric totals."""
+
+    __slots__ = ("_addend", "_special", "_sum")
+
+    def __init__(self):
+        self._sum = 0.0
+        self._addend = 0.0
+        self._special = 0.0
+
+    @staticmethod
+    def _fast_two_sum(left, right):
+        total = left + right
+        rounded_left = total - left
+        return total, right - rounded_left
+
+    @staticmethod
+    def _two_sum(left, right):
+        total = left + right
+        left_prime = total - right
+        right_prime = total - left_prime
+        return total, (left - left_prime) + (right - right_prime)
+
+    def add_double(self, value):
+        self._special += value
+        value, self._addend = self._fast_two_sum(value, self._addend)
+        self._sum, value = self._two_sum(self._sum, value)
+        self._addend += value
+
+    def add_int(self, value):
+        # MongoDB adds signed 64-bit integers as two exactly representable
+        # doubles. Small integers need only the low component.
+        if -(2**31) <= value <= (2**31 - 1):
+            self.add_double(float(value))
+            return
+        divisor = 2**32
+        high = (abs(value) // divisor) * divisor
+        if value < 0:
+            high = -high
+        self.add_double(float(value - high))
+        self.add_double(float(high))
+
+    def value(self, include_addend=False):
+        if math.isnan(self._sum):
+            return self._special
+        if include_addend and math.isfinite(self._sum):
+            return self._sum + self._addend
+        return self._sum
+
+    def decimal_value(self, context):
+        if not math.isfinite(self._sum):
+            return context.create_decimal_from_float(self._special)
+        return context.create_decimal_from_float(
+            self._sum
+        ) + context.create_decimal_from_float(self._addend)
+
+
+class _AddToSetAccumulator(object):
+    """Retain the first instance of each recursive BSON value identity."""
+
+    __slots__ = ("_keys", "_values")
+
+    def __init__(self):
+        self._keys = set()
+        self._values = []
+
+    def add(self, value):
+        # A missing expression contributes no element. An explicit null is a
+        # normal BSON value and is therefore retained once.
+        if value is _MISSING:
+            return
+        key = bson_value_identity_key(value)
+        if key is None:
+            raise TinyMongoNotSupportedError(
+                "$addToSet cannot compare values of type {0}".format(
+                    type(value).__name__
+                )
+            )
+        if key not in self._keys:
+            self._keys.add(key)
+            self._values.append(copy.deepcopy(value))
+
+    def value(self):
+        return copy.deepcopy(self._values)
 
 
 def aggregation_capabilities():
@@ -937,9 +1081,7 @@ class AggregationEngine(object):
                 group = {
                     "key": copy.deepcopy(group_value),
                     "states": {
-                        output_field: (
-                            _SumAccumulator() if operator == "$sum" else _MISSING
-                        )
+                        output_field: self._new_accumulator_state(operator)
                         for output_field, operator, _operand in accumulators
                     },
                 }
@@ -947,8 +1089,36 @@ class AggregationEngine(object):
                 groups_by_key[group_key] = group
 
             for output_field, operator, operand in accumulators:
-                value = self.context.evaluate(document, operand)
-                if operator == "$sum":
+                value = self.context.evaluate(
+                    document,
+                    operand,
+                    allowed_operators=_SUPPORTED_EXPRESSIONS,
+                )
+                if operator in ("$avg", "$sum"):
+                    group["states"][output_field].add(value)
+                    continue
+
+                if operator == "$first":
+                    if group["states"][output_field] is not _MISSING:
+                        continue
+                    group["states"][output_field] = (
+                        None if value is _MISSING else copy.deepcopy(value)
+                    )
+                    continue
+
+                if operator == "$last":
+                    group["states"][output_field] = (
+                        None if value is _MISSING else copy.deepcopy(value)
+                    )
+                    continue
+
+                if operator == "$push":
+                    if value is _MISSING:
+                        continue
+                    group["states"][output_field].append(copy.deepcopy(value))
+                    continue
+
+                if operator == "$addToSet":
                     group["states"][output_field].add(value)
                     continue
 
@@ -971,14 +1141,28 @@ class AggregationEngine(object):
             result = {"_id": copy.deepcopy(group["key"])}
             for output_field, operator, _operand in accumulators:
                 value = group["states"][output_field]
-                if operator == "$sum":
+                if operator in ("$addToSet", "$avg", "$sum"):
                     result[output_field] = value.value()
+                elif operator == "$push":
+                    result[output_field] = copy.deepcopy(value)
                 else:
                     result[output_field] = (
                         None if value is _MISSING else copy.deepcopy(value)
                     )
             results.append(result)
         return results
+
+    @staticmethod
+    def _new_accumulator_state(operator):
+        if operator == "$sum":
+            return _SumAccumulator()
+        if operator == "$avg":
+            return _AverageAccumulator()
+        if operator == "$addToSet":
+            return _AddToSetAccumulator()
+        if operator == "$push":
+            return []
+        return _MISSING
 
     @staticmethod
     def _is_better(operator, candidate, current):
@@ -1011,27 +1195,57 @@ class AggregationEngine(object):
         for output_field, accumulator in specification.items():
             if output_field == "_id":
                 continue
-            if (
-                not isinstance(output_field, str)
-                or output_field.startswith("$")
-                or "." in output_field
-            ):
+            if not isinstance(output_field, str):
                 raise OperationFailure(
                     "$group output field names must be plain strings"
                 )
-            if not isinstance(accumulator, Mapping) or len(accumulator) != 1:
+            if not isinstance(accumulator, Mapping) or not accumulator:
                 raise OperationFailure(
-                    "$group output field {0!r} must contain one accumulator".format(
+                    "The field {0!r} must be an accumulator object".format(
                         output_field
-                    )
+                    ),
+                    code=40234,
                 )
-            operator, operand = next(iter(accumulator.items()))
+            operator = next(iter(accumulator))
+            if not isinstance(operator, str) or not operator.startswith("$"):
+                raise OperationFailure(
+                    "The field {0!r} must be an accumulator object".format(
+                        output_field
+                    ),
+                    code=40234,
+                )
+            if "." in output_field:
+                raise OperationFailure(
+                    "The field name {0!r} cannot contain '.'".format(output_field),
+                    code=40235,
+                )
+            if output_field.startswith("$"):
+                raise OperationFailure(
+                    "The field name {0!r} cannot be an operator name".format(
+                        output_field
+                    ),
+                    code=40236,
+                )
+            if len(accumulator) != 1:
+                raise OperationFailure(
+                    "The field {0!r} must specify one accumulator".format(output_field),
+                    code=40238,
+                )
+            operand = accumulator[operator]
+            if isinstance(operand, (list, tuple)):
+                raise OperationFailure(
+                    "The {0} accumulator is a unary operator".format(operator),
+                    code=40237,
+                )
             if operator not in _SUPPORTED_ACCUMULATORS:
                 raise TinyMongoNotSupportedError(
                     "Aggregation accumulator {0} is not supported by TinyMongo".format(
                         operator
                     )
                 )
-            self.context.validate_expression(operand)
+            self.context.validate_expression(
+                operand,
+                allowed_operators=_SUPPORTED_EXPRESSIONS,
+            )
             accumulators.append((output_field, operator, operand))
         return group_expression, accumulators

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -17,6 +17,8 @@ from collections.abc import Mapping
 from datetime import datetime
 import json
 import math
+import re
+from uuid import UUID
 
 from . import bson_types
 from .errors import InvalidDocument
@@ -28,6 +30,7 @@ from .errors import InvalidDocument
 _ObjectId = bson_types.object_id_type()
 _Binary = bson_types.binary_type()
 _Decimal128 = bson_types.decimal128_type()
+_Regex = bson_types.regex_type()
 
 
 _TYPE_MARKER = "__tinymongo_type_v1__"
@@ -38,12 +41,27 @@ _BINARY_DATA = "base64"
 _BINARY_SUBTYPE = "subtype"
 _NONFINITE_FLOAT = "float"
 _DECIMAL128_VALUE = "decimal128"
+_UUID_VALUE = "uuid"
+_REGEX_VALUE = "regex"
+_REGEX_PATTERN = "pattern"
+_REGEX_FLAGS = "flags"
+_REGEX_REPRESENTATION = "representation"
+_REGEX_PATTERN_TYPE = "pattern_type"
+_REGEX_NATIVE = "python"
+_REGEX_BSON = "bson"
+_REGEX_TEXT = "string"
+_REGEX_BYTES = "bytes"
 _ROOT_UNSET = object()
 
 
 def bson_available():
     """Return whether the optional BSON implementation can be used."""
-    return object_id_available() and binary_available() and decimal128_available()
+    return (
+        object_id_available()
+        and binary_available()
+        and decimal128_available()
+        and regex_available()
+    )
 
 
 def object_id_available():
@@ -62,6 +80,12 @@ def decimal128_available():
     """Return whether PyMongo ``Decimal128`` values can be restored."""
 
     return _Decimal128 is not None
+
+
+def regex_available():
+    """Return whether PyMongo ``Regex`` values can be restored."""
+
+    return _Regex is not None
 
 
 def _nested_path(path, key):
@@ -94,6 +118,26 @@ def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
         # Store the raw IEEE-754 BID bytes. ``str(value)`` loses the distinction
         # between quiet and signaling NaN and would not be an exact round trip.
         return {_TYPE_MARKER: _DECIMAL128_VALUE, _VALUE_MARKER: value.bid.hex()}
+    if storage_tag == _UUID_VALUE:
+        return {_TYPE_MARKER: _UUID_VALUE, _VALUE_MARKER: str(value)}
+    if storage_tag == _REGEX_VALUE:
+        try:
+            return {
+                _TYPE_MARKER: _REGEX_VALUE,
+                _VALUE_MARKER: _encode_regex(value),
+            }
+        except (UnicodeDecodeError, ValueError) as error:
+            context = " for {0}".format(_context) if _context else ""
+            raise InvalidDocument(
+                "Invalid document{0} at {1!r}: cannot encode regular "
+                "expression {2}: {3}".format(
+                    context,
+                    _path,
+                    _bounded_repr(value),
+                    error,
+                ),
+                document=_root,
+            ) from error
     if isinstance(value, float) and not math.isfinite(value):
         if math.isnan(value):
             payload = "nan"
@@ -193,6 +237,61 @@ def _decode_binary(payload):
     return _Binary(raw, subtype=subtype)
 
 
+def _encode_regex(value):
+    pattern = value.pattern
+    pattern_type = _REGEX_BYTES if isinstance(pattern, bytes) else _REGEX_TEXT
+    if isinstance(pattern, bytes):
+        pattern = pattern.decode("utf8")
+    if "\x00" in pattern:
+        raise ValueError("BSON regular-expression patterns cannot contain NUL")
+    return {
+        _REGEX_PATTERN: pattern,
+        _REGEX_FLAGS: int(value.flags),
+        _REGEX_REPRESENTATION: (
+            _REGEX_NATIVE if bson_types.is_native_regex(value) else _REGEX_BSON
+        ),
+        _REGEX_PATTERN_TYPE: pattern_type,
+    }
+
+
+def _decode_regex(payload):
+    if not isinstance(payload, dict):
+        raise ValueError("Regex payload must be a mapping")
+    expected = {
+        _REGEX_PATTERN,
+        _REGEX_FLAGS,
+        _REGEX_REPRESENTATION,
+        _REGEX_PATTERN_TYPE,
+    }
+    if set(payload) != expected:
+        raise ValueError("Regex payload has an unexpected shape")
+
+    pattern = payload[_REGEX_PATTERN]
+    flags = payload[_REGEX_FLAGS]
+    representation = payload[_REGEX_REPRESENTATION]
+    pattern_type = payload[_REGEX_PATTERN_TYPE]
+    if not isinstance(pattern, str) or "\x00" in pattern:
+        raise ValueError("Regex pattern must be NUL-free text")
+    if isinstance(flags, bool) or not isinstance(flags, int):
+        raise ValueError("Regex flags must be an integer")
+    if representation not in (_REGEX_NATIVE, _REGEX_BSON):
+        raise ValueError("Regex representation is not supported")
+    if pattern_type not in (_REGEX_TEXT, _REGEX_BYTES):
+        raise ValueError("Regex pattern type is not supported")
+
+    decoded_pattern = (
+        pattern.encode("utf8") if pattern_type == _REGEX_BYTES else pattern
+    )
+    if representation == _REGEX_NATIVE:
+        return re.compile(decoded_pattern, flags)
+    if _Regex is None:
+        raise ImportError(
+            "Reading BSON Regex values requires the optional 'pymongo' "
+            "package. Install it with: pip install 'tinymongo[bson]'"
+        )
+    return _Regex(decoded_pattern, flags)
+
+
 def decode_value(value):
     """Recursively restore values previously produced by :func:`encode_value`."""
     if isinstance(value, dict):
@@ -232,6 +331,17 @@ def decode_value(value):
                             "pip install 'tinymongo[bson]'"
                         )
                     return _Decimal128.from_bid(raw)
+            if kind == _UUID_VALUE:
+                parsed = _uuid_payload(payload)
+                if parsed is not None:
+                    return parsed
+            if kind == _REGEX_VALUE:
+                try:
+                    return _decode_regex(payload)
+                except ImportError:
+                    raise
+                except (OverflowError, TypeError, ValueError, re.error):
+                    return value
             if kind == _NONFINITE_FLOAT:
                 if payload == "nan":
                     return float("nan")
@@ -322,3 +432,15 @@ def _decimal128_payload(payload):
     except ValueError:
         return None
     return decoded if len(decoded) == 16 else None
+
+
+def _uuid_payload(payload):
+    """Return a canonical RFC-4122 UUID payload, or ``None``."""
+
+    if not isinstance(payload, str) or len(payload) != 36:
+        return None
+    try:
+        parsed = UUID(payload)
+    except (AttributeError, ValueError):
+        return None
+    return parsed if str(parsed) == payload.lower() else None

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -3,7 +3,9 @@
 The JSON codec, query comparison, and cursor sorting all consume this registry
 so type recognition and subclass precedence cannot drift between them. PyMongo
 is optional: its bundled :mod:`bson` implementation is enabled atomically only
-when ``ObjectId``, ``Binary``, and ``Decimal128`` can all be imported.
+when ``ObjectId``, ``Binary``, ``Decimal128``, and ``Regex`` can all be
+imported. Native UUID and compiled regular-expression values remain available
+without PyMongo.
 """
 
 from __future__ import absolute_import
@@ -13,7 +15,9 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal, localcontext
 import math
+import re
 from typing import Any, Callable, Optional
+from uuid import UUID
 
 
 try:
@@ -24,6 +28,7 @@ try:
         Decimal128 as _Decimal128,
         create_decimal128_context as _create_decimal128_context,
     )
+    from bson.regex import Regex as _Regex
 except ImportError:  # pragma: no cover - environment without optional bson
     # Treat the optional implementation as one capability. This avoids
     # accidentally accepting the unrelated third-party ``bson`` distribution
@@ -31,7 +36,11 @@ except ImportError:  # pragma: no cover - environment without optional bson
     _ObjectId = None  # type: ignore[misc,assignment]
     _Binary = None  # type: ignore[misc,assignment]
     _Decimal128 = None  # type: ignore[misc,assignment]
+    _Regex = None  # type: ignore[misc,assignment]
     _create_decimal128_context = None  # type: ignore[misc,assignment]
+
+
+_NATIVE_REGEX_TYPE = type(re.compile(""))
 
 
 @dataclass(frozen=True)
@@ -173,9 +182,12 @@ def binary_components(value):
     """Return a binary value as ``(bytes, subtype)``.
 
     Native ``bytes`` and ``bytearray`` use BSON's generic subtype 0. PyMongo's
-    ``Binary`` retains its explicit subtype.
+    ``Binary`` retains its explicit subtype. UUID values use MongoDB's standard
+    UUID representation, binary subtype 4 with RFC-4122 byte order.
     """
 
+    if isinstance(value, UUID):
+        return value.bytes, 4
     raw = bytes(value)
     subtype = (
         int(value.subtype) if _Binary is not None and isinstance(value, _Binary) else 0
@@ -192,6 +204,79 @@ def _binary_sort_key(value):
 def _binary_identity_key(value):
     raw, subtype = binary_components(value)
     return subtype, raw
+
+
+def _regex_pattern(value):
+    """Return the UTF-8 pattern text represented by a BSON regex value."""
+
+    pattern = value.pattern
+    if isinstance(pattern, bytes):
+        return pattern.decode("utf8")
+    return pattern
+
+
+def regex_flags_text(flags):
+    """Return MongoDB's canonical, ordered BSON regex option string."""
+
+    rendered = []
+    for letter, flag in (
+        ("i", re.IGNORECASE),
+        ("l", re.LOCALE),
+        ("m", re.MULTILINE),
+        ("s", re.DOTALL),
+        ("u", re.UNICODE),
+        ("x", re.VERBOSE),
+    ):
+        if int(flags) & int(flag):
+            rendered.append(letter)
+    return "".join(rendered)
+
+
+def regex_components(value):
+    """Return a regex value as canonical BSON ``(pattern, options)`` text."""
+
+    if not is_bson_regex(value):
+        raise TypeError(
+            "Unsupported BSON regular-expression type: {0}".format(type(value).__name__)
+        )
+    return _regex_pattern(value), regex_flags_text(value.flags)
+
+
+def regex_compile_components(value):
+    """Return the original pattern and BSON-supported flags for matching."""
+
+    if not is_bson_regex(value):
+        raise TypeError(
+            "Unsupported BSON regular-expression type: {0}".format(type(value).__name__)
+        )
+    known_flags = sum(
+        int(flag)
+        for flag in (
+            re.IGNORECASE,
+            re.LOCALE,
+            re.MULTILINE,
+            re.DOTALL,
+            re.UNICODE,
+            re.VERBOSE,
+        )
+    )
+    return _regex_pattern(value), int(value.flags) & known_flags
+
+
+def _regex_key(value):
+    return regex_components(value)
+
+
+def is_native_regex(value):
+    """Return whether ``value`` is a compiled :mod:`re` pattern."""
+
+    return isinstance(value, _NATIVE_REGEX_TYPE)
+
+
+def is_bson_regex(value):
+    """Return whether ``value`` can be represented as a BSON regex."""
+
+    return is_native_regex(value) or (_Regex is not None and isinstance(value, _Regex))
 
 
 def _object_id_key(value):
@@ -258,18 +343,38 @@ _DATETIME = BSONTypeSpec(
     storage_tag="datetime",
     requires_python_comparison=True,
 )
+_UUID = BSONTypeSpec(
+    "binary",
+    5,
+    _binary_sort_key,
+    _binary_identity_key,
+    storage_tag="uuid",
+    requires_python_comparison=True,
+)
+_REGEX = BSONTypeSpec(
+    "regex",
+    9,
+    _regex_key,
+    _regex_key,
+    storage_tag="regex",
+    requires_python_comparison=True,
+)
 
 
 def bson_capabilities():
     """Return the optional PyMongo BSON capabilities available at import time."""
 
     available = (
-        _ObjectId is not None and _Binary is not None and _Decimal128 is not None
+        _ObjectId is not None
+        and _Binary is not None
+        and _Decimal128 is not None
+        and _Regex is not None
     )
     return {
         "objectid": available,
         "binary": available,
         "decimal128": available,
+        "regex": available,
     }
 
 
@@ -291,6 +396,12 @@ def decimal128_type():
     return _Decimal128
 
 
+def regex_type():
+    """Return PyMongo's ``Regex`` class, or ``None`` when unavailable."""
+
+    return _Regex
+
+
 def bson_type_spec(value) -> Optional[BSONTypeSpec]:
     """Return sorting metadata for a supported scalar, or ``None``.
 
@@ -304,10 +415,14 @@ def bson_type_spec(value) -> Optional[BSONTypeSpec]:
         return _BINARY
     if isinstance(value, (bytes, bytearray)):
         return _BINARY
+    if isinstance(value, UUID):
+        return _UUID
     if _ObjectId is not None and isinstance(value, _ObjectId):
         return _OBJECT_ID
     if _Decimal128 is not None and isinstance(value, _Decimal128):
         return _DECIMAL_NUMBER
+    if is_bson_regex(value):
+        return _REGEX
     if isinstance(value, datetime):
         return _DATETIME
     if isinstance(value, bool):

--- a/tinymongo/indexes.py
+++ b/tinymongo/indexes.py
@@ -7,7 +7,7 @@ from decimal import Decimal, localcontext
 from typing import Mapping, Optional
 
 from .errors import DuplicateKeyError, TinyMongoNotSupportedError
-from .bson_types import bson_number_decimal, decimal128_type
+from .bson_types import bson_identity_key, bson_number_decimal, decimal128_type
 from .warning_context import emit_warning
 
 
@@ -470,6 +470,19 @@ def _scalar_token(value):
     if isinstance(value, str):
         return "string:{0}".format(
             json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+        )
+    identity = bson_identity_key(value)
+    if identity is not None and identity[0] == "binary":
+        subtype, raw = identity[1]
+        return "binary:{0}:{1}".format(subtype, raw.hex())
+    if identity is not None and identity[0] == "regex":
+        pattern, options = identity[1]
+        return "regex:{0}".format(
+            json.dumps(
+                [pattern, options],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
         )
     if isinstance(value, Mapping):
         _unsupported("Object values cannot be indexed")

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -26,7 +26,12 @@ from .bson_types import (
     bson_scalar_sort_key,
     bson_values_equal,
     decimal128_type,
+    is_bson_regex,
     is_bson_number,
+    is_native_regex,
+    regex_compile_components,
+    regex_components,
+    regex_flags_text,
 )
 from .errors import (
     DuplicateKeyError,
@@ -525,6 +530,14 @@ def _reject_remote_unique_values(documents, specs):
                     "values; its native JSON constraint cannot guarantee "
                     "cross-process MongoDB numeric uniqueness".format(spec.name)
                 )
+            identity = bson_identity_key(value)
+            if identity is not None and identity[0] in ("binary", "regex"):
+                raise TinyMongoNotSupportedError(
+                    "Remote SQL unique index {0!r} does not support UUID, "
+                    "Binary, or regular-expression values; its native JSON "
+                    "constraint cannot guarantee cross-process BSON "
+                    "identity".format(spec.name)
+                )
 
 
 def _comparison_matches(actual, operand, comparison):
@@ -561,20 +574,35 @@ def _comparison_matches(actual, operand, comparison):
 
 
 def _regex_matches(actual, pattern, options=""):
+    if not isinstance(options, str) or any(option not in "imsxu" for option in options):
+        raise OperationFailure("$options supports only i, m, s, u, and x")
     flags = 0
+    if is_bson_regex(pattern):
+        if options and regex_flags_text(pattern.flags):
+            raise OperationFailure(
+                "$options cannot be combined with flags embedded in $regex"
+            )
+        pattern, flags = regex_compile_components(pattern)
     for option, flag in (
         ("i", re.IGNORECASE),
         ("m", re.MULTILINE),
         ("s", re.DOTALL),
+        ("u", re.UNICODE),
         ("x", re.VERBOSE),
     ):
         if option in str(options):
             flags |= flag
+    regex_identity = ("regex", (pattern, regex_flags_text(flags)))
+    values = actual if isinstance(actual, list) else [actual]
+    if any(
+        is_bson_regex(value) and bson_identity_key(value) == regex_identity
+        for value in values
+    ):
+        return True
     try:
         expression = re.compile(pattern, flags)
     except (TypeError, ValueError, re.error):
         return False
-    values = actual if isinstance(actual, list) else [actual]
     return any(
         isinstance(value, str) and expression.search(value) is not None
         for value in values
@@ -587,6 +615,8 @@ def _field_matches(actual, expected, exact=False):
     if not isinstance(expected, dict) or not any(
         str(key).startswith("$") for key in expected
     ):
+        if is_bson_regex(expected):
+            return exists and _regex_matches(actual, expected)
         return exists and equality(actual, expected)
 
     options = expected.get("$options", "")
@@ -624,24 +654,52 @@ def _field_matches(actual, expected, exact=False):
                 return False
         elif operator == "$in":
             values = operand if isinstance(operand, (list, tuple)) else [operand]
-            if not exists or not any(equality(actual, item) for item in values):
+            if not exists or not any(
+                (
+                    _regex_matches(actual, item)
+                    if is_bson_regex(item)
+                    else equality(actual, item)
+                )
+                for item in values
+            ):
                 return False
         elif operator == "$nin":
             values = operand if isinstance(operand, (list, tuple)) else [operand]
             if (not exists and any(item is None for item in values)) or (
-                exists and any(equality(actual, item) for item in values)
+                exists
+                and any(
+                    (
+                        _regex_matches(actual, item)
+                        if is_bson_regex(item)
+                        else equality(actual, item)
+                    )
+                    for item in values
+                )
             ):
                 return False
         elif operator == "$all":
-            if not isinstance(actual, list) or not all(
-                any(_values_equal(item, value) for value in actual) for item in operand
+            actual_values = actual if isinstance(actual, list) else [actual]
+            if not operand or not all(
+                any(
+                    (
+                        _regex_matches(item, value)
+                        if is_bson_regex(value)
+                        else _values_equal(item, value)
+                    )
+                    for item in actual_values
+                )
+                for value in operand
             ):
                 return False
         elif operator == "$regex":
             if not exists or not _regex_matches(actual, operand, options):
                 return False
         elif operator == "$not":
-            nested = operand if isinstance(operand, dict) else {"$eq": operand}
+            nested = (
+                operand
+                if isinstance(operand, dict)
+                else {("$regex" if is_bson_regex(operand) else "$eq"): operand}
+            )
             if exists and _field_matches(actual, nested, exact=exact):
                 return False
         elif operator == "$eq":
@@ -675,6 +733,76 @@ def matches_filter(doc, filter_doc):
     return True
 
 
+def _validate_regex_literal(value):
+    """Reject regex values that cannot cross a BSON persistence boundary."""
+
+    try:
+        pattern, options = regex_components(value)
+    except (TypeError, UnicodeDecodeError) as error:
+        raise OperationFailure(
+            "Regular-expression patterns must be valid UTF-8 BSON text"
+        ) from error
+    if "\x00" in pattern:
+        raise OperationFailure("Regular-expression patterns cannot contain NUL")
+    if is_native_regex(value) or "l" in options:
+        return
+    compile_pattern, flags = regex_compile_components(value)
+    try:
+        re.compile(compile_pattern, flags)
+    except (TypeError, ValueError, re.error) as error:
+        raise OperationFailure(
+            "Regular expression is not valid for TinyMongo's Python regex engine"
+        ) from error
+
+
+def _validate_regex_literals(value):
+    if is_bson_regex(value):
+        _validate_regex_literal(value)
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            _validate_regex_literals(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _validate_regex_literals(item)
+
+
+def _regex_query_flags(options):
+    if not isinstance(options, str) or any(option not in "imsxu" for option in options):
+        raise OperationFailure("$options supports only i, m, s, u, and x")
+    flags = 0
+    for option, flag in (
+        ("i", re.IGNORECASE),
+        ("m", re.MULTILINE),
+        ("s", re.DOTALL),
+        ("u", re.UNICODE),
+        ("x", re.VERBOSE),
+    ):
+        if option in options:
+            flags |= flag
+    return flags
+
+
+def _validate_regex_query_operand(operand, options=""):
+    flags = _regex_query_flags(options)
+    if is_bson_regex(operand):
+        _validate_regex_literal(operand)
+        if options and regex_flags_text(operand.flags):
+            raise OperationFailure(
+                "$options cannot be combined with flags embedded in $regex"
+            )
+        return
+    if not isinstance(operand, str):
+        raise OperationFailure("$regex requires a string or compiled regex value")
+    if "\x00" in operand:
+        raise OperationFailure("Regular-expression patterns cannot contain NUL")
+    try:
+        re.compile(operand, flags)
+    except (TypeError, ValueError, re.error) as error:
+        raise OperationFailure(
+            "$regex pattern is not valid for TinyMongo's Python regex engine"
+        ) from error
+
+
 def _validate_field_filter_operators(expression):
     """Validate one field's operator document, including nested ``$not``."""
 
@@ -687,12 +815,25 @@ def _validate_field_filter_operators(expression):
             raise OperationFailure(
                 "Field query documents cannot mix operators and literal fields"
             )
+        _validate_regex_literals(operand)
         if operator in ("$all", "$in", "$nin") and not isinstance(
             operand, (list, tuple)
         ):
             raise OperationFailure("{0} requires an array".format(operator))
+        if operator in ("$all", "$in", "$nin"):
+            if any(isinstance(item, Mapping) and "$regex" in item for item in operand):
+                raise OperationFailure(
+                    "{0} accepts regex values, not $regex operator documents".format(
+                        operator
+                    )
+                )
+            _validate_regex_literals(operand)
+        if operator == "$regex":
+            _validate_regex_query_operand(operand, expression.get("$options", ""))
         if operator == "$options" and "$regex" not in expression:
             raise OperationFailure("$options requires $regex in the same query")
+        if operator == "$options":
+            _validate_regex_query_operand(expression["$regex"], operand)
         if (
             operator == "$not"
             and isinstance(operand, Mapping)
@@ -727,6 +868,52 @@ def validate_filter_operators(filter_doc):
             str(operator).startswith("$") for operator in expected
         ):
             _validate_field_filter_operators(expected)
+        else:
+            _validate_regex_literals(expected)
+
+
+def _validate_regex_field_expression(expression):
+    """Validate only regex-specific shapes without widening query policy."""
+
+    if "$regex" in expression:
+        _validate_regex_query_operand(
+            expression["$regex"], expression.get("$options", "")
+        )
+    for operator in ("$all", "$in", "$nin"):
+        operand = expression.get(operator)
+        if not isinstance(operand, (list, tuple)):
+            continue
+        if any(isinstance(item, Mapping) and "$regex" in item for item in operand):
+            raise OperationFailure(
+                "{0} accepts regex values, not $regex operator documents".format(
+                    operator
+                )
+            )
+        _validate_regex_literals(operand)
+    not_operand = expression.get("$not")
+    if isinstance(not_operand, Mapping) and any(
+        str(key).startswith("$") for key in not_operand
+    ):
+        _validate_regex_field_expression(not_operand)
+    else:
+        _validate_regex_literals(not_operand)
+
+
+def validate_regex_filter(filter_doc):
+    """Preflight regex operands without changing other legacy query behavior."""
+
+    if not isinstance(filter_doc, Mapping):
+        return
+    for key, expected in filter_doc.items():
+        if key in _LOGICAL_FILTER_OPERATORS and isinstance(expected, (list, tuple)):
+            for specification in expected:
+                validate_regex_filter(specification)
+        elif isinstance(expected, Mapping) and any(
+            str(operator).startswith("$") for operator in expected
+        ):
+            _validate_regex_field_expression(expected)
+        else:
+            _validate_regex_literals(expected)
 
 
 def _filter_references_id(filter_doc):
@@ -2756,6 +2943,7 @@ class RemoteSQLTableBackend(TableBackend):
             isinstance(filter_doc, dict)
             and set(filter_doc.keys()) == {"_id"}
             and not isinstance(filter_doc["_id"], dict)
+            and not is_bson_regex(filter_doc["_id"])
         ):
             doc = self._find_by_id(collection, filter_doc["_id"])
             return [doc] if doc else []

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -22,9 +22,11 @@ from .bson_types import (
     bson_identity_key,
     bson_number_decimal,
     bson_scalar_sort_key,
+    bson_value_identity_key,
     bson_value_sort_key,
     bson_values_equal,
     decimal128_type,
+    is_bson_regex,
     is_bson_number,
     object_id_type,
 )
@@ -74,6 +76,7 @@ from .table_backends import (
     _value_matches,
     matches_filter,
     requires_python_filter,
+    validate_regex_filter,
 )
 
 basestring = str
@@ -684,10 +687,15 @@ def _direct_id_equality(filter_doc):
     if not isinstance(filter_doc, dict) or set(filter_doc) != {"_id"}:
         return _MISSING
     expected = filter_doc["_id"]
+    if is_bson_regex(expected):
+        return _MISSING
     if isinstance(expected, dict) and any(str(key).startswith("$") for key in expected):
         if set(expected) != {"$eq"}:
             return _MISSING
-        return expected["$eq"]
+        expected = expected["$eq"]
+        if is_bson_regex(expected):
+            return _MISSING
+        return expected
     return expected
 
 
@@ -728,7 +736,7 @@ def _simple_equality_filter(_filter):
     if not isinstance(_filter, dict) or len(_filter) != 1:
         return None
     field, value = next(iter(_filter.items()))
-    if field.startswith("$") or isinstance(value, (dict, list)):
+    if field.startswith("$") or isinstance(value, (dict, list)) or is_bson_regex(value):
         return None
     return field, value
 
@@ -1813,9 +1821,16 @@ class TinyMongoCollection(object):
                 self.build_table()
             self._refresh_table()
 
-            existing = self.find_one({"_id": _id})
+            # A bare regex is a query predicate, but an ``_id`` collision is
+            # always exact BSON identity. Looking it up through ``find_one``
+            # could otherwise confuse a regex ID with a matching string ID.
+            documents = self.table.all()
+            existing = next(
+                (item for item in documents if bson_values_equal(item.get("_id"), _id)),
+                None,
+            )
             if existing is None:
-                self._validate_unique_post_image(self.table.all() + [doc])
+                self._validate_unique_post_image(documents + [doc])
                 eid = self.table.insert(doc)
             else:
                 raise DuplicateKeyError(
@@ -2150,6 +2165,7 @@ class TinyMongoCollection(object):
         :return: UpdateResult
         """
         _reject_session(kwargs)
+        validate_regex_filter(query)
         _validate_update_document(doc)
         self._validate_storage_document(doc)
         upsert = kwargs.get("upsert") is True
@@ -2281,6 +2297,7 @@ class TinyMongoCollection(object):
         :return: UpdateResult
         """
         _reject_session(kwargs)
+        validate_regex_filter(query)
         _validate_update_document(doc)
         self._validate_storage_document(doc)
         upsert = kwargs.get("upsert") is True
@@ -2416,6 +2433,7 @@ class TinyMongoCollection(object):
         Replaces one document matching the query with the replacement document.
         """
         _reject_session(kwargs)
+        validate_regex_filter(query)
         if not isinstance(replacement, dict):
             raise TypeError('"replacement" must be a dict')
         self._validate_storage_document(replacement)
@@ -2644,6 +2662,7 @@ class TinyMongoCollection(object):
         _reject_session(kwargs)
         if _filter is None and "filter" in kwargs:
             _filter = kwargs["filter"]
+        validate_regex_filter({} if _filter is None else _filter)
         projection = normalize_projection(projection)
         sort = kwargs.get("sort")
         if self.parent.engine is not None:
@@ -2764,17 +2783,27 @@ class TinyMongoCollection(object):
         """Return unique values for a field among matching documents."""
         _reject_session(kwargs)
         values = []
+        identities = set()
+        unsupported_values = []
         for document in self.find(filter or {}):
             value = _get_nested(document, key)
             if value is _MISSING:
                 continue
             candidates = value if isinstance(value, list) else [value]
             for candidate in candidates:
-                if not any(
-                    type(candidate) is type(existing) and candidate == existing
-                    for existing in values
-                ):
-                    values.append(copy.deepcopy(candidate))
+                identity = bson_value_identity_key(candidate)
+                if identity is not None:
+                    if identity in identities:
+                        continue
+                    identities.add(identity)
+                else:
+                    if any(
+                        type(candidate) is type(existing) and candidate == existing
+                        for existing in unsupported_values
+                    ):
+                        continue
+                    unsupported_values.append(candidate)
+                values.append(copy.deepcopy(candidate))
         return values
 
     def remove(self, spec_or_id, multi=True, *args, **kwargs):
@@ -2792,6 +2821,7 @@ class TinyMongoCollection(object):
         :return: DeleteResult
         """
         _reject_session(kwargs)
+        validate_regex_filter(query)
         if self.parent.engine is not None:
             result = self.parent.engine.delete_many(self.tablename, query, multi=False)
             return DeleteResult(raw_result=result)
@@ -2821,6 +2851,7 @@ class TinyMongoCollection(object):
         :return: DeleteResult
         """
         _reject_session(kwargs)
+        validate_regex_filter(query)
         if self.parent.engine is not None:
             result = self.parent.engine.delete_many(self.tablename, query, multi=True)
             return DeleteResult(raw_result=result)


### PR DESCRIPTION
## Summary

This PR completes the remaining optional BSON serialization work in #75 and the remaining `$group` accumulator scope in #91. UUID and regular-expression behavior is now available alongside the existing BSON support, and all eight planned group accumulators run through the shared synchronous/asynchronous aggregation engine.

Closes #75
Closes #91

## UUID and regular-expression support

- Adds native `uuid.UUID` and compiled `re.Pattern` persistence without requiring PyMongo.
- Adds optional `bson.Regex` round trips through `tinymongo[bson]`.
- Uses MongoDB's STANDARD RFC-4122 subtype-4 UUID identity, including equality with equivalent `bson.Binary` values.
- Supports BSON-aware queries, sorting, `distinct()`, document IDs, and embedded unique-index tokens.
- Supports bare regex predicates plus `$regex`, `$in`, `$nin`, `$all`, `$not`, and exact `$eq`.
- Validates malformed regex operands before reading storage.
- Preserves native versus BSON regex representation locally and documents the Python `re` versus MongoDB PCRE2 boundary.
- Makes remote SQL unique indexes fail closed when native constraints cannot guarantee Binary, UUID, or regex identity.

## Group accumulators

- Adds `$avg`, `$first`, `$last`, `$push`, and `$addToSet` beside `$min`, `$max`, and `$sum`.
- Preserves MongoDB missing/null rules, incoming order, whole-array values, and recursive BSON equality.
- Implements compensated numeric averaging with integer, double, Decimal128, NaN, and infinity behavior verified against MongoDB.
- Allows the currently supported aggregation expressions inside accumulator operands, including `$literal` for literal arrays.
- Adds MongoDB-compatible validation ordering and error codes 40234–40238.

## API and backend coverage

The implementation remains in shared backend-independent code and is available through synchronous and asynchronous clients on memory, JSON/TinyDB, SQLite, DuckDB, Parquet, PostgreSQL, and MariaDB/MySQL.

Remote SQL stores and queries UUID/regex values but rejects unsafe unique-index cases until native constraints can enforce exact BSON identity across concurrent processes.

## Documentation

- Updates README behavior and compatibility boundaries.
- Updates the changelog.
- Marks #75 and #91 complete in `ROADMAP.md` and records completion of the aggregation core work.

## Validation

- Full suite: **2,435 passed, 325 deselected**
- Coverage: **100% statements and branches**
  - 6,547 statements
  - 2,670 branches
- Live MongoDB 8.0 new contracts: **38 passed, 2 intentional regex-ID skips**
- PostgreSQL and MariaDB sync/async checks: **8 passed**
- No-PyMongo sync/async persistent-backend tests: passed
- Ruff: passed
- Black: passed
- mypy: passed
- Package build and Twine validation: passed

## Compatibility boundaries

- TinyMongo always uses STANDARD UUID representation for native UUID values; PyMongo's per-client UUID representation negotiation is not exposed.
- TinyMongo preserves native `re.Pattern` values locally; PyMongo decodes the same BSON value as `bson.Regex`.
- Regex matching uses Python's `re` engine, so advanced PCRE2 syntax fails clearly instead of silently returning no matches.
- MongoDB forbids regex `_id` values; TinyMongo retains its broader local ID support and uses exact BSON identity for duplicate checks.
- PostgreSQL/MariaDB unique indexes fail closed for Binary, UUID, and regex values.
