### PR TITLE
Add strict query operators and MongoDB-compatible write errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   unique-index identity across synchronous and asynchronous backends. UUIDs
   use standard subtype-4 BinData identity, and native or BSON regex values use
   their pattern plus canonical MongoDB options.
+- MongoDB-style `$size`, `$elemMatch`, `$type`, and `$mod` query operators,
+  including array-member behavior, BSON type aliases and numeric codes, and
+  operand validation across synchronous and asynchronous clients.
 
 ### Changed
 - Aggregation capability reporting now describes the exact supported stages,
@@ -31,6 +34,10 @@
   value. The value therefore changed from falsey `False` to a truthy structured
   mapping; use `client.supports("aggregation")` for a Boolean check or inspect
   the mapping when selecting individual features.
+- Query capability reporting now enumerates logical and field operators.
+  `bson_types` likewise changed from a Boolean to a structured mapping of
+  dependency-free `native` families and installed optional `pymongo` types;
+  inspect its `pymongo` tuple when detecting optional BSON support.
 - Remote SQL unique indexes fail closed for Decimal128 values, as they already
   do for arrays, when their native JSON constraints cannot guarantee exact
   MongoDB numeric identity across concurrent writers.
@@ -39,6 +46,15 @@
   constraint.
 
 ### Fixed
+- **TM-016:** `distinct()` now collapses BSON-equivalent numeric values across
+  integers, doubles, and Decimal128 while keeping booleans distinct.
+- **TM-018:** Every CRUD filter now rejects unsupported or misspelled query
+  operators before storage access instead of silently returning no matches.
+- **TM-020:** Duplicate `_id` and unique-index failures now expose MongoDB error
+  code `11000` through `DuplicateKeyError`.
+- **TM-021:** Applying `$addToSet` to a null or non-array field now raises
+  PyMongo-compatible `WriteError` code `2` instead of a bare `ValueError`, while
+  preserving update atomicity.
 - Aggregation field references no longer cross a raw array nested directly
   inside another array before reaching the requested field.
 - Aggregation projections preserve source BSON field order for retained fields

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ For development, clone this repository and run `pip install -e .` from its
 root. Use the `v1.2.1` tag when you need source and documentation that match
 the current stable package exactly; `master` may contain unreleased changes.
 This README follows `master`: the aggregation core, advanced array-update
-modifiers, and Decimal128 support described below were added after `v1.2.1`
-and are not part of the 1.2.1 package on PyPI. See
+modifiers, Decimal128, UUID, and regex support, and the additional query
+operators described below were added after `v1.2.1` and are not part of the
+1.2.1 package on PyPI. See
 [`CHANGELOG.md`](https://github.com/schapman1974/tinymongo/blob/master/CHANGELOG.md)
 for the complete unreleased list.
 
@@ -416,7 +417,16 @@ and `to_list()`; `limit(0)` means no limit.
 Query support includes equality (including scalar matches against array
 members), nested document paths, `$gt`, `$gte`, `$lt`, `$lte`, `$ne`,
 `$nin`, `$in`, `$all`, `$and`, `$or`, `$nor`, `$not`, `$regex`,
-case-insensitive `$options`, and `$exists`.
+case-insensitive `$options`, `$exists`, `$size`, `$elemMatch`, `$type`, and
+`$mod`. `$size` matches an exact array length, while `$elemMatch` requires one
+array member to satisfy the complete nested condition. `$type` accepts MongoDB
+type names, numeric codes, or a list of either; `$mod` follows MongoDB's
+integer-truncation and array-member matching rules.
+
+Every CRUD method that accepts a filter validates it before reading or changing
+storage. Unsupported or misspelled `$`-prefixed query operators raise
+`TinyMongoNotSupportedError` instead of silently returning no matches, and
+malformed operands for recognized operators raise `OperationFailure`.
 
 MongoDB treats missing fields differently depending on the negated value.
 `{"field": {"$ne": None}}` and `$nin` lists containing `None` exclude
@@ -429,7 +439,8 @@ Update support includes `$set`, `$unset`, `$inc`, `$push`, `$pull`, and
 `update_many()` require update operators; use `replace_one()` for full-document
 replacement. `$push` accepts `$each`, `$position`, `$sort`, and `$slice`;
 `$addToSet` accepts `$each`; and `$pull` accepts literal, query, and document
-operands.
+operands. Applying `$addToSet` to an existing null or non-array field raises a
+PyMongo-compatible `WriteError` with code `2`, and the update remains atomic.
 
 `find()` and `find_one()` accept Mongo-style inclusion and exclusion
 projections. Dotted paths project nested fields, `_id` follows MongoDB's special
@@ -469,7 +480,8 @@ Index definitions and unique constraints survive client restarts on persistent
 backends. SQLite, PostgreSQL, and MariaDB/MySQL create native database indexes;
 JSON, DuckDB, and Parquet persist metadata and enforce unique constraints through
 TinyMongo. Named memory databases retain metadata while their process-local
-namespace exists.
+namespace exists. Duplicate `_id` and unique-index violations raise
+`DuplicateKeyError` with MongoDB-compatible code `11000`.
 
 Plural `create_indexes()` accepts duck-typed PyMongo `IndexModel` batches
 without importing PyMongo in TinyMongo's core. Unique indexes are enforced.
@@ -738,14 +750,22 @@ TinyMongo reports behavior that each configured backend can honor:
 
 ```python
 client = TinyMongoClient("./data", backend="sqlite")
-print(client.capabilities())
+capabilities = client.capabilities()
+print(capabilities)
+print(capabilities["query_operators"]["field"])
+print(capabilities["bson_types"]["pymongo"])
 print(client.supports("multiprocess_writes"))
 ```
 
 The capability map covers persistence, remote and object storage, table-native
 storage, multiprocess writes, native indexes, projections, bulk writes,
-aggregation, sessions, transactions, change streams, and installed BSON support.
-Unknown capability names raise `ValueError` so configuration mistakes are
+aggregation, query operators, BSON types, sessions, transactions, and change
+streams. `query_operators` separates top-level logical operators from field
+operators. `bson_types` separates dependency-free `native` families from the
+richer `pymongo` types available when the optional BSON extra is installed.
+These values are structured mappings; use `client.supports()` for a Boolean
+feature check or inspect their tuples when selecting a particular operator or
+type. Unknown capability names raise `ValueError` so configuration mistakes are
 visible.
 
 For local persistent backends, `multiprocess_writes=True` promises safe writes,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,6 +108,18 @@ with the follow-up audit of his
   concurrent WAL reads; describe the differing Parquet lock scope separately.
 - [x] **TM-005:** Preserve application-level caller attribution for warnings
   emitted by synchronous work dispatched through the async executor.
+- [x] **TM-016:** Make `distinct()` collapse BSON-equivalent integers, doubles,
+  and Decimal128 values while keeping booleans distinct from numbers.
+- [x] **TM-018 / #77:** Reject unsupported or misspelled query operators before
+  storage access, and implement the application-prioritized `$size`,
+  `$elemMatch`, `$type`, and `$mod` query slices across CRUD entry points.
+- [x] Enumerate supported logical and field query operators plus dependency-free
+  and optional-PyMongo BSON type families through structured capabilities.
+- [x] **TM-020:** Report MongoDB duplicate-key code `11000` for duplicate `_id`
+  and unique-index failures.
+- [x] **TM-021:** Raise PyMongo-compatible `WriteError` code `2` when
+  `$addToSet` targets a null or non-array field, without partially applying the
+  update.
 - [ ] **Remote SQL numeric uniqueness:** Persist canonical BSON numeric tokens
   for remote unique indexes so native constraints can enforce exact
   cross-process equality for every int/float representation; Decimal128
@@ -130,13 +142,12 @@ with the follow-up audit of his
   capabilities-detection, portable-error-catching, index-migration wording,
   and the contradictory async `db.name` collection example identified by the
   guide audit.
-- [ ] Under [#77](https://github.com/schapman1974/tinymongo/issues/77), reject
+- [x] Under [#77](https://github.com/schapman1974/tinymongo/issues/77), reject
   unsupported query operators with `TinyMongoNotSupportedError` instead of
-  silently returning no matches; then implement the application-prioritized
-  `$size`, `$elemMatch`, `$type`, and `$mod` slices.
-- [ ] Under [#94](https://github.com/schapman1974/tinymongo/issues/94), replace
-  raw Python range comparisons with BSON-aware comparison contracts and reuse
-  BSON identity rules in `$pull`, `$addToSet`, and `distinct()`.
+  silently returning no matches, and implement `$size`, `$elemMatch`, `$type`,
+  and `$mod`.
+- [ ] Under [#94](https://github.com/schapman1974/tinymongo/issues/94), complete
+  the remaining BSON-aware range-comparison contracts.
 - [ ] Extend unique-index tokens to supported BSON values through
   [#75](https://github.com/schapman1974/tinymongo/issues/75) and
   [#76](https://github.com/schapman1974/tinymongo/issues/76).
@@ -169,8 +180,10 @@ Application-compatibility work:
   - [x] Talk Python query slice: scalar-to-array equality, combined `$nin`,
     `$not`, `$regex`, case-insensitive `$options`, and Mongo-correct
     null-versus-missing negation.
-  - [ ] Prioritize the remaining query and update candidates from measured
-    application failures.
+  - [x] Reject unsupported or misspelled query operators across CRUD filters and
+    add `$size`, `$elemMatch`, `$type`, and `$mod`.
+  - [ ] Prioritize the remaining update candidates from measured application
+    failures.
 - [ ] [#102: Optional PyMongo-version adaptation](https://github.com/schapman1974/tinymongo/issues/102)
   - [x] TinyMongo errors conditionally inherit matching PyMongo errors.
   - [ ] Add version-matrix CI plus broader signature and result adaptation.

--- a/tests/contracts/test_query_operator_contract.py
+++ b/tests/contracts/test_query_operator_contract.py
@@ -1,0 +1,542 @@
+"""Query-validation and write-error contracts shared by every target."""
+
+from collections import UserDict
+
+import pytest
+
+from tinymongo.errors import DuplicateKeyError as TinyMongoDuplicateKeyError
+from tinymongo.errors import OperationFailure as TinyMongoOperationFailure
+from tinymongo.errors import TinyMongoNotSupportedError
+from tinymongo.errors import WriteError as TinyMongoWriteError
+
+
+pytestmark = pytest.mark.contract
+
+_DUPLICATE_KEY_ERRORS = (TinyMongoDuplicateKeyError,)
+_OPERATION_ERRORS = (TinyMongoOperationFailure,)
+_WRITE_ERRORS = (TinyMongoWriteError,)
+try:
+    from pymongo.errors import DuplicateKeyError as PyMongoDuplicateKeyError
+    from pymongo.errors import OperationFailure as PyMongoOperationFailure
+    from pymongo.errors import WriteError as PyMongoWriteError
+except ImportError:  # pragma: no cover - optional dependency guard
+    pass
+else:
+    _DUPLICATE_KEY_ERRORS += (PyMongoDuplicateKeyError,)
+    _OPERATION_ERRORS += (PyMongoOperationFailure,)
+    _WRITE_ERRORS += (PyMongoWriteError,)
+
+_QUERY_REJECTION_ERRORS = _OPERATION_ERRORS + (TinyMongoNotSupportedError,)
+
+
+def _ids(rows):
+    return sorted(document["_id"] for document in rows)
+
+
+def _run_filter_operation(collection, operation, query):
+    """Exercise every PyMongo-style CRUD entry point that accepts a filter."""
+
+    if operation == "find":
+        return list(collection.find(query))
+    if operation == "find_one":
+        return collection.find_one(query)
+    if operation == "count_documents":
+        return collection.count_documents(query)
+    if operation == "distinct":
+        return collection.distinct("value", query)
+    if operation == "update_one":
+        return collection.update_one(query, {"$set": {"touched": True}})
+    if operation == "update_many":
+        return collection.update_many(query, {"$set": {"touched": True}})
+    if operation == "replace_one":
+        return collection.replace_one(query, {"value": "replacement"})
+    if operation == "delete_one":
+        return collection.delete_one(query)
+    if operation == "delete_many":
+        return collection.delete_many(query)
+    if operation == "find_one_and_update":
+        return collection.find_one_and_update(
+            query,
+            {"$set": {"touched": True}},
+        )
+    if operation == "find_one_and_replace":
+        return collection.find_one_and_replace(
+            query,
+            {"value": "replacement"},
+        )
+    if operation == "find_one_and_delete":
+        return collection.find_one_and_delete(query)
+    raise AssertionError("Unknown test operation: {0}".format(operation))
+
+
+def test_size_matches_arrays_with_the_exact_requested_length(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "empty", "values": []},
+            {"_id": "one", "values": [1]},
+            {"_id": "two", "values": [1, 2]},
+            {"_id": "nested-two", "values": [[1], [2, 3]]},
+            {"_id": "scalar", "values": "not-an-array"},
+            {"_id": "missing"},
+        ]
+    )
+
+    assert _ids(collection.find({"values": {"$size": 0}})) == ["empty"]
+    assert _ids(collection.find({"values": {"$size": 2}})) == [
+        "nested-two",
+        "two",
+    ]
+
+
+def test_elem_match_requires_one_array_member_to_satisfy_every_condition(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "same-document",
+                "results": [
+                    {"kind": "quiz", "score": 8},
+                    {"kind": "exam", "score": 10},
+                ],
+                "values": [2, 7, 12],
+            },
+            {
+                "_id": "split-documents",
+                "results": [
+                    {"kind": "quiz", "score": 3},
+                    {"kind": "exam", "score": 8},
+                ],
+                "values": [1, 3, 12],
+            },
+            {
+                "_id": "scalar-field",
+                "results": {"kind": "quiz", "score": 8},
+                "values": 7,
+            },
+        ]
+    )
+
+    assert _ids(
+        collection.find(
+            {
+                "results": {
+                    "$elemMatch": {
+                        "kind": "quiz",
+                        "score": {"$gte": 8},
+                    }
+                }
+            }
+        )
+    ) == ["same-document"]
+    assert _ids(
+        collection.find({"values": {"$elemMatch": {"$gte": 5, "$lt": 10}}})
+    ) == ["same-document"]
+
+
+def test_elem_match_document_paths_traverse_nested_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "nested-array", "values": [[1, 2], [3]]},
+            {
+                "_id": "nested-document",
+                "values": [{"a": [{"b": 1}, {"b": 2}]}],
+            },
+            {"_id": "raw-nested-document", "values": [[{"x": 2}]]},
+        ]
+    )
+
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-array",
+                "values": {"$elemMatch": {"0": 1}},
+            }
+        )["_id"]
+        == "nested-array"
+    )
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-array",
+                "values": {"$elemMatch": {"missing": {"$exists": False}}},
+            }
+        )["_id"]
+        == "nested-array"
+    )
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-document",
+                "values": {"$elemMatch": {"a.b": {"$type": "int"}}},
+            }
+        )["_id"]
+        == "nested-document"
+    )
+    assert (
+        _ids(
+            collection.find(
+                {
+                    "_id": "raw-nested-document",
+                    "values": {"$elemMatch": {"x": 2}},
+                }
+            )
+        )
+        == []
+    )
+    assert (
+        _ids(
+            collection.find(
+                {
+                    "_id": "raw-nested-document",
+                    "values": {"$all": [{"$elemMatch": {"x": 2}}]},
+                }
+            )
+        )
+        == []
+    )
+    assert (
+        collection.find_one(
+            {
+                "_id": "nested-document",
+                "values": {"$elemMatch": {"a.0.b": 1}},
+            }
+        )["_id"]
+        == "nested-document"
+    )
+
+    for condition in (
+        1,
+        {"$type": "int"},
+        {"$mod": [2, 1]},
+        {"$gt": 0},
+        {"$all": [1, 2]},
+    ):
+        assert (
+            collection.find_one({"_id": "nested-array", "values.0": condition}) is None
+        )
+    for condition in (
+        [1, 2],
+        {"$size": 2},
+        {"$type": "array"},
+        {"$elemMatch": {"$gt": 1}},
+    ):
+        assert (
+            collection.find_one({"_id": "nested-array", "values.0": condition})["_id"]
+            == "nested-array"
+        )
+
+
+def test_elem_match_null_conditions_match_missing_document_fields(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "raw-array", "values": [[1, 2]]},
+            {"_id": "missing-field", "values": [{"other": 1}]},
+            {"_id": "explicit-null", "values": [{"value": None}]},
+        ]
+    )
+
+    for condition in (
+        None,
+        {"$eq": None},
+        {"$in": [None]},
+        {"$all": [None]},
+    ):
+        assert _ids(
+            collection.find({"values": {"$elemMatch": {"value": condition}}})
+        ) == ["explicit-null", "missing-field", "raw-array"]
+
+
+def test_dotted_query_paths_traverse_document_arrays_not_raw_nested_arrays(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "documents", "items": [{"score": 1}, {"score": 5}]},
+            {"_id": "partly-missing", "items": [{"other": 1}, {"score": 2}]},
+            {"_id": "raw-array", "items": [[{"score": 1}]]},
+        ]
+    )
+
+    assert _ids(collection.find({"items.score": 1})) == ["documents"]
+    assert _ids(collection.find({"items.score": {"$type": "int"}})) == [
+        "documents",
+        "partly-missing",
+    ]
+    assert _ids(collection.find({"items.score": {"$exists": False}})) == ["raw-array"]
+    assert _ids(collection.find({"items.score": {"$ne": None}})) == [
+        "documents",
+        "raw-array",
+    ]
+    assert _ids(collection.find({"items.score": {"$nin": [None]}})) == [
+        "documents",
+        "raw-array",
+    ]
+
+    collection.create_index("items.score")
+    assert _ids(collection.find({"items.score": 1})) == ["documents"]
+
+
+def test_null_equality_keeps_missing_fields_visible_after_indexing(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "missing"},
+            {"_id": "null", "value": None},
+            {"_id": "other", "value": 1},
+        ]
+    )
+
+    assert _ids(collection.find({"value": None})) == ["missing", "null"]
+    collection.create_index("value")
+    assert _ids(collection.find({"value": None})) == ["missing", "null"]
+
+
+def test_tuple_equality_keeps_array_matches_visible_after_indexing(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "exact-array", "value": [1, 2]},
+            {"_id": "array-member", "value": [[1, 2]]},
+            {"_id": "other", "value": [2, 3]},
+        ]
+    )
+
+    assert _ids(collection.find({"value": (1, 2)})) == [
+        "array-member",
+        "exact-array",
+    ]
+    collection.create_index("value")
+    assert _ids(collection.find({"value": (1, 2)})) == [
+        "array-member",
+        "exact-array",
+    ]
+
+
+def test_continued_numeric_paths_ignore_scalar_index_dead_ends(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "scalar-index", "items": [1, 2]},
+            {"_id": "numeric-field", "items": [1, {"0": {"score": 3}}]},
+        ]
+    )
+
+    assert _ids(collection.find({"items.0.score": {"$ne": None}})) == [
+        "numeric-field",
+        "scalar-index",
+    ]
+    assert _ids(collection.find({"items.0.score": {"$nin": [None]}})) == [
+        "numeric-field",
+        "scalar-index",
+    ]
+    assert _ids(collection.find({"items.0.score": 3})) == ["numeric-field"]
+
+
+def test_numeric_query_paths_consider_array_indexes_and_document_field_names(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "array-index", "items": ["index-zero"]},
+            {"_id": "first-field", "items": [{"0": "field-zero"}]},
+            {
+                "_id": "later-field",
+                "items": [{"other": 1}, {"0": "later-zero"}],
+            },
+            {"_id": "indexed-array-only", "items": [[1, 2]]},
+            {"_id": "mixed", "items": [[1, 2], {"0": 1}]},
+        ]
+    )
+
+    assert _ids(collection.find({"items.0": "index-zero"})) == ["array-index"]
+    assert _ids(collection.find({"items.0": "field-zero"})) == ["first-field"]
+    assert _ids(collection.find({"items.0": "later-zero"})) == ["later-field"]
+    assert _ids(collection.find({"items.0": 1})) == ["mixed"]
+
+
+def test_mapping_filters_work_for_new_operators_and_dotted_paths(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "match", "values": [1, 2], "items": [{"score": 1}]},
+            {"_id": "other", "values": [1], "items": [{"score": 2}]},
+        ]
+    )
+
+    assert _ids(collection.find(UserDict({"values": UserDict({"$size": 2})}))) == [
+        "match"
+    ]
+    assert _ids(collection.find(UserDict({"items.score": 1}))) == ["match"]
+    assert _ids(
+        collection.find(
+            UserDict({"items": UserDict({"$elemMatch": UserDict({"score": 1})})})
+        )
+    ) == ["match"]
+
+
+def test_type_supports_aliases_codes_lists_and_array_element_matching(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "string", "value": "hello"},
+            {"_id": "int", "value": 7},
+            {"_id": "long", "value": 2**40},
+            {"_id": "double", "value": 7.5},
+            {"_id": "bool", "value": True},
+            {"_id": "array", "value": ["hello", 7]},
+            {"_id": "object", "value": {"nested": 1}},
+            {"_id": "null", "value": None},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$type": "string"}})) == [
+        "array",
+        "string",
+    ]
+    assert _ids(collection.find({"value": {"$type": 2}})) == [
+        "array",
+        "string",
+    ]
+    assert _ids(collection.find({"value": {"$type": "int"}})) == [
+        "array",
+        "int",
+    ]
+    assert _ids(collection.find({"value": {"$type": "array"}})) == ["array"]
+    assert _ids(collection.find({"value": {"$type": ["long", "double"]}})) == [
+        "double",
+        "long",
+    ]
+    assert _ids(collection.find({"value": {"$type": "number"}})) == [
+        "array",
+        "double",
+        "int",
+        "long",
+    ]
+
+
+def test_mod_uses_mongodb_integer_truncation_and_array_member_rules(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "ten", "value": 10},
+            {"_id": "eleven", "value": 11},
+            {"_id": "fraction", "value": 10.9},
+            {"_id": "negative", "value": -10},
+            {"_id": "array", "value": [1, 14]},
+            {"_id": "string", "value": "10"},
+        ]
+    )
+
+    expected = ["array", "fraction", "ten"]
+    assert _ids(collection.find({"value": {"$mod": [4, 2]}})) == expected
+    assert _ids(collection.find({"value": {"$mod": [4.9, 2.9]}})) == expected
+    assert _ids(collection.find({"value": {"$mod": [4, -2]}})) == ["negative"]
+
+
+def test_recognized_query_operators_reject_malformed_operands(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": [1, 2]})
+    malformed_queries = [
+        {"value": {"$size": "2"}},
+        {"value": {"$elemMatch": 1}},
+        {"value": {"$type": "not-a-real-bson-type"}},
+        {"value": {"$mod": [4]}},
+    ]
+
+    for query in malformed_queries:
+        with pytest.raises(_OPERATION_ERRORS):
+            list(collection.find(query))
+
+
+def test_find_rejects_top_level_and_field_operator_typos(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": 1})
+
+    for query in ({"$madeUp": 1}, {"value": {"$madeUp": 1}}):
+        with pytest.raises(_QUERY_REJECTION_ERRORS):
+            list(collection.find(query))
+
+
+def test_every_filtering_crud_entrypoint_rejects_operator_typos(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "original", "value": 1}
+    collection.insert_one(original)
+    operations = (
+        "find",
+        "find_one",
+        "count_documents",
+        "distinct",
+        "update_one",
+        "update_many",
+        "replace_one",
+        "delete_one",
+        "delete_many",
+        "find_one_and_update",
+        "find_one_and_replace",
+        "find_one_and_delete",
+    )
+    typo = {"value": {"$madeUp": 1}}
+
+    for operation in operations:
+        with pytest.raises(_QUERY_REJECTION_ERRORS):
+            _run_filter_operation(collection, operation, typo)
+        assert collection.find_one({"_id": "original"}) == original
+
+
+def test_distinct_rejects_falsey_non_document_filters(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": 1})
+
+    for malformed_filter in ([], (), 0, False, ""):
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            collection.distinct("value", malformed_filter)
+        assert caught.value.code == 14
+
+
+def test_duplicate_key_errors_report_code_11000(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "first", "email": "ada@example.test"})
+
+    with pytest.raises(_DUPLICATE_KEY_ERRORS) as duplicate_id:
+        collection.insert_one({"_id": "first", "email": "grace@example.test"})
+    assert duplicate_id.value.code == 11000
+
+    collection.create_index("email", unique=True)
+    with pytest.raises(_DUPLICATE_KEY_ERRORS) as duplicate_index:
+        collection.insert_one({"_id": "second", "email": "ada@example.test"})
+    assert duplicate_index.value.code == 11000
+
+
+def test_add_to_set_non_array_errors_report_code_2_and_leave_document_atomic(
+    contract_target,
+):
+    collection = contract_target.collection
+    originals = [
+        {"_id": "scalar", "values": "not-an-array", "status": "original"},
+        {"_id": "null", "values": None, "status": "original"},
+    ]
+    collection.insert_many(originals)
+
+    for method in (collection.update_one, collection.update_many):
+        for original in originals:
+            with pytest.raises(_WRITE_ERRORS) as caught:
+                method(
+                    {"_id": original["_id"]},
+                    {
+                        "$set": {"status": "changed"},
+                        "$addToSet": {"values": "new"},
+                    },
+                )
+            assert caught.value.code == 2
+            assert collection.find_one({"_id": original["_id"]}) == original

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -13,6 +13,7 @@ from tinymongo.errors import (
     BulkWriteError,
     DuplicateKeyError,
     TinyMongoNotSupportedError,
+    WriteError,
 )
 from tinymongo.table_backends import _json_dumps
 
@@ -102,6 +103,79 @@ def test_remote_sql_backend_round_trip(backend, env_name):
     finally:
         docs.drop()
         client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_query_operators_and_write_error_codes(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][prefix + "_query_operators"]
+    try:
+        docs.insert_many(
+            [
+                {"_id": "one", "values": [2, 7], "results": [{"score": 8}]},
+                {"_id": "two", "values": [1, 4, 9], "results": [{"score": 3}]},
+                {"_id": "scalar", "values": "not-an-array"},
+            ]
+        )
+
+        assert docs.find_one({"values": {"$size": 2}})["_id"] == "one"
+        assert docs.find_one({"results": {"$elemMatch": {"score": 8}}})["_id"] == "one"
+        assert {item["_id"] for item in docs.find({"values": {"$type": "int"}})} == {
+            "one",
+            "two",
+        }
+        assert {item["_id"] for item in docs.find({"values": {"$mod": [2, 0]}})} == {
+            "one",
+            "two",
+        }
+
+        with pytest.raises(TinyMongoNotSupportedError, match=r"\$exsits"):
+            docs.find({"values": {"$exsits": True}})
+        with pytest.raises(DuplicateKeyError) as duplicate:
+            docs.insert_one({"_id": "one"})
+        assert duplicate.value.code == 11000
+        with pytest.raises(WriteError) as write_error:
+            docs.update_one(
+                {"_id": "scalar"},
+                {"$addToSet": {"values": "new"}},
+            )
+        assert write_error.value.code == 2
+    finally:
+        docs.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_async_query_operators(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+
+    async def scenario():
+        client = AsyncTinyMongoClient(backend=backend, dsn=dsn)
+        docs = client[database][prefix + "_async_query_operators"]
+        try:
+            await docs.insert_many(
+                [
+                    {"_id": "one", "values": [2, 7], "results": [{"score": 8}]},
+                    {"_id": "two", "values": [1, 4, 9]},
+                ]
+            )
+            size_rows = await docs.find({"values": {"$size": 2}}).to_list()
+            elem_rows = await docs.find(
+                {"results": {"$elemMatch": {"score": 8}}}
+            ).to_list()
+            type_rows = await docs.find({"values": {"$type": "int"}}).to_list()
+            mod_rows = await docs.find({"values": {"$mod": [2, 0]}}).to_list()
+
+            assert [item["_id"] for item in size_rows] == ["one"]
+            assert [item["_id"] for item in elem_rows] == ["one"]
+            assert {item["_id"] for item in type_rows} == {"one", "two"}
+            assert {item["_id"] for item in mod_rows} == {"one", "two"}
+        finally:
+            await docs.drop()
+            await client.close()
+
+    asyncio.run(scenario())
 
 
 @pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -45,7 +45,15 @@ def test_result_properties_and_error_classes():
     assert updated.upserted_id is None
     assert deleted.raw_result == 3
     assert deleted.deleted_count == 3
-    assert str(DuplicateKeyError("duplicate"))
+    duplicate = DuplicateKeyError("duplicate")
+    assert str(duplicate)
+    assert duplicate.code == 11000
+    detailed_duplicate = DuplicateKeyError(
+        "duplicate",
+        details={"keyPattern": {"email": 1}},
+    )
+    assert detailed_duplicate.code == 11000
+    assert detailed_duplicate.details == {"keyPattern": {"email": 1}}
     failure = OperationFailure("failed", code=42, details={"ok": False})
     assert str(failure)
     assert failure.code == 42
@@ -625,10 +633,11 @@ def test_direct_helper_and_lock_edges(tmp_path, monkeypatch):
     ] == ["x"]
     with pytest.raises(ValueError):
         core._apply_update_document({"_id": 1, "items": "x"}, {"$pull": {"items": "x"}})
-    with pytest.raises(ValueError):
+    with pytest.raises(WriteError) as caught:
         core._apply_update_document(
             {"_id": 1, "items": "x"}, {"$addToSet": {"items": "x"}}
         )
+    assert caught.value.code == 2
 
     with monkeypatch.context() as ctx:
         ctx.setattr(
@@ -695,7 +704,34 @@ def test_query_operator_branches_without_mongo(tmp_path):
     assert c.find({"$or": [{"name": "alpha"}, {"name": "gamma"}]}).count() == 2
     assert c.find({"missing": {"$exists": False}}).count() == 3
     assert c.find({"tags": [["a"]]}).count() == 0
-    assert c.find({"tags": {"$unknown": ["a"]}}).count() == 0
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$unknown"):
+        c.find({"tags": {"$unknown": ["a"]}})
+
+
+def test_unknown_query_operator_fails_before_collection_storage_is_created(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path / "db"), backend="sqlite")
+    collection = client.app.items
+
+    with pytest.raises(TinyMongoNotSupportedError, match=r"\$exsits"):
+        collection.find({"value": {"$exsits": True}})
+
+    assert client.app.list_collection_names() == []
+    client.close()
+
+
+@pytest.mark.parametrize("error", [AttributeError("bad query"), TypeError("bad query")])
+def test_tinydb_native_search_errors_remain_empty_results(tmp_path, monkeypatch, error):
+    client = tm.TinyMongoClient(str(tmp_path / "db"))
+    collection = client.app.items
+    collection.insert_one({"_id": 1, "name": "Ada"})
+    monkeypatch.setattr(
+        collection.table,
+        "search",
+        lambda _condition: (_ for _ in ()).throw(error),
+    )
+
+    assert list(collection.find({"name": {"$gt": "A"}})) == []
+    client.close()
 
 
 def test_collection_write_and_no_match_edges(tmp_path):

--- a/tests/test_insert_many_semantics.py
+++ b/tests/test_insert_many_semantics.py
@@ -349,6 +349,10 @@ def test_bulk_write_error_remains_available_without_pymongo(monkeypatch):
     assert error.details["writeErrors"][0]["index"] == 0
     assert error.timeout is False
 
+    duplicate = namespace["DuplicateKeyError"]("duplicate")
+    assert duplicate.code == 11000
+    assert duplicate.details is None
+
 
 def test_native_duplicate_race_is_replanned_as_a_bulk_write_error():
     class RacingEngine:

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -155,9 +155,47 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
         ),
         "expressions": ("$ifNull", "$literal", "$size"),
     }
+    assert capabilities["query_operators"] == {
+        "logical": ("$and", "$or", "$nor"),
+        "field": (
+            "$all",
+            "$elemMatch",
+            "$eq",
+            "$exists",
+            "$gt",
+            "$gte",
+            "$in",
+            "$lt",
+            "$lte",
+            "$ne",
+            "$nin",
+            "$not",
+            "$mod",
+            "$options",
+            "$regex",
+            "$size",
+            "$type",
+        ),
+    }
+    assert capabilities["bson_types"]["native"] == (
+        "array",
+        "binary",
+        "boolean",
+        "datetime",
+        "double",
+        "int",
+        "long",
+        "null",
+        "object",
+        "regex",
+        "string",
+        "uuid",
+    )
     assert capabilities["sessions"] is False
     assert client.supports("multiprocess_writes") is True
     assert client.supports("aggregation") is True
+    assert client.supports("query_operators") is True
+    assert client.supports("bson_types") is True
 
 
 def test_object_storage_capabilities_are_conservative(tmp_path):

--- a/tests/test_query_operator_coverage_edges.py
+++ b/tests/test_query_operator_coverage_edges.py
@@ -1,0 +1,231 @@
+"""Focused branch coverage for MongoDB-style query operator edge cases."""
+
+import re
+
+import pytest
+
+from tinymongo import table_backends as backends
+from tinymongo.errors import OperationFailure
+
+
+@pytest.mark.parametrize(
+    ("operand", "message"),
+    [
+        (float("nan"), "finite integral"),
+        (1.5, "integral values"),
+        (-1, "below the supported range"),
+        (2**31, "above the supported range"),
+    ],
+)
+def test_size_rejects_nonfinite_fractional_and_out_of_range_values(
+    operand,
+    message,
+):
+    with pytest.raises(OperationFailure, match=message) as caught:
+        backends.validate_filter_operators({"value": {"$size": operand}})
+
+    assert caught.value.code == 2
+
+
+def test_mod_rejects_a_zero_divisor_with_mongodb_error_metadata():
+    with pytest.raises(OperationFailure, match="divisor cannot be zero") as caught:
+        backends.validate_filter_operators({"value": {"$mod": [0, 0]}})
+
+    assert caught.value.code == 2
+
+
+def test_mod_skips_nonfinite_and_out_of_int64_stored_values():
+    query = {"value": {"$mod": [2, 0]}}
+
+    assert not backends.matches_filter({"value": float("nan")}, query)
+    assert not backends.matches_filter({"value": float("inf")}, query)
+    assert not backends.matches_filter({"value": 2**63}, query)
+    assert not backends.matches_filter({"value": -(2**63) - 1}, query)
+
+
+def test_mod_treats_a_defensive_numeric_conversion_failure_as_no_match(
+    monkeypatch,
+):
+    original_conversion = backends.bson_number_decimal
+
+    def fail_for_stored_value(value):
+        if value == 7:
+            raise ArithmeticError("defensive conversion failure")
+        return original_conversion(value)
+
+    monkeypatch.setattr(backends, "bson_number_decimal", fail_for_stored_value)
+
+    assert not backends._mod_matches(7, [2, 1])
+
+
+def test_type_rejects_empty_invalid_and_wrongly_typed_operands():
+    cases = [
+        ([], 9, "at least one type"),
+        (42, 2, "Invalid numerical BSON type code"),
+        (True, 14, "number or a string"),
+    ]
+
+    for operand, code, message in cases:
+        with pytest.raises(OperationFailure, match=message) as caught:
+            backends.validate_filter_operators({"value": {"$type": operand}})
+        assert caught.value.code == code
+
+
+def test_type_deduplicates_equivalent_aliases_and_codes():
+    assert backends._normalize_type_operand(["string", 2, "string"]) == frozenset(
+        ("string",)
+    )
+
+
+def test_type_names_cover_unregistered_and_decimal_values():
+    assert backends._bson_query_type_names(object()) == frozenset()
+
+    if backends._DECIMAL128 is None:
+        pytest.skip("Decimal128 query typing requires the optional BSON package")
+    value = backends._DECIMAL128("1.25")
+
+    assert backends._bson_query_type_names(value) == frozenset(("number", "decimal"))
+    assert backends.matches_filter({"value": value}, {"value": {"$type": 19}})
+
+
+def test_empty_elem_match_matches_only_container_array_members():
+    query = {"value": {"$elemMatch": {}}}
+    backends.validate_filter_operators(query)
+
+    assert backends.matches_filter({"value": [{"kind": "document"}]}, query)
+    assert backends.matches_filter({"value": [["nested-array"]]}, query)
+    assert not backends.matches_filter({"value": [1, "scalar", None]}, query)
+    assert not backends.matches_filter({"value": "not-an-array"}, query)
+
+
+def test_query_path_candidates_cover_numeric_fanout_and_scalar_boundaries():
+    assert backends._is_query_array_index("0")
+    assert backends._is_query_array_index("12")
+    assert not backends._is_query_array_index("")
+    assert not backends._is_query_array_index("01")
+
+    assert backends._query_path_match_candidates("value", []) == [("value", False)]
+    assert backends._query_path_candidates([{"3": "named"}], ["3"]) == ["named"]
+    assert backends._query_path_candidates(("zero",), ["0"]) == ["zero"]
+    assert backends._query_path_candidates([{"0": "field"}, "index"], ["0"]) == [
+        {"0": "field"},
+        "field",
+    ]
+    assert backends._query_path_match_candidates([[1, 2]], ["0"]) == [([1, 2], True)]
+    assert backends._query_path_match_candidates([1], ["0", "nested"]) == []
+    assert backends._query_path_candidates({"value": 1}, ["value", "nested"]) == [
+        backends._MISSING
+    ]
+    assert backends._query_path_candidates([], ["missing"]) == []
+
+
+def test_multiple_query_path_candidates_preserve_operator_semantics():
+    assert backends._field_path_matches([1, 2], 2)
+    assert backends._field_path_matches([{"a": 1}, {"a": 2}], {"a": 2})
+    assert backends._field_path_matches(
+        ["Ada", "Grace"],
+        {"$regex": "^a", "$options": "i"},
+    )
+    assert backends._field_path_matches([1, 2], {"$gt": 1})
+    assert not backends._field_path_matches([1, 2], {"$gt": 3})
+    assert not backends._field_path_matches([1, 2], {"$ne": 1})
+    assert backends._field_path_matches(
+        [backends._MISSING, backends._MISSING],
+        {"$exists": False},
+    )
+    assert not backends._field_path_matches(
+        [[1, 2]],
+        1,
+        indexed_endpoints=[True],
+    )
+    assert backends._field_path_matches(
+        [[1, 2], 1],
+        1,
+        indexed_endpoints=[True, False],
+    )
+    assert backends._field_path_matches([], {"$ne": None})
+    assert backends._field_path_matches([], {"$exists": False})
+    assert not backends._field_path_matches([], {"$exists": True})
+
+
+def test_query_null_equality_distinguishes_missing_from_zero_candidates():
+    assert backends._query_values_equal(backends._MISSING, None)
+    assert not backends._query_values_equal(backends._MISSING, 0)
+    assert backends._field_path_matches([backends._MISSING], None)
+    assert not backends._field_path_matches([], None)
+
+
+def test_all_accepts_elem_match_but_rejects_other_nested_operator_documents():
+    valid = {"value": {"$all": [{"$elemMatch": {"$gt": 1, "$lt": 3}}]}}
+    backends.validate_filter_operators(valid)
+
+    assert backends.matches_filter({"value": [0, 2, 4]}, valid)
+    assert not backends.matches_filter({"value": [0, 4]}, valid)
+
+    with pytest.raises(OperationFailure, match="cannot contain nested") as caught:
+        backends.validate_filter_operators({"value": {"$all": [{"$gt": 1}]}})
+    assert caught.value.code == 2
+
+
+@pytest.mark.parametrize("operator", ["$in", "$nin"])
+def test_in_and_nin_reject_nested_operator_documents(operator):
+    with pytest.raises(OperationFailure, match="cannot contain nested") as caught:
+        backends.validate_filter_operators({"value": {operator: [{"$gt": 1}]}})
+
+    assert caught.value.code == 2
+
+
+def test_elem_match_accepts_logical_document_queries():
+    query = {
+        "value": {
+            "$elemMatch": {
+                "$or": [
+                    {"kind": "quiz"},
+                    {"score": {"$gt": 8}},
+                ]
+            }
+        }
+    }
+    backends.validate_filter_operators(query)
+
+    assert backends.matches_filter(
+        {"value": [{"kind": "quiz", "score": 1}]},
+        query,
+    )
+    assert backends.matches_filter(
+        {"value": [{"kind": "exam", "score": 9}]},
+        query,
+    )
+    assert not backends.matches_filter(
+        {"value": [{"kind": "exam", "score": 8}]},
+        query,
+    )
+
+
+def test_regex_compatibility_validator_walks_every_legacy_query_shape():
+    backends.validate_regex_filter(
+        {
+            "$and": [
+                {"name": {"$regex": "^ada", "$options": "i"}},
+                {"alias": {"$not": {"$regex": "^admin"}}},
+            ],
+            "tags": {"$in": ["python", re.compile("^database")]},
+            "literal": re.compile("^value"),
+            "not_literal": {"$not": re.compile("^hidden")},
+        }
+    )
+
+
+def test_get_nested_returns_custom_default_for_missing_paths():
+    marker = object()
+
+    assert backends._get_nested({"outer": {}}, "outer.missing", marker) is marker
+    assert backends._get_nested({"outer": 1}, "outer.missing", marker) is marker
+
+
+@pytest.mark.parametrize("operator", ["$all", "$in", "$nin"])
+def test_regex_compatibility_validator_rejects_operator_documents_in_arrays(
+    operator,
+):
+    with pytest.raises(OperationFailure, match="accepts regex values"):
+        backends.validate_regex_filter({"value": {operator: [{"$regex": "^value"}]}})

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -24,9 +24,16 @@ def test_bson_capabilities_are_enabled_atomically(monkeypatch):
         "decimal128": True,
         "regex": True,
     }
+    assert bson_types.supported_bson_types()["pymongo"] == (
+        "binary",
+        "decimal128",
+        "objectid",
+        "regex",
+    )
 
     monkeypatch.setattr(bson_types, "_Regex", None)
     assert not any(bson_types.bson_capabilities().values())
+    assert bson_types.supported_bson_types()["pymongo"] == ()
     monkeypatch.setattr(bson_types, "_Regex", marker)
     monkeypatch.setattr(bson_types, "_Binary", None)
     assert bson_types.bson_capabilities() == {

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -403,7 +403,7 @@ def contains_extended_value(value):
     spec = bson_types.bson_type_spec(value)
     if spec is not None and spec.requires_python_comparison:
         return True
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         return any(contains_extended_value(item) for item in value.values())
     if isinstance(value, (list, tuple)):
         return any(contains_extended_value(item) for item in value)

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -378,6 +378,33 @@ def bson_capabilities():
     }
 
 
+def supported_bson_types():
+    """Enumerate native families and richer types enabled by PyMongo."""
+
+    optional = bson_capabilities()
+    return {
+        "native": (
+            "array",
+            "binary",
+            "boolean",
+            "datetime",
+            "double",
+            "int",
+            "long",
+            "null",
+            "object",
+            "regex",
+            "string",
+            "uuid",
+        ),
+        "pymongo": tuple(
+            name
+            for name in ("binary", "decimal128", "objectid", "regex")
+            if optional[name]
+        ),
+    }
+
+
 def object_id_type():
     """Return PyMongo's ``ObjectId`` class, or ``None`` when unavailable."""
 

--- a/tinymongo/errors.py
+++ b/tinymongo/errors.py
@@ -103,6 +103,14 @@ class WriteError(_WriteError, OperationFailure):
 class DuplicateKeyError(_DuplicateKeyError, WriteError):
     """Raised when a write violates a unique key constraint."""
 
+    def __init__(self, error, code=11000, details=None, max_wire_version=None):
+        super(DuplicateKeyError, self).__init__(
+            error,
+            code,
+            details,
+            max_wire_version,
+        )
+
 
 class BulkWriteError(_BulkWriteError, OperationFailure):
     """Raised when one or more operations in a batch write fail."""

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -59,24 +59,57 @@ _SAFE_JSON_INTEGER_BITS = 1800
 _SQLITE_UNIQUE_TOKEN_VERSION = 3
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
 _PHYSICAL_ID_PREFIX = "__tinymongo_id_v2__:"
-_LOGICAL_FILTER_OPERATORS = frozenset(("$and", "$or", "$nor"))
-_FIELD_FILTER_OPERATORS = frozenset(
-    (
-        "$all",
-        "$eq",
-        "$exists",
-        "$gt",
-        "$gte",
-        "$in",
-        "$lt",
-        "$lte",
-        "$ne",
-        "$nin",
-        "$not",
-        "$options",
-        "$regex",
-    )
+_LOGICAL_FILTER_OPERATOR_NAMES = ("$and", "$or", "$nor")
+_FIELD_FILTER_OPERATOR_NAMES = (
+    "$all",
+    "$elemMatch",
+    "$eq",
+    "$exists",
+    "$gt",
+    "$gte",
+    "$in",
+    "$lt",
+    "$lte",
+    "$ne",
+    "$nin",
+    "$not",
+    "$mod",
+    "$options",
+    "$regex",
+    "$size",
+    "$type",
 )
+_LOGICAL_FILTER_OPERATORS = frozenset(_LOGICAL_FILTER_OPERATOR_NAMES)
+_FIELD_FILTER_OPERATORS = frozenset(_FIELD_FILTER_OPERATOR_NAMES)
+_BSON_QUERY_TYPE_CODES = {
+    -1: "minKey",
+    1: "double",
+    2: "string",
+    3: "object",
+    4: "array",
+    5: "binData",
+    6: "undefined",
+    7: "objectId",
+    8: "bool",
+    9: "date",
+    10: "null",
+    11: "regex",
+    12: "dbPointer",
+    13: "javascript",
+    14: "symbol",
+    15: "javascriptWithScope",
+    16: "int",
+    17: "timestamp",
+    18: "long",
+    19: "decimal",
+    127: "maxKey",
+}
+_BSON_QUERY_TYPE_ALIASES = frozenset(
+    tuple(_BSON_QUERY_TYPE_CODES.values()) + ("number",)
+)
+_SIGNED_INT64_MIN = -(2**63)
+_SIGNED_INT64_MAX = 2**63 - 1
+_SIGNED_INT32_MAX = 2**31 - 1
 
 
 def _large_numeric_ratio(key):
@@ -456,6 +489,57 @@ def _get_nested(doc, path, default=_MISSING):
     return current
 
 
+def _is_query_array_index(part):
+    return part == "0" or (
+        part
+        and part[0] in "123456789"
+        and all("0" <= character <= "9" for character in part)
+    )
+
+
+def _query_path_match_candidates(value, parts):
+    """Resolve values plus whether a numeric index selected the endpoint."""
+
+    if not parts:
+        return [(value, False)]
+
+    part = parts[0]
+    if isinstance(value, Mapping):
+        if part not in value:
+            return [(_MISSING, False)]
+        if len(parts) == 1:
+            return [(value[part], False)]
+        return _query_path_match_candidates(value[part], parts[1:])
+
+    if isinstance(value, (list, tuple)):
+        candidates = []
+        if _is_query_array_index(part):
+            index = int(part)
+            if index < len(value):
+                if len(parts) == 1:
+                    candidates.append((value[index], True))
+                elif isinstance(value[index], (Mapping, list, tuple)):
+                    candidates.extend(
+                        _query_path_match_candidates(value[index], parts[1:])
+                    )
+
+        for member in value:
+            if isinstance(member, Mapping):
+                candidates.extend(_query_path_match_candidates(member, parts))
+        return candidates
+
+    return [(_MISSING, False)]
+
+
+def _query_path_candidates(value, parts):
+    """Resolve query paths through documents and arrays without flattening endpoints."""
+
+    return [
+        candidate
+        for candidate, _indexed_endpoint in _query_path_match_candidates(value, parts)
+    ]
+
+
 def _values_equal(actual, expected):
     """Compare values recursively with BSON scalar equality semantics."""
 
@@ -463,7 +547,7 @@ def _values_equal(actual, expected):
         return len(actual) == len(expected) and all(
             _values_equal(left, right) for left, right in zip(actual, expected)
         )
-    if isinstance(actual, dict) and isinstance(expected, dict):
+    if isinstance(actual, Mapping) and isinstance(expected, Mapping):
         actual_items = list(actual.items())
         expected_items = list(expected.items())
         return len(actual_items) == len(expected_items) and all(
@@ -483,6 +567,14 @@ def _value_matches(actual, expected):
     return _values_equal(actual, expected)
 
 
+def _query_values_equal(actual, expected, exact=False):
+    """Apply MongoDB's null-equals-missing rule at query boundaries."""
+
+    if actual is _MISSING:
+        return expected is None
+    return (_values_equal if exact else _value_matches)(actual, expected)
+
+
 def _sqlite_unique_token(data, field):
     """Return the same lossless unique token used by Python validation."""
     document = _json_loads(data)
@@ -495,7 +587,7 @@ def _sqlite_unique_token(data, field):
 
 def _simple_scalar_equality(filter_doc):
     """Return one SQL-safe equality pair, or ``None`` for richer filters."""
-    if not isinstance(filter_doc, dict) or len(filter_doc) != 1:
+    if not isinstance(filter_doc, Mapping) or len(filter_doc) != 1:
         return None
     field, expected = next(iter(filter_doc.items()))
     if (
@@ -503,7 +595,7 @@ def _simple_scalar_equality(filter_doc):
         or field.startswith("$")
         or field == "_id"
         or expected is None
-        or isinstance(expected, (dict, list, tuple))
+        or isinstance(expected, (Mapping, list, tuple))
         or not isinstance(expected, (bool, int, float, str))
     ):
         return None
@@ -540,12 +632,12 @@ def _reject_remote_unique_values(documents, specs):
                 )
 
 
-def _comparison_matches(actual, operand, comparison):
+def _comparison_matches(actual, operand, comparison, exact=False):
     operand_identity = bson_identity_key(operand)
     operand_order = bson_scalar_sort_key(operand)
     if operand_identity is None or operand_order is None:
         return False
-    values = actual if isinstance(actual, list) else [actual]
+    values = actual if isinstance(actual, list) and not exact else [actual]
     for value in values:
         value_identity = bson_identity_key(value)
         value_order = bson_scalar_sort_key(value)
@@ -573,7 +665,7 @@ def _comparison_matches(actual, operand, comparison):
     return False
 
 
-def _regex_matches(actual, pattern, options=""):
+def _regex_matches(actual, pattern, options="", exact=False):
     if not isinstance(options, str) or any(option not in "imsxu" for option in options):
         raise OperationFailure("$options supports only i, m, s, u, and x")
     flags = 0
@@ -593,7 +685,7 @@ def _regex_matches(actual, pattern, options=""):
         if option in str(options):
             flags |= flag
     regex_identity = ("regex", (pattern, regex_flags_text(flags)))
-    values = actual if isinstance(actual, list) else [actual]
+    values = actual if isinstance(actual, list) and not exact else [actual]
     if any(
         is_bson_regex(value) and bson_identity_key(value) == regex_identity
         for value in values
@@ -609,15 +701,236 @@ def _regex_matches(actual, pattern, options=""):
     )
 
 
+def _query_integer(value, operator, minimum=None, maximum=None, truncate=False):
+    """Return one finite integral BSON number for a query operator."""
+
+    if not is_bson_number(value):
+        raise OperationFailure("{0} requires numeric values".format(operator), code=2)
+    try:
+        decimal_value = bson_number_decimal(value)
+        if not decimal_value.is_finite():
+            raise ValueError
+        integer = int(decimal_value)
+    except (ArithmeticError, TypeError, ValueError, OverflowError) as error:
+        raise OperationFailure(
+            "{0} requires finite integral values".format(operator), code=2
+        ) from error
+    if not truncate and decimal_value != integer:
+        raise OperationFailure("{0} requires integral values".format(operator), code=2)
+    if minimum is not None and integer < minimum:
+        raise OperationFailure(
+            "{0} value is below the supported range".format(operator), code=2
+        )
+    if maximum is not None and integer > maximum:
+        raise OperationFailure(
+            "{0} value is above the supported range".format(operator), code=2
+        )
+    return integer
+
+
+def _normalize_size_operand(operand):
+    return _query_integer(
+        operand,
+        "$size",
+        minimum=0,
+        maximum=_SIGNED_INT32_MAX,
+    )
+
+
+def _normalize_mod_operand(operand):
+    if not isinstance(operand, (list, tuple)) or len(operand) != 2:
+        raise OperationFailure("$mod requires an array of two numbers", code=2)
+    divisor = _query_integer(
+        operand[0],
+        "$mod",
+        minimum=_SIGNED_INT64_MIN,
+        maximum=_SIGNED_INT64_MAX,
+        truncate=True,
+    )
+    remainder = _query_integer(
+        operand[1],
+        "$mod",
+        minimum=_SIGNED_INT64_MIN,
+        maximum=_SIGNED_INT64_MAX,
+        truncate=True,
+    )
+    if divisor == 0:
+        raise OperationFailure("$mod divisor cannot be zero", code=2)
+    return divisor, remainder
+
+
+def _truncating_remainder(dividend, divisor):
+    quotient = abs(dividend) // abs(divisor)
+    if (dividend < 0) != (divisor < 0):
+        quotient = -quotient
+    return dividend - quotient * divisor
+
+
+def _mod_matches(actual, operand, exact=False):
+    divisor, expected_remainder = _normalize_mod_operand(operand)
+    values = actual if isinstance(actual, list) and not exact else [actual]
+    for value in values:
+        if not is_bson_number(value):
+            continue
+        try:
+            decimal_value = bson_number_decimal(value)
+            if not decimal_value.is_finite():
+                continue
+            dividend = int(decimal_value)
+        except (ArithmeticError, TypeError, ValueError, OverflowError):
+            continue
+        if not _SIGNED_INT64_MIN <= dividend <= _SIGNED_INT64_MAX:
+            continue
+        if _truncating_remainder(dividend, divisor) == expected_remainder:
+            return True
+    return False
+
+
+def _normalize_type_operand(operand):
+    values = operand if isinstance(operand, (list, tuple)) else [operand]
+    if not values:
+        raise OperationFailure("$type must match at least one type", code=9)
+
+    aliases = []
+    for value in values:
+        if isinstance(value, str):
+            if value not in _BSON_QUERY_TYPE_ALIASES:
+                raise OperationFailure(
+                    "Unknown BSON type alias: {0}".format(value), code=2
+                )
+            alias = value
+        elif is_bson_number(value):
+            code = _query_integer(value, "$type")
+            if code not in _BSON_QUERY_TYPE_CODES:
+                raise OperationFailure(
+                    "Invalid numerical BSON type code: {0}".format(code), code=2
+                )
+            alias = _BSON_QUERY_TYPE_CODES[code]
+        else:
+            raise OperationFailure(
+                "$type must be represented as a number or a string", code=14
+            )
+        if alias not in aliases:
+            aliases.append(alias)
+    return frozenset(aliases)
+
+
+def _bson_query_type_names(value):
+    if isinstance(value, Mapping):
+        return frozenset(("object",))
+    if isinstance(value, (list, tuple)):
+        return frozenset(("array",))
+
+    identity = bson_identity_key(value)
+    if identity is None:
+        return frozenset()
+    family = identity[0]
+    if family == "number":
+        if _DECIMAL128 is not None and isinstance(value, _DECIMAL128):
+            exact = "decimal"
+        elif isinstance(value, float):
+            exact = "double"
+        elif _SIGNED_INT32_MAX >= value >= -(2**31):
+            exact = "int"
+        else:
+            exact = "long"
+        return frozenset(("number", exact))
+    return frozenset(
+        (
+            {
+                "binary": "binData",
+                "boolean": "bool",
+                "datetime": "date",
+                "objectid": "objectId",
+            }.get(family, family),
+        )
+    )
+
+
+def _type_matches(actual, operand, exact=False):
+    requested = _normalize_type_operand(operand)
+    if requested.intersection(_bson_query_type_names(actual)):
+        return True
+    return (
+        not exact
+        and isinstance(actual, list)
+        and any(requested.intersection(_bson_query_type_names(item)) for item in actual)
+    )
+
+
+def _elem_match_matches(actual, operand):
+    if not isinstance(actual, list):
+        return False
+    if not operand:
+        return any(isinstance(item, (Mapping, list, tuple)) for item in actual)
+    operator_expression = any(key in _FIELD_FILTER_OPERATORS for key in operand)
+    if operator_expression:
+        return any(_field_matches(item, operand, exact=True) for item in actual)
+    return any(
+        isinstance(item, Mapping)
+        and matches_filter(item, operand)
+        or isinstance(item, (list, tuple))
+        and matches_filter(item, operand, _array_document=True)
+        for item in actual
+    )
+
+
+def _field_path_matches(candidates, expected, exact=False, indexed_endpoints=None):
+    if indexed_endpoints is None:
+        indexed_endpoints = [False] * len(candidates)
+    if len(candidates) == 1:
+        return _field_matches(
+            candidates[0],
+            expected,
+            exact=exact or indexed_endpoints[0],
+        )
+    if not isinstance(expected, Mapping) or not any(
+        str(key).startswith("$") for key in expected
+    ):
+        return any(
+            _field_matches(
+                candidate,
+                expected,
+                exact=exact or indexed_endpoint,
+            )
+            for candidate, indexed_endpoint in zip(candidates, indexed_endpoints)
+        )
+
+    options = expected.get("$options")
+    for operator, operand in expected.items():
+        if operator == "$options":
+            continue
+        clause = {operator: operand}
+        if operator == "$regex" and options is not None:
+            clause["$options"] = options
+        matches = (
+            _field_matches(
+                candidate,
+                clause,
+                exact=exact or indexed_endpoint,
+            )
+            for candidate, indexed_endpoint in zip(candidates, indexed_endpoints)
+        )
+        negative = operator in ("$ne", "$nin", "$not") or (
+            operator == "$exists" and not bool(operand)
+        )
+        if not (all(matches) if negative else any(matches)):
+            return False
+    return True
+
+
 def _field_matches(actual, expected, exact=False):
     exists = actual is not _MISSING
-    equality = _values_equal if exact else _value_matches
-    if not isinstance(expected, dict) or not any(
+
+    def equality(left, right):
+        return _query_values_equal(left, right, exact=exact)
+
+    if not isinstance(expected, Mapping) or not any(
         str(key).startswith("$") for key in expected
     ):
         if is_bson_regex(expected):
-            return exists and _regex_matches(actual, expected)
-        return exists and equality(actual, expected)
+            return exists and _regex_matches(actual, expected, exact=exact)
+        return equality(actual, expected)
 
     options = expected.get("$options", "")
     for operator, operand in expected.items():
@@ -629,34 +942,32 @@ def _field_matches(actual, expected, exact=False):
                 return False
         elif operator == "$gt":
             if not exists or not _comparison_matches(
-                actual, operand, lambda a, b: a > b
+                actual, operand, lambda a, b: a > b, exact=exact
             ):
                 return False
         elif operator == "$gte":
             if not exists or not _comparison_matches(
-                actual, operand, lambda a, b: a >= b
+                actual, operand, lambda a, b: a >= b, exact=exact
             ):
                 return False
         elif operator == "$lt":
             if not exists or not _comparison_matches(
-                actual, operand, lambda a, b: a < b
+                actual, operand, lambda a, b: a < b, exact=exact
             ):
                 return False
         elif operator == "$lte":
             if not exists or not _comparison_matches(
-                actual, operand, lambda a, b: a <= b
+                actual, operand, lambda a, b: a <= b, exact=exact
             ):
                 return False
         elif operator == "$ne":
-            if (not exists and operand is None) or (
-                exists and equality(actual, operand)
-            ):
+            if equality(actual, operand):
                 return False
         elif operator == "$in":
             values = operand if isinstance(operand, (list, tuple)) else [operand]
-            if not exists or not any(
+            if not any(
                 (
-                    _regex_matches(actual, item)
+                    _regex_matches(actual, item, exact=exact)
                     if is_bson_regex(item)
                     else equality(actual, item)
                 )
@@ -665,70 +976,103 @@ def _field_matches(actual, expected, exact=False):
                 return False
         elif operator == "$nin":
             values = operand if isinstance(operand, (list, tuple)) else [operand]
-            if (not exists and any(item is None for item in values)) or (
-                exists
-                and any(
-                    (
-                        _regex_matches(actual, item)
-                        if is_bson_regex(item)
-                        else equality(actual, item)
-                    )
-                    for item in values
+            if any(
+                (
+                    _regex_matches(actual, item, exact=exact)
+                    if is_bson_regex(item)
+                    else equality(actual, item)
                 )
+                for item in values
             ):
                 return False
         elif operator == "$all":
-            actual_values = actual if isinstance(actual, list) else [actual]
+            actual_values = (
+                actual if isinstance(actual, list) and not exact else [actual]
+            )
             if not operand or not all(
                 any(
                     (
-                        _regex_matches(item, value)
-                        if is_bson_regex(value)
-                        else _values_equal(item, value)
+                        _elem_match_matches(actual, value["$elemMatch"])
+                        if isinstance(value, Mapping) and set(value) == {"$elemMatch"}
+                        else (
+                            _regex_matches(item, value, exact=exact)
+                            if is_bson_regex(value)
+                            else _query_values_equal(item, value, exact=True)
+                        )
                     )
                     for item in actual_values
                 )
                 for value in operand
             ):
                 return False
+        elif operator == "$elemMatch":
+            if not exists or not _elem_match_matches(actual, operand):
+                return False
         elif operator == "$regex":
-            if not exists or not _regex_matches(actual, operand, options):
+            if not exists or not _regex_matches(actual, operand, options, exact=exact):
                 return False
         elif operator == "$not":
             nested = (
                 operand
-                if isinstance(operand, dict)
+                if isinstance(operand, Mapping)
                 else {("$regex" if is_bson_regex(operand) else "$eq"): operand}
             )
-            if exists and _field_matches(actual, nested, exact=exact):
+            if _field_matches(actual, nested, exact=exact):
                 return False
         elif operator == "$eq":
-            if not exists or not equality(actual, operand):
+            if not equality(actual, operand):
+                return False
+        elif operator == "$mod":
+            if not exists or not _mod_matches(actual, operand, exact=exact):
+                return False
+        elif operator == "$size":
+            if (
+                not exists
+                or not isinstance(actual, list)
+                or len(actual) != _normalize_size_operand(operand)
+            ):
+                return False
+        elif operator == "$type":
+            if not exists or not _type_matches(actual, operand, exact=exact):
                 return False
         else:
             return False
     return True
 
 
-def matches_filter(doc, filter_doc):
+def matches_filter(doc, filter_doc, _array_document=False):
     if not filter_doc:
         return True
-    if not isinstance(filter_doc, dict):
+    if not isinstance(filter_doc, Mapping):
         return False
 
     for key, expected in filter_doc.items():
         if key == "$and":
-            if not all(matches_filter(doc, spec) for spec in expected):
+            if not all(matches_filter(doc, spec, _array_document) for spec in expected):
                 return False
         elif key == "$or":
-            if not any(matches_filter(doc, spec) for spec in expected):
+            if not any(matches_filter(doc, spec, _array_document) for spec in expected):
                 return False
         elif key == "$nor":
-            if any(matches_filter(doc, spec) for spec in expected):
+            if any(matches_filter(doc, spec, _array_document) for spec in expected):
                 return False
         else:
-            actual = _get_nested(doc, key)
-            if not _field_matches(actual, expected, exact=key == "_id"):
+            parts = key.split(".")
+            resolved = (
+                [(_MISSING, False)]
+                if _array_document
+                and isinstance(doc, (list, tuple))
+                and not _is_query_array_index(parts[0])
+                else _query_path_match_candidates(doc, parts)
+            )
+            candidates = [candidate for candidate, _indexed in resolved]
+            indexed_endpoints = [indexed for _candidate, indexed in resolved]
+            if not _field_path_matches(
+                candidates,
+                expected,
+                exact=key == "_id",
+                indexed_endpoints=indexed_endpoints,
+            ):
                 return False
     return True
 
@@ -820,14 +1164,48 @@ def _validate_field_filter_operators(expression):
             operand, (list, tuple)
         ):
             raise OperationFailure("{0} requires an array".format(operator))
-        if operator in ("$all", "$in", "$nin"):
-            if any(isinstance(item, Mapping) and "$regex" in item for item in operand):
+        if operator in ("$in", "$nin"):
+            nested_operator_documents = [
+                item
+                for item in operand
+                if isinstance(item, Mapping)
+                and any(str(key).startswith("$") for key in item)
+            ]
+            if any("$regex" in item for item in nested_operator_documents):
                 raise OperationFailure(
                     "{0} accepts regex values, not $regex operator documents".format(
                         operator
-                    )
+                    ),
+                    code=2,
+                )
+            if nested_operator_documents:
+                raise OperationFailure(
+                    "{0} cannot contain nested query operator documents".format(
+                        operator
+                    ),
+                    code=2,
                 )
             _validate_regex_literals(operand)
+        if operator == "$all":
+            for item in operand:
+                nested_operators = (
+                    [key for key in item if str(key).startswith("$")]
+                    if isinstance(item, Mapping)
+                    else []
+                )
+                if not nested_operators:
+                    continue
+                if set(item) != {"$elemMatch"}:
+                    if "$regex" in item:
+                        raise OperationFailure(
+                            "$all accepts regex values, not $regex operator documents",
+                            code=2,
+                        )
+                    raise OperationFailure(
+                        "$all cannot contain nested query operator documents",
+                        code=2,
+                    )
+                _validate_elem_match_operand(item["$elemMatch"])
         if operator == "$regex":
             _validate_regex_query_operand(operand, expression.get("$options", ""))
         if operator == "$options" and "$regex" not in expression:
@@ -840,13 +1218,32 @@ def _validate_field_filter_operators(expression):
             and any(str(key).startswith("$") for key in operand)
         ):
             _validate_field_filter_operators(operand)
+        if operator == "$elemMatch":
+            _validate_elem_match_operand(operand)
+        if operator == "$mod":
+            _normalize_mod_operand(operand)
+        if operator == "$size":
+            _normalize_size_operand(operand)
+        if operator == "$type":
+            _normalize_type_operand(operand)
+
+
+def _validate_elem_match_operand(operand):
+    if not isinstance(operand, Mapping):
+        raise OperationFailure("$elemMatch requires a query document", code=2)
+    if any(key in _LOGICAL_FILTER_OPERATORS for key in operand):
+        validate_filter_operators(operand)
+    elif any(str(key).startswith("$") for key in operand):
+        _validate_field_filter_operators(operand)
+    else:
+        validate_filter_operators(operand)
 
 
 def validate_filter_operators(filter_doc):
     """Reject operators the shared Python matcher cannot evaluate safely."""
 
     if not isinstance(filter_doc, Mapping):
-        raise OperationFailure("Filter must be a query document")
+        raise OperationFailure("Filter must be a query document", code=14)
 
     for key, expected in filter_doc.items():
         if not isinstance(key, str):
@@ -870,6 +1267,15 @@ def validate_filter_operators(filter_doc):
             _validate_field_filter_operators(expected)
         else:
             _validate_regex_literals(expected)
+
+
+def query_operator_capabilities():
+    """Return the exact query operators handled by the shared matcher."""
+
+    return {
+        "logical": _LOGICAL_FILTER_OPERATOR_NAMES,
+        "field": _FIELD_FILTER_OPERATOR_NAMES,
+    }
 
 
 def _validate_regex_field_expression(expression):
@@ -917,7 +1323,7 @@ def validate_regex_filter(filter_doc):
 
 
 def _filter_references_id(filter_doc):
-    if not isinstance(filter_doc, dict):
+    if not isinstance(filter_doc, Mapping):
         return False
     if "_id" in filter_doc:
         return True
@@ -926,14 +1332,14 @@ def _filter_references_id(filter_doc):
         for operator in ("$and", "$or", "$nor")
         for item in (
             filter_doc.get(operator, [])
-            if isinstance(filter_doc.get(operator, []), list)
+            if isinstance(filter_doc.get(operator, []), (list, tuple))
             else []
         )
     )
 
 
 def _id_condition_requires_legacy_scan(condition):
-    if not isinstance(condition, dict):
+    if not isinstance(condition, Mapping):
         return _requires_legacy_id_scan(condition)
     if not any(str(key).startswith("$") for key in condition):
         return _requires_legacy_id_scan(condition)
@@ -948,7 +1354,7 @@ def _id_condition_requires_legacy_scan(condition):
 
 
 def _filter_requires_legacy_id_scan(filter_doc):
-    if not isinstance(filter_doc, dict):
+    if not isinstance(filter_doc, Mapping):
         return False
     if "_id" in filter_doc and _id_condition_requires_legacy_scan(filter_doc["_id"]):
         return True
@@ -957,7 +1363,7 @@ def _filter_requires_legacy_id_scan(filter_doc):
         for operator in ("$and", "$or", "$nor")
         for item in (
             filter_doc.get(operator, [])
-            if isinstance(filter_doc.get(operator, []), list)
+            if isinstance(filter_doc.get(operator, []), (list, tuple))
             else []
         )
     )
@@ -973,9 +1379,9 @@ def _postfilter_id_candidates(documents, filter_doc, fallback):
         document for document in documents if matches_filter(document, filter_doc)
     ]
     direct_equality = (
-        isinstance(filter_doc, dict)
+        isinstance(filter_doc, Mapping)
         and set(filter_doc) == {"_id"}
-        and not isinstance(filter_doc["_id"], dict)
+        and not isinstance(filter_doc["_id"], Mapping)
     )
     if direct_equality and matches:
         return matches
@@ -988,8 +1394,10 @@ def _postfilter_id_candidates(documents, filter_doc, fallback):
 
 def requires_python_filter(filter_doc):
     """Return whether SQL JSON scalar comparison could change query meaning."""
-    if not filter_doc or not isinstance(filter_doc, dict):
+    if not filter_doc or not isinstance(filter_doc, Mapping):
         return False
+    if not isinstance(filter_doc, dict):
+        return True
     if contains_extended_value(filter_doc):
         return True
     for field, expected in filter_doc.items():
@@ -1005,10 +1413,14 @@ def requires_python_filter(filter_doc):
         else:
             if field.startswith("$"):
                 return True
-            if field != "_id" and not isinstance(expected, dict):
+            if "." in field:
+                return True
+            if field != "_id" and not isinstance(expected, Mapping):
                 # A JSON scalar comparison cannot also see members of array fields.
                 return True
-            if isinstance(expected, dict):
+            if isinstance(expected, Mapping):
+                if not isinstance(expected, dict):
+                    return True
                 if not any(str(operator).startswith("$") for operator in expected):
                     # Literal embedded-document equality is not an operator
                     # expression and TinyDB/SQL parsers otherwise treat its keys
@@ -1018,13 +1430,17 @@ def requires_python_filter(filter_doc):
                     operator in expected
                     for operator in (
                         "$eq",
+                        "$elemMatch",
                         "$ne",
                         "$in",
                         "$nin",
                         "$all",
+                        "$mod",
                         "$regex",
                         "$not",
                         "$options",
+                        "$size",
+                        "$type",
                     )
                 ):
                     return True
@@ -1711,9 +2127,9 @@ class SQLiteTableBackend(TableBackend):
                 ),
             )
             direct_id_equality = (
-                isinstance(filter_doc, dict)
+                isinstance(filter_doc, Mapping)
                 and set(filter_doc) == {"_id"}
-                and not isinstance(filter_doc["_id"], dict)
+                and not isinstance(filter_doc["_id"], Mapping)
             )
             if direct_id_equality and documents:
                 return documents
@@ -1834,6 +2250,8 @@ class SQLiteTableBackend(TableBackend):
         if equality is None:
             return None
         field, _ = equality
+        if "." in field:
+            return None
         if not any(spec.field == field for spec in self.get_index_specs(collection)):
             return None
 
@@ -2940,9 +3358,9 @@ class RemoteSQLTableBackend(TableBackend):
         if not filter_doc:
             return self._all_docs_unfiltered(collection)
         if (
-            isinstance(filter_doc, dict)
+            isinstance(filter_doc, Mapping)
             and set(filter_doc.keys()) == {"_id"}
-            and not isinstance(filter_doc["_id"], dict)
+            and not isinstance(filter_doc["_id"], Mapping)
             and not is_bson_regex(filter_doc["_id"])
         ):
             doc = self._find_by_id(collection, filter_doc["_id"])

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -16,7 +16,7 @@ import threading
 from uuid import uuid4
 
 from tinydb import Query, TinyDB, where  # type: ignore[attr-defined]
-from .bson_codec import bson_available, storage_values_equal
+from .bson_codec import storage_values_equal
 from .bson_types import (
     add_bson_numbers,
     bson_identity_key,
@@ -29,6 +29,7 @@ from .bson_types import (
     is_bson_regex,
     is_bson_number,
     object_id_type,
+    supported_bson_types,
 )
 from .aggregation import AggregationEngine, aggregation_capabilities
 from .sorting import bson_document_sort_value_key, sort_documents
@@ -75,8 +76,9 @@ from .table_backends import (
     _filter_references_id,
     _value_matches,
     matches_filter,
+    query_operator_capabilities,
     requires_python_filter,
-    validate_regex_filter,
+    validate_filter_operators,
 )
 
 basestring = str
@@ -639,7 +641,7 @@ def _apply_update_document(item, update_doc):
             for path, value in changes.items():
                 current = _get_nested(updated, path, [])
                 if not isinstance(current, list):
-                    raise ValueError("$addToSet target must be a list")
+                    _raise_write_error("Cannot apply $addToSet to non-array field")
                 current = list(current)
                 current = _apply_add_to_set(current, value)
                 _set_nested(updated, path, current)
@@ -684,12 +686,14 @@ def _tinydb_id_condition(value):
 def _direct_id_equality(filter_doc):
     """Return the operand for a direct exact ``_id`` query, if present."""
 
-    if not isinstance(filter_doc, dict) or set(filter_doc) != {"_id"}:
+    if not isinstance(filter_doc, Mapping) or set(filter_doc) != {"_id"}:
         return _MISSING
     expected = filter_doc["_id"]
     if is_bson_regex(expected):
         return _MISSING
-    if isinstance(expected, dict) and any(str(key).startswith("$") for key in expected):
+    if isinstance(expected, Mapping) and any(
+        str(key).startswith("$") for key in expected
+    ):
         if set(expected) != {"$eq"}:
             return _MISSING
         expected = expected["$eq"]
@@ -721,7 +725,7 @@ def _document_for_upsert(query, update_doc):
     for key, value in (query or {}).items():
         if key.startswith("$"):
             continue
-        if isinstance(value, dict):
+        if isinstance(value, Mapping):
             if set(value) == {"$eq"}:
                 value = value["$eq"]
             else:
@@ -733,10 +737,15 @@ def _document_for_upsert(query, update_doc):
 
 
 def _simple_equality_filter(_filter):
-    if not isinstance(_filter, dict) or len(_filter) != 1:
+    if not isinstance(_filter, Mapping) or len(_filter) != 1:
         return None
     field, value = next(iter(_filter.items()))
-    if field.startswith("$") or isinstance(value, (dict, list)) or is_bson_regex(value):
+    if (
+        field.startswith("$")
+        or value is None
+        or isinstance(value, (Mapping, list, tuple))
+        or is_bson_regex(value)
+    ):
         return None
     return field, value
 
@@ -973,10 +982,11 @@ class TinyMongoClient(object):
             "projections": True,
             "bulk_writes": False,
             "aggregation": aggregation_capabilities(),
+            "query_operators": query_operator_capabilities(),
             "sessions": False,
             "transactions": False,
             "change_streams": False,
-            "bson_types": bson_available(),
+            "bson_types": supported_bson_types(),
         }
 
     def supports(self, feature):
@@ -2165,7 +2175,7 @@ class TinyMongoCollection(object):
         :return: UpdateResult
         """
         _reject_session(kwargs)
-        validate_regex_filter(query)
+        validate_filter_operators(query)
         _validate_update_document(doc)
         self._validate_storage_document(doc)
         upsert = kwargs.get("upsert") is True
@@ -2297,7 +2307,7 @@ class TinyMongoCollection(object):
         :return: UpdateResult
         """
         _reject_session(kwargs)
-        validate_regex_filter(query)
+        validate_filter_operators(query)
         _validate_update_document(doc)
         self._validate_storage_document(doc)
         upsert = kwargs.get("upsert") is True
@@ -2433,7 +2443,7 @@ class TinyMongoCollection(object):
         Replaces one document matching the query with the replacement document.
         """
         _reject_session(kwargs)
-        validate_regex_filter(query)
+        validate_filter_operators(query)
         if not isinstance(replacement, dict):
             raise TypeError('"replacement" must be a dict')
         self._validate_storage_document(replacement)
@@ -2662,7 +2672,7 @@ class TinyMongoCollection(object):
         _reject_session(kwargs)
         if _filter is None and "filter" in kwargs:
             _filter = kwargs["filter"]
-        validate_regex_filter({} if _filter is None else _filter)
+        validate_filter_operators({} if _filter is None else _filter)
         projection = normalize_projection(projection)
         sort = kwargs.get("sort")
         if self.parent.engine is not None:
@@ -2711,7 +2721,10 @@ class TinyMongoCollection(object):
                         projection=projection,
                         query=_filter,
                     )
+                python_filter = requires_python_filter(_filter)
                 simple = _simple_equality_filter(_filter)
+                if simple is not None and "." in simple[0]:
+                    simple = None
                 if simple is not None:
                     key, value = simple
                     index = self._get_index(key)
@@ -2731,7 +2744,7 @@ class TinyMongoCollection(object):
                             projection=projection,
                             query=_filter,
                         )
-                if _filter_references_id(_filter) or requires_python_filter(_filter):
+                if _filter_references_id(_filter) or python_filter:
                     result = [
                         document
                         for document in self.table.all()
@@ -2785,7 +2798,7 @@ class TinyMongoCollection(object):
         values = []
         identities = set()
         unsupported_values = []
-        for document in self.find(filter or {}):
+        for document in self.find({} if filter is None else filter):
             value = _get_nested(document, key)
             if value is _MISSING:
                 continue
@@ -2821,7 +2834,7 @@ class TinyMongoCollection(object):
         :return: DeleteResult
         """
         _reject_session(kwargs)
-        validate_regex_filter(query)
+        validate_filter_operators(query)
         if self.parent.engine is not None:
             result = self.parent.engine.delete_many(self.tablename, query, multi=False)
             return DeleteResult(raw_result=result)
@@ -2851,7 +2864,7 @@ class TinyMongoCollection(object):
         :return: DeleteResult
         """
         _reject_session(kwargs)
-        validate_regex_filter(query)
+        validate_filter_operators(query)
         if self.parent.engine is not None:
             result = self.parent.engine.delete_many(self.tablename, query, multi=True)
             return DeleteResult(raw_result=result)


### PR DESCRIPTION
## Why

Mike's Talk Python testing in #136 exposed several compatibility gaps: misspelled query operators could fail silently, several common query operators were missing, and some write failures did not provide MongoDB-compatible error codes. This records the already-fixed TM-016 result and addresses TM-018, TM-020, and TM-021 while advancing the query work tracked in #77.

## What changed

- Added `$size`, `$elemMatch`, `$type`, and `$mod` across all filtering CRUD entry points.
- Added strict filter validation before storage access:
  - unknown operators raise `TinyMongoNotSupportedError`
  - malformed recognized operands raise `OperationFailure`
  - non-document filters report code `14`
- Matched MongoDB behavior for:
  - array-member and exact-array matching
  - dotted paths through arrays and canonical numeric indexes
  - numeric paths that can also refer to same-named document fields
  - nested, document, and scalar `$elemMatch`
  - `$all` with `$elemMatch`
  - `$type` aliases, numeric codes, lists, and BSON numeric families
  - `$mod` truncation, signed remainders, and finite signed-64-bit values
  - null-versus-missing behavior across direct, dotted, and array paths
  - mapping-style filters such as `UserDict`
- Fixed `distinct()` so falsey invalid filters cannot bypass validation, while retaining BSON-equivalent numeric collapsing with booleans kept distinct.
- Duplicate `_id` and unique-index failures now expose code `11000`.
- `$addToSet` against null or non-array fields now raises `WriteError` code `2` without partially applying the update.
- Query-operator and BSON-type capabilities are now structured and inspectable.
- Preserved safe scalar index shortcuts while routing dotted and null/tuple-sensitive cases through exact Python matching.
- Updated the README, changelog, roadmap, shared contracts, focused edge tests, and remote SQL integration coverage.

## Backend and async scope

The implementation lives in the shared matcher and validation layer, so the same behavior is available through synchronous and asynchronous clients on memory, JSON, SQLite, DuckDB, Parquet, PostgreSQL, and MariaDB/MySQL backends. Rich queries use Python post-filtering whenever native JSON or TinyDB evaluation could change BSON semantics.

PyMongo remains optional. Native BSON families are always reported, while PyMongo-specific types appear in capabilities only when the optional dependency is installed.

## Intentional boundaries

This PR does not complete the remaining BSON-aware range-comparison work in #94, remote SQL canonical numeric uniqueness, broader update-operator additions, or the optional PyMongo version matrix. Those remain separate roadmap items.

## Validation

- 2,641 selected tests passed
- 100% production coverage: 6,770 statements and 2,822 branches
- 250 MongoDB differential cases completed with zero mismatches
- 28 final live MongoDB sync/async contract cases passed
- 24 PostgreSQL/MariaDB integration tests passed, including sync and async paths
- 33 direct-index operand shapes matched before and after indexing
- Ruff, Black, CI-equivalent mypy, package build, and Twine checks passed

Related: #136, #77, #94
