### PR TITLE
Bound SQLite cursor reads and counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@
   scan, and `_id`-only sweeps avoid transferring unrequested JSON payloads into
   Python. Sorted cursors retain their complete-document fallback so omitted
   sort keys continue to order results correctly.
+- **TM-015:** Unsorted SQLite cursors now defer execution until their final
+  `skip` and `limit` are known, push that window into eligible native SQL
+  scans, stop Python-filtered scans after the requested result window, and use
+  payload-free SQL counts where possible. This prevents
+  `find_one({})`, `find({}).limit(1)`, and `count_documents({})` from
+  materializing an entire collection; synchronous and asynchronous paths share
+  the optimization, while sorted cursors still load every candidate needed for
+  correct global ordering.
 
 ## [1.2.1] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -461,6 +461,15 @@ The common `{"_id": 1}` sweep goes further and reads only each JSON `_id` value,
 so large unrequested payloads never enter Python memory. Filters still evaluate
 against complete source values when Python-side matching is required.
 
+SQLite `find()` cursors defer their scan until first consumption. For
+unindexed filters handled by SQLite's existing SQL compiler, a final `skip()`
+and `limit()` can therefore be applied before later payloads are read.
+Python-only filters stream until that result window is filled; paths that must
+merge scalar and array index candidates retain their complete-candidate
+fallback. `count_documents()` uses a native SQL count for the same SQL-routed
+filters and otherwise counts a row-at-a-time scan without retaining documents.
+The same paths back synchronous and asynchronous collections.
+
 This memory bound has explicit limits. Sorting must see unprojected sort keys,
 so a sorted SQLite cursor falls back to complete source documents before it
 projects the results. Other TinyMongo backends also continue to materialize

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,8 +95,17 @@ with the follow-up audit of his
   attached 400-document, 200,000-character reproduction dropped from 160.26 MB
   to 0.26 MB locally. Sorted SQLite cursors and non-SQLite backends explicitly
   retain the full-document fallback needed by their current ordering and scan
-  implementations. Mike's private 559-transcript rerun remains an external
-  acceptance check.
+  implementations. Mike's private 559-transcript rerun confirmed projected
+  single-document reads remain near 0.1 MB and separated the remaining
+  unprojected limit/count work into TM-015.
+- [x] **TM-015:** Defer SQLite cursor scans until the final unsorted window is
+  known, push `skip`/`limit` into unindexed SQL scans or a streaming Python
+  filter, and count
+  SQL-compatible filters without fetching document payloads. Deterministic
+  sync and async regressions verify that `find_one({})` and
+  `find({}).limit(1)` decode one row, `count_documents({})` decodes none, and
+  sorted cursors still consider the complete candidate set.
+  - [ ] Rerun Mike's private 559-transcript acceptance case after merge.
 - [x] **TM-001:** When a degraded index resolves to an effective key
   specification that already exists, warn once and skip the duplicate native
   index instead of creating redundant metadata or storage work.

--- a/tests/test_projection_memory.py
+++ b/tests/test_projection_memory.py
@@ -1,4 +1,4 @@
-"""TM-011 projection-pushdown regressions for SQLite collection sweeps."""
+"""TM-011 projection and TM-015 bounded-read regressions for SQLite scans."""
 
 import asyncio
 import gc
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import tracemalloc
 
 import tinymongo as tm
+import tinymongo.table_backends as table_backends
 from tinymongo.tinymongo import TinyMongoCollection
 
 
@@ -193,6 +194,354 @@ def test_projection_hook_is_optional_for_third_party_backends():
     assert list(collection.find({}, {"_id": 1})) == [{"_id": 1}]
     assert backend.calls == [("items", {})]
 
+    assert list(collection.find({}).limit(1)) == [
+        {"_id": 1, "body": "kept in the backend result"}
+    ]
+    assert collection.count_documents({}) == 1
+    assert backend.calls == [("items", {}), ("items", {}), ("items", {})]
+
+
+def test_projected_legacy_backend_reloads_complete_rows_before_sorting():
+    class ProjectedLegacyBackend:
+        def find(self, collection, filter_doc=None):
+            return [
+                {"_id": 1, "rank": 1, "body": "first"},
+                {"_id": 2, "rank": 2, "body": "second"},
+            ]
+
+        def find_projected(self, collection, filter_doc, projection):
+            return [{"_id": 1}, {"_id": 2}]
+
+    collection = TinyMongoCollection(
+        "items",
+        SimpleNamespace(engine=ProjectedLegacyBackend()),
+    )
+
+    assert list(collection.find({}, {"_id": 1}).sort("rank", -1)) == [
+        {"_id": 2},
+        {"_id": 1},
+    ]
+
+
+def test_legacy_bounded_backend_without_projected_window_hook():
+    class LegacyBoundedBackend:
+        def find_bounded(self, collection, filter_doc=None, skip=0, limit=0):
+            documents = [
+                {"_id": 1, "body": "first"},
+                {"_id": 2, "body": "second"},
+            ]
+            end = None if not limit else skip + limit
+            return documents[skip:end]
+
+        def find_projected(self, collection, filter_doc, projection):
+            return [{"_id": 1}, {"_id": 2}]
+
+    collection = TinyMongoCollection(
+        "items",
+        SimpleNamespace(engine=LegacyBoundedBackend()),
+    )
+
+    assert list(collection.find({}, {"_id": 1}).skip(1).limit(1)) == [{"_id": 2}]
+
+
+def test_sqlite_subclass_legacy_projection_override_keeps_three_arg_hook(tmp_path):
+    class LegacyProjectedSQLiteBackend(table_backends.SQLiteTableBackend):
+        def __init__(self, path):
+            super().__init__(path)
+            self.projected_calls = 0
+
+        def find_projected(self, collection, filter_doc, projection):
+            self.projected_calls += 1
+            return iter(super().find_projected(collection, filter_doc, projection))
+
+    backend = LegacyProjectedSQLiteBackend(str(tmp_path / "legacy.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1, "body": "first"},
+            {"_id": 2, "body": "second"},
+        ],
+    )
+    collection = TinyMongoCollection(
+        "items",
+        SimpleNamespace(engine=backend),
+    )
+
+    assert list(collection.find({}, {"_id": 1}).limit(1)) == [{"_id": 1}]
+    assert backend.projected_calls == 1
+
+
+def _track_sqlite_reads(monkeypatch, engine):
+    decodes = []
+    statements = []
+    original_loads = table_backends._json_loads
+    original_connect = engine._connect
+
+    def tracked_loads(value):
+        decodes.append(value)
+        return original_loads(value)
+
+    def traced_connect():
+        connection = original_connect()
+        connection.set_trace_callback(statements.append)
+        return connection
+
+    monkeypatch.setattr(table_backends, "_json_loads", tracked_loads)
+    monkeypatch.setattr(engine, "_connect", traced_connect)
+    return decodes, statements
+
+
+def _payload_selects(statements):
+    return [
+        statement
+        for statement in statements
+        if statement.lstrip().upper().startswith("SELECT DATA FROM")
+    ]
+
+
+def test_sqlite_single_result_paths_push_limit_into_payload_scan(tmp_path, monkeypatch):
+    client, collection = _sqlite_collection(tmp_path, name="bounded_reads")
+    collection.insert_many(
+        [{"_id": index, "rank": index, "body": "x" * 10_000} for index in range(12)]
+    )
+    decodes, statements = _track_sqlite_reads(monkeypatch, collection.parent.engine)
+
+    try:
+        operations = (
+            lambda: collection.find_one({}),
+            lambda: list(collection.find({}, limit=1))[0],
+            lambda: list(collection.find({}).limit(1))[0],
+        )
+        for operation in operations:
+            decodes.clear()
+            statements.clear()
+            assert operation()["_id"] == 0
+            assert len(decodes) == 1
+            payload_selects = _payload_selects(statements)
+            assert len(payload_selects) == 1
+            assert "LIMIT 1" in payload_selects[0].upper()
+
+        decodes.clear()
+        statements.clear()
+        assert collection.find_one({}, {"_id": 1}) == {"_id": 0}
+        assert decodes == []
+        assert any("LIMIT 1" in sql.upper() for sql in statements)
+
+        decodes.clear()
+        assert collection.find_one({"_id": 11})["_id"] == 11
+        assert len(decodes) == 1
+
+        query = {"rank": 0}
+        cursor = collection.find(query).limit(1)
+        query["rank"] = 11
+        assert list(cursor)[0]["_id"] == 0
+    finally:
+        client.close()
+
+
+def test_sqlite_python_filtered_limit_stops_after_first_match(tmp_path, monkeypatch):
+    client, collection = _sqlite_collection(tmp_path, name="filtered_reads")
+    collection.insert_many(
+        [
+            {
+                "_id": index,
+                "nested": {"selected": index == 3},
+                "body": "x" * 10_000,
+            }
+            for index in range(12)
+        ]
+    )
+    decodes, _statements = _track_sqlite_reads(
+        monkeypatch,
+        collection.parent.engine,
+    )
+
+    try:
+        for operation in (
+            lambda: collection.find_one({"nested.selected": True}),
+            lambda: list(collection.find({"nested.selected": True}).limit(1))[0],
+        ):
+            decodes.clear()
+            assert operation()["_id"] == 3
+            assert len(decodes) == 4
+
+        decodes.clear()
+        assert collection.find_one({"nested.selected": "missing"}) is None
+        assert len(decodes) == 12
+
+        decodes.clear()
+        assert (
+            list(
+                collection.find({"nested.selected": {"$exists": True}}).skip(2).limit(1)
+            )[0]["_id"]
+            == 2
+        )
+        assert len(decodes) == 3
+    finally:
+        client.close()
+
+
+def test_sqlite_native_count_does_not_read_payloads(tmp_path, monkeypatch):
+    client, collection = _sqlite_collection(tmp_path, name="native_counts")
+    collection.insert_many(
+        [
+            {"_id": index, "kind": "even" if index % 2 == 0 else "odd"}
+            for index in range(12)
+        ]
+    )
+    decodes, statements = _track_sqlite_reads(monkeypatch, collection.parent.engine)
+
+    try:
+        for operation, expected in (
+            (lambda: collection.count_documents({}), 12),
+            (
+                lambda: collection.count_documents({"kind": {"$exists": True}}),
+                12,
+            ),
+            (collection.estimated_document_count, 12),
+        ):
+            decodes.clear()
+            statements.clear()
+            assert operation() == expected
+            assert decodes == []
+            assert any("SELECT COUNT(*)" in sql.upper() for sql in statements)
+            assert _payload_selects(statements) == []
+    finally:
+        client.close()
+
+
+def test_sqlite_python_filtered_count_streams_exact_documents(tmp_path, monkeypatch):
+    client, collection = _sqlite_collection(tmp_path, name="filtered_counts")
+    collection.insert_many(
+        [{"_id": index, "values": list(range(index % 4))} for index in range(12)]
+    )
+    decodes, statements = _track_sqlite_reads(monkeypatch, collection.parent.engine)
+
+    try:
+        assert collection.count_documents({"values": {"$size": 2}}) == 3
+        assert len(decodes) == 12
+        assert len(_payload_selects(statements)) == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_cursor_window_reconfiguration_and_sort_precedence(tmp_path):
+    client, collection = _sqlite_collection(tmp_path, name="cursor_windows")
+    collection.insert_many([{"_id": index, "rank": 10 - index} for index in range(6)])
+
+    try:
+        assert [doc["_id"] for doc in collection.find({}).limit(1).skip(2)] == [2]
+        assert [doc["_id"] for doc in collection.find({}).limit(1).limit(0)] == list(
+            range(6)
+        )
+        assert [doc["_id"] for doc in collection.find({}).skip(4)] == [4, 5]
+        assert [doc["_id"] for doc in collection.find({}).limit(1).sort("rank", 1)] == [
+            5
+        ]
+        cursor = collection.find({}, {"_id": 1}).skip(2).limit(1)
+        assert list(cursor.clone()) == [{"_id": 2}]
+        assert list(cursor) == [{"_id": 2}]
+        assert list(cursor.rewind()) == [{"_id": 2}]
+
+        sorted_cursor = collection.find({}).sort("rank", -1).limit(2)
+        assert [doc["_id"] for doc in sorted_cursor.clone()] == [0, 1]
+        assert [doc["_id"] for doc in sorted_cursor] == [0, 1]
+
+        lazy = collection.find({})
+        assert lazy.alive is True
+        lazy.close()
+        assert lazy.alive is False
+
+        empty_cursor = client.app.empty.find({})
+        assert empty_cursor.alive is True
+        assert empty_cursor.has_next() is False
+        assert empty_cursor.hasNext() is False
+        assert empty_cursor.alive is False
+    finally:
+        client.close()
+
+
+def test_sqlite_bounded_and_count_fallbacks_after_compiler_error(tmp_path, monkeypatch):
+    client, collection = _sqlite_collection(tmp_path, name="fallbacks")
+    collection.insert_many([{"_id": index, "kind": "match"} for index in range(4)])
+    engine = collection.parent.engine
+    monkeypatch.setattr(
+        engine.compiler,
+        "compile",
+        lambda filter_doc: (_ for _ in ()).throw(ValueError("unsupported SQL")),
+    )
+
+    try:
+        assert list(collection.find({}).limit(1)) == [{"_id": 0, "kind": "match"}]
+        assert collection.count_documents({}) == 4
+    finally:
+        client.close()
+
+
+def test_sqlite_indexed_sorted_find_and_projected_filtered_skip(tmp_path):
+    client, collection = _sqlite_collection(tmp_path, name="indexed_sorted")
+    collection.insert_many(
+        [
+            {"_id": 1, "tags": ["python"], "name": "Ada"},
+            {"_id": 2, "tags": ["other"], "name": "Grace"},
+            {"_id": 3, "tags": ["python"], "name": "Lin"},
+        ]
+    )
+    collection.create_index("tags")
+
+    try:
+        assert list(collection.find({"tags": "python"}).sort("_id", -1)) == [
+            {"_id": 3, "tags": ["python"], "name": "Lin"},
+            {"_id": 1, "tags": ["python"], "name": "Ada"},
+        ]
+        assert list(
+            collection.find(
+                {"_id": {"$in": [1, 3]}},
+                {"name": 1, "_id": 0},
+            )
+            .skip(1)
+            .limit(1)
+        ) == [{"name": "Lin"}]
+    finally:
+        client.close()
+
+
+def test_async_sqlite_single_result_and_count_pushdown(tmp_path, monkeypatch):
+    sync_client, sync_collection = _sqlite_collection(
+        tmp_path,
+        name="async_bounded_reads",
+    )
+    sync_collection.insert_many(
+        [{"_id": index, "body": "x" * 10_000} for index in range(12)]
+    )
+    sync_client.close()
+    decodes, _statements = _track_sqlite_reads(
+        monkeypatch,
+        sync_collection.parent.engine,
+    )
+
+    async def scenario():
+        client = tm.AsyncTinyMongoClient(str(tmp_path), backend="sqlite")
+        collection = client.app.async_bounded_reads
+        try:
+            decodes.clear()
+            assert (await collection.find_one({}))["_id"] == 0
+            assert len(decodes) == 1
+
+            decodes.clear()
+            assert await collection.find({}).limit(1).to_list(None) == [
+                {"_id": 0, "body": "x" * 10_000}
+            ]
+            assert len(decodes) == 1
+
+            decodes.clear()
+            assert await collection.count_documents({}) == 12
+            assert decodes == []
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
 
 def _read_peak(collection, projection):
     gc.collect()
@@ -201,6 +550,17 @@ def _read_peak(collection, projection):
         documents = list(collection.find({}, projection))
         _, peak = tracemalloc.get_traced_memory()
         return documents, peak
+    finally:
+        tracemalloc.stop()
+
+
+def _operation_peak(operation):
+    gc.collect()
+    tracemalloc.start()
+    try:
+        result = operation()
+        _, peak = tracemalloc.get_traced_memory()
+        return result, peak
     finally:
         tracemalloc.stop()
 
@@ -217,11 +577,17 @@ def test_sqlite_id_projection_materially_reduces_public_sweep_peak_memory(tmp_pa
     )
 
     try:
+        first, first_peak = _operation_peak(lambda: collection.find_one({}))
+        counted, count_peak = _operation_peak(lambda: collection.count_documents({}))
         projected, projected_peak = _read_peak(collection, {"_id": 1})
         complete, complete_peak = _read_peak(collection, None)
+        assert first["_id"] == 0
+        assert counted == count
         assert projected == [{"_id": index} for index in range(count)]
         assert len(complete) == count
         assert complete_peak - projected_peak > 4_000_000
         assert projected_peak * 5 < complete_peak
+        assert first_peak * 5 < complete_peak
+        assert count_peak * 5 < complete_peak
     finally:
         client.close()

--- a/tests/test_warning_attribution.py
+++ b/tests/test_warning_attribution.py
@@ -37,6 +37,25 @@ def test_sync_cursor_sort_warning_points_to_application_call():
     _assert_origin(caught, expected_line)
 
 
+def test_sync_deferred_cursor_sort_warning_keeps_sort_origin():
+    cursor = TinyMongoCursor(
+        (),
+        deferred_loader=lambda sort_requested, skip, limit: (
+            [{"published": date(2026, 1, 1)}],
+            False,
+            not sort_requested,
+        ),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", TinyMongoUnsupportedWarning)
+        expected_line = inspect.currentframe().f_lineno + 1
+        cursor.sort("published")
+        list(cursor)
+
+    _assert_origin(caught, expected_line)
+
+
 def test_sync_aggregation_sort_warning_points_to_application_call():
     engine = AggregationEngine()
 
@@ -84,7 +103,14 @@ def test_async_create_indexes_warning_keeps_await_call_origin():
 
 def test_async_find_cursor_sort_warning_keeps_sort_origin_through_clone(monkeypatch):
     def find_with_unsupported_value(_collection, *args, **kwargs):
-        return TinyMongoCursor([{"published": date(2026, 1, 1)}])
+        return TinyMongoCursor(
+            (),
+            deferred_loader=lambda sort_requested, skip, limit: (
+                [{"published": date(2026, 1, 1)}],
+                False,
+                not sort_requested,
+            ),
+        )
 
     monkeypatch.setattr(TinyMongoCollection, "find", find_with_unsupported_value)
 

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -601,12 +601,12 @@ class AsyncTinyMongoCursor:
             if self._sort is not None:
                 with use_warning_origin(self._sort_warning_origin):
                     cursor.sort(self._sort[0], self._sort[1])
-            documents = list(cursor)
+                cursor._sort_warning_origin = self._sort_warning_origin
             if self._skip:
-                documents = documents[self._skip :]
+                cursor.skip(self._skip)
             if self._limit:
-                documents = documents[: self._limit]
-            return documents
+                cursor.limit(self._limit)
+            return list(cursor)
 
         collection_handle = self.collection
         if collection_handle is None:  # pragma: no cover - constructor invariant
@@ -628,12 +628,12 @@ class AsyncTinyMongoCursor:
             if self._sort is not None:
                 with use_warning_origin(self._sort_warning_origin):
                     cursor.sort(self._sort[0], self._sort[1])
-            documents = list(cursor)
+                cursor._sort_warning_origin = self._sort_warning_origin
             if self._skip:
-                documents = documents[self._skip :]
+                cursor.skip(self._skip)
             if self._limit:
-                documents = documents[: self._limit]
-            return documents
+                cursor.limit(self._limit)
+            return list(cursor)
 
         return state._invoke(operation)
 

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -2083,7 +2083,162 @@ class SQLiteTableBackend(TableBackend):
                 if matches_filter(doc, filter_doc)
             ]
 
+    @staticmethod
+    def _bounded_slice(documents, skip=0, limit=0):
+        """Apply Mongo-style cursor bounds to an already materialized result."""
+
+        end = None if not limit else skip + limit
+        return list(documents)[skip:end]
+
+    @staticmethod
+    def _sqlite_bounds(skip=0, limit=0):
+        """Return a SQLite LIMIT/OFFSET suffix and its bound parameters."""
+
+        if limit:
+            return " LIMIT ? OFFSET ?", [limit, skip]
+        if skip:
+            return " LIMIT -1 OFFSET ?", [skip]
+        return "", []
+
+    def _scan_bounded(self, collection, filter_doc, skip=0, limit=0):
+        """Decode rows until the requested number of Python matches is found."""
+
+        sql = "SELECT data FROM {0}".format(_quote_identifier(collection))
+        conn = self._connect()
+        try:
+            documents = []
+            matched = 0
+            for row in conn.execute(sql):
+                document = _json_loads(row[0])
+                if not matches_filter(document, filter_doc):
+                    continue
+                if matched < skip:
+                    matched += 1
+                    continue
+                documents.append(document)
+                if limit and len(documents) >= limit:
+                    break
+            return documents
+        finally:
+            conn.close()
+
+    def find_bounded(self, collection, filter_doc=None, skip=0, limit=0):
+        """Return an unsorted cursor window without decoding later rows.
+
+        This optional backend hook lets the public cursor stay lazy until its
+        final ``skip`` and ``limit`` are known.  Sorting is intentionally kept
+        out of this path because TinyMongo currently applies BSON ordering in
+        Python and therefore needs every candidate document.
+        """
+
+        self.create_collection(collection)
+        indexed = self._find_indexed_scalar_with_array_union(collection, filter_doc)
+        if indexed is not None:
+            return self._bounded_slice(indexed, skip, limit)
+        if requires_python_filter(filter_doc):
+            return self._scan_bounded(collection, filter_doc, skip, limit)
+        try:
+            if _filter_references_id(filter_doc):
+                return self._bounded_slice(
+                    self.find(collection, filter_doc),
+                    skip,
+                    limit,
+                )
+            where, params = self.compiler.compile(filter_doc)
+            bounds, bound_params = self._sqlite_bounds(skip, limit)
+            sql = "SELECT data FROM {0}{1}{2}".format(
+                _quote_identifier(collection),
+                where,
+                bounds,
+            )
+            conn = self._connect()
+            try:
+                rows = conn.execute(sql, params + bound_params).fetchall()
+            finally:
+                conn.close()
+            return [_json_loads(row[0]) for row in rows]
+        except Exception:
+            return self._scan_bounded(collection, filter_doc, skip, limit)
+
+    def count_documents(self, collection, filter_doc=None):
+        """Count matching SQLite rows without retaining document payloads."""
+
+        self.create_collection(collection)
+        if requires_python_filter(filter_doc):
+            return self._count_filtered_scan(collection, filter_doc)
+        try:
+            if _filter_references_id(filter_doc):
+                return len(self.find(collection, filter_doc))
+            where, params = self.compiler.compile(filter_doc)
+            sql = "SELECT COUNT(*) FROM {0}{1}".format(
+                _quote_identifier(collection),
+                where,
+            )
+            conn = self._connect()
+            try:
+                row = conn.execute(sql, params).fetchone()
+            finally:
+                conn.close()
+            # SQLite always returns one row for ``COUNT(*)``.
+            return int(row[0])
+        except Exception:
+            return self._count_filtered_scan(collection, filter_doc)
+
+    def _count_filtered_scan(self, collection, filter_doc):
+        """Count exact Python-filter matches while releasing each row promptly."""
+
+        sql = "SELECT data FROM {0}".format(_quote_identifier(collection))
+        conn = self._connect()
+        try:
+            return sum(
+                1
+                for row in conn.execute(sql)
+                if matches_filter(_json_loads(row[0]), filter_doc)
+            )
+        finally:
+            conn.close()
+
     def find_projected(self, collection, filter_doc, projection):
+        """Return projected rows through the established backend hook."""
+
+        return self._find_projected_bounded(
+            collection,
+            filter_doc,
+            projection,
+        )
+
+    def find_projected_bounded(
+        self,
+        collection,
+        filter_doc,
+        projection,
+        skip=0,
+        limit=0,
+    ):
+        """Return a projected cursor window without breaking legacy overrides."""
+
+        if type(self).find_projected is not SQLiteTableBackend.find_projected:
+            return self._bounded_slice(
+                self.find_projected(collection, filter_doc, projection),
+                skip,
+                limit,
+            )
+        return self._find_projected_bounded(
+            collection,
+            filter_doc,
+            projection,
+            skip=skip,
+            limit=limit,
+        )
+
+    def _find_projected_bounded(
+        self,
+        collection,
+        filter_doc,
+        projection,
+        skip=0,
+        limit=0,
+    ):
         """Scan SQLite rows while retaining only each projected post-image.
 
         ``TinyMongoCollection`` discovers this optional backend hook at runtime,
@@ -2099,13 +2254,15 @@ class SQLiteTableBackend(TableBackend):
             projection=projection,
         )
         if indexed is not None:
-            return indexed
+            return self._bounded_slice(indexed, skip, limit)
 
         if requires_python_filter(filter_doc):
             return self._scan_projected(
                 collection,
                 projection,
                 predicate=lambda document: matches_filter(document, filter_doc),
+                skip=skip,
+                limit=limit,
             )
 
         try:
@@ -2113,7 +2270,13 @@ class SQLiteTableBackend(TableBackend):
             if self._is_id_only_projection(projection) and not _filter_references_id(
                 filter_doc
             ):
-                return self._scan_projected_ids(collection, where, params)
+                return self._scan_projected_ids(
+                    collection,
+                    where,
+                    params,
+                    skip=skip,
+                    limit=limit,
+                )
 
             documents = self._scan_projected(
                 collection,
@@ -2125,6 +2288,8 @@ class SQLiteTableBackend(TableBackend):
                     if _filter_references_id(filter_doc)
                     else None
                 ),
+                skip=skip,
+                limit=limit,
             )
             direct_id_equality = (
                 isinstance(filter_doc, Mapping)
@@ -2138,6 +2303,8 @@ class SQLiteTableBackend(TableBackend):
                     collection,
                     projection,
                     predicate=lambda document: matches_filter(document, filter_doc),
+                    skip=skip,
+                    limit=limit,
                 )
             return documents
         except Exception:
@@ -2145,6 +2312,8 @@ class SQLiteTableBackend(TableBackend):
                 collection,
                 projection,
                 predicate=lambda document: matches_filter(document, filter_doc),
+                skip=skip,
+                limit=limit,
             )
 
     @staticmethod
@@ -2182,19 +2351,27 @@ class SQLiteTableBackend(TableBackend):
             )
         return {"_id": value}
 
-    def _scan_projected_ids(self, collection, where, params):
+    def _scan_projected_ids(
+        self,
+        collection,
+        where,
+        params,
+        skip=0,
+        limit=0,
+    ):
         """Return ``_id`` documents without transferring large JSON payloads."""
 
         table = _quote_identifier(collection)
         path = _sql_literal("$._id")
+        bounds, bound_params = self._sqlite_bounds(skip, limit)
         sql = (
             "SELECT _id, json_type(data, {path}), "
-            "json_extract(data, {path}) FROM {table}{where}"
-        ).format(path=path, table=table, where=where)
+            "json_extract(data, {path}) FROM {table}{where}{bounds}"
+        ).format(path=path, table=table, where=where, bounds=bounds)
         conn = self._connect()
         try:
             documents = []
-            cursor = conn.execute(sql, params)
+            cursor = conn.execute(sql, params + bound_params)
             for physical_id, kind, value in cursor:
                 document = self._project_sqlite_id(kind, value)
                 if document is None:
@@ -2220,22 +2397,35 @@ class SQLiteTableBackend(TableBackend):
         where="",
         params=None,
         predicate=None,
+        skip=0,
+        limit=0,
     ):
         """Decode, filter, and release one source row at a time."""
 
-        sql = "SELECT data FROM {0}{1}".format(
+        bounds = ""
+        bound_params = []
+        if predicate is None:
+            bounds, bound_params = self._sqlite_bounds(skip, limit)
+        sql = "SELECT data FROM {0}{1}{2}".format(
             _quote_identifier(collection),
             where,
+            bounds,
         )
         conn = self._connect()
         try:
             documents = []
-            cursor = conn.execute(sql, params or [])
+            matched = 0
+            cursor = conn.execute(sql, (params or []) + bound_params)
             for row in cursor:
                 document = _json_loads(row[0])
                 if predicate is not None and not predicate(document):
                     continue
+                if predicate is not None and matched < skip:
+                    matched += 1
+                    continue
                 documents.append(project_document(document, projection))
+                if predicate is not None and limit and len(documents) >= limit:
+                    break
             return documents
         finally:
             conn.close()

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -33,7 +33,7 @@ from .bson_types import (
 )
 from .aggregation import AggregationEngine, aggregation_capabilities
 from .sorting import bson_document_sort_value_key, sort_documents
-from .warning_context import emit_warning
+from .warning_context import capture_warning_origin, emit_warning, use_warning_origin
 from .storage_backends import (
     clear_memory_database,
     clear_memory_namespace,
@@ -1740,7 +1740,13 @@ class TinyMongoCollection(object):
         :return: Integer representing the number of documents in the collection.
         """
         _reject_session(kwargs)
-        return self.find(filter).count()
+        filter_doc = {} if filter is None else filter
+        validate_filter_operators(filter_doc)
+        if self.parent.engine is not None:
+            backend_count = getattr(self.parent.engine, "count_documents", None)
+            if callable(backend_count):
+                return backend_count(self.tablename, filter_doc)
+        return self.find(filter_doc).count()
 
     def estimated_document_count(self, *args, **kwargs):
         """Return the local collection size."""
@@ -2677,6 +2683,64 @@ class TinyMongoCollection(object):
         sort = kwargs.get("sort")
         if self.parent.engine is not None:
             projected_find = getattr(self.parent.engine, "find_projected", None)
+            projected_bounded_find = getattr(
+                self.parent.engine,
+                "find_projected_bounded",
+                None,
+            )
+            bounded_find = getattr(self.parent.engine, "find_bounded", None)
+            if callable(bounded_find):
+                deferred_filter = copy.deepcopy(_filter)
+
+                def load_cursor(sort_requested, cursor_skip, cursor_limit):
+                    projection_applied = (
+                        projection is not None
+                        and not sort_requested
+                        and callable(projected_find)
+                    )
+                    if projection_applied:
+                        if callable(projected_bounded_find):
+                            result = projected_bounded_find(
+                                self.tablename,
+                                deferred_filter,
+                                projection,
+                                skip=cursor_skip,
+                                limit=cursor_limit,
+                            )
+                            window_applied = True
+                        else:
+                            result = projected_find(
+                                self.tablename,
+                                deferred_filter,
+                                projection,
+                            )
+                            window_applied = False
+                    elif not sort_requested:
+                        result = bounded_find(
+                            self.tablename,
+                            deferred_filter,
+                            skip=cursor_skip,
+                            limit=cursor_limit,
+                        )
+                        window_applied = True
+                    else:
+                        result = self.parent.engine.find(
+                            self.tablename,
+                            deferred_filter,
+                        )
+                        window_applied = False
+                    return result, projection_applied, window_applied
+
+                return TinyMongoCursor(
+                    (),
+                    sort=sort,
+                    skip=skip,
+                    limit=limit,
+                    collection=self,
+                    projection=projection,
+                    query=deferred_filter,
+                    deferred_loader=load_cursor,
+                )
             projection_applied = (
                 projection is not None and not sort and callable(projected_find)
             )
@@ -2904,15 +2968,20 @@ class TinyMongoCursor(object):
         projection=None,
         query=None,
         source_projected=False,
+        deferred_loader=None,
     ):
         """Initialize the mongo iterable cursor with data"""
-        self._source_data = list(cursordat)
+        self._deferred_loader = deferred_loader
+        self._deferred_loaded = deferred_loader is None
+        self._source_data = list(cursordat) if self._deferred_loaded else []
         self.cursordat = list(self._source_data)
         self.collection = collection
         self.projection = projection
         self.query = copy.deepcopy(query)
         self._source_projected = source_projected
         self._sort_spec = None
+        self._normalized_sort_spec = None
+        self._sort_warning_origin = None
         self._skip = 0
         self._limit = 0
         self._closed = False
@@ -2927,6 +2996,7 @@ class TinyMongoCursor(object):
 
     def __getitem__(self, key):
         """Gets record by index or value by key"""
+        self._ensure_loaded()
         if isinstance(key, int):
             return self._project(self.cursordat[key])
         return self._project(self.currentrec)[key]
@@ -2936,14 +3006,56 @@ class TinyMongoCursor(object):
             return copy.deepcopy(document)
         return project_document(document, self.projection)
 
+    def _invalidate_deferred_source(self):
+        """Discard a loaded SQLite window after cursor options change."""
+
+        if self._deferred_loader is None:
+            return
+        self._deferred_loaded = False
+        self._source_data = []
+        self.cursordat = []
+        self.cursorpos = -1
+        self.currentrec = None
+
+    def _ensure_loaded(self):
+        """Execute a deferred backend query using the final cursor window."""
+
+        if self._deferred_loaded:
+            return
+        sort_requested = self._normalized_sort_spec is not None
+        source, source_projected, window_applied = self._deferred_loader(
+            sort_requested,
+            self._skip,
+            self._limit,
+        )
+        self._source_data = list(source)
+        self._source_projected = source_projected
+        if sort_requested:
+            with use_warning_origin(self._sort_warning_origin):
+                self._source_data = sort_documents(
+                    self._source_data,
+                    self._normalized_sort_spec,
+                    unsupported_value_callback=self._warn_unsupported_sort_value,
+                )
+        self._deferred_loaded = True
+        if window_applied:
+            self.cursordat = list(self._source_data)
+            self.cursorpos = -1
+            self.currentrec = self.cursordat[-1] if self.cursordat else None
+        else:
+            self._refresh_view()
+
     def paginate(self, skip, limit):
         """Paginate list of records"""
+        changed = skip is not None or limit is not None
         if skip is not None:
             self._validate_skip(skip)
             self._skip = skip
         if limit is not None:
             self._validate_limit(limit)
             self._limit = abs(limit)
+        if changed:
+            self._invalidate_deferred_source()
         self._refresh_view()
         return self
 
@@ -2960,6 +3072,11 @@ class TinyMongoCursor(object):
             raise TypeError("limit must be an integer")
 
     def _refresh_view(self):
+        if not self._deferred_loaded:
+            self.cursordat = []
+            self.cursorpos = -1
+            self.currentrec = None
+            return
         end = None if self._limit == 0 else self._skip + self._limit
         self.cursordat = self._source_data[self._skip : end]
         self.cursorpos = -1
@@ -3054,6 +3171,12 @@ class TinyMongoCursor(object):
             )
 
         self._sort_spec = (copy.deepcopy(key_or_list), direction)
+        self._normalized_sort_spec = copy.deepcopy(sort_specifier)
+
+        if self._deferred_loader is not None:
+            self._sort_warning_origin = capture_warning_origin()
+            self._invalidate_deferred_source()
+            return self
 
         if self._source_projected:
             # A chained sort can name a field omitted by the projection.  Load
@@ -3075,6 +3198,7 @@ class TinyMongoCursor(object):
     def limit(self, n):
         self._validate_limit(n)
         self._limit = abs(n)
+        self._invalidate_deferred_source()
         self._refresh_view()
         return self
 
@@ -3082,12 +3206,22 @@ class TinyMongoCursor(object):
         """Skip the first ``n`` records without changing the result source."""
         self._validate_skip(n)
         self._skip = n
+        self._invalidate_deferred_source()
         self._refresh_view()
         return self
 
     def clone(self):
         """Return an independently consumable copy of this cursor."""
-        if self.collection is None:
+        if self._deferred_loader is not None:
+            clone = type(self)(
+                (),
+                collection=self.collection,
+                projection=copy.deepcopy(self.projection),
+                query=copy.deepcopy(self.query),
+                source_projected=self._source_projected,
+                deferred_loader=self._deferred_loader,
+            )
+        elif self.collection is None:
             clone = type(self)(
                 copy.deepcopy(self._source_data),
                 projection=copy.deepcopy(self.projection),
@@ -3096,11 +3230,14 @@ class TinyMongoCursor(object):
         else:
             clone = self.collection.find(copy.deepcopy(self.query))
             clone.projection = copy.deepcopy(self.projection)
-            if self._sort_spec is not None:
-                clone.sort(
-                    copy.deepcopy(self._sort_spec[0]),
-                    self._sort_spec[1],
-                )
+        if self._sort_spec is not None and (
+            self._deferred_loader is not None or self.collection is not None
+        ):
+            clone.sort(
+                copy.deepcopy(self._sort_spec[0]),
+                self._sort_spec[1],
+            )
+            clone._sort_warning_origin = self._sort_warning_origin
         clone._skip = self._skip
         clone._limit = self._limit
         clone._refresh_view()
@@ -3115,6 +3252,8 @@ class TinyMongoCursor(object):
 
     @property
     def alive(self):
+        if not self._deferred_loaded:
+            return not self._closed
         return not self._closed and self.cursorpos + 1 < len(self.cursordat)
 
     def close(self):
@@ -3130,6 +3269,7 @@ class TinyMongoCursor(object):
                 raise ValueError("length must be non-negative")
         if self._closed:
             return []
+        self._ensure_loaded()
         start = self.cursorpos + 1
         end = len(self.cursordat) if length is None else start + length
         documents = [self._project(item) for item in self.cursordat[start:end]]
@@ -3141,7 +3281,7 @@ class TinyMongoCursor(object):
         Returns True if the cursor has a next position, False if not
         :return:
         """
-        return self.alive
+        return self.hasNext()
 
     def hasNext(self):
         """
@@ -3150,6 +3290,7 @@ class TinyMongoCursor(object):
         """
         if self._closed:
             return False
+        self._ensure_loaded()
         cursor_pos = self.cursorpos + 1
 
         try:
@@ -3175,6 +3316,7 @@ class TinyMongoCursor(object):
 
         :return: number of records
         """
+        self._ensure_loaded()
         return len(self.cursordat)
 
     def __iter__(self):


### PR DESCRIPTION
## Summary

This implements TM-015, the unprojected limit/count follow-up from the 559-transcript acceptance run.

- Defer SQLite cursor loading until first consumption so final `sort()`, `skip()`, and `limit()` options are known before storage is read.
- Push eligible unsorted windows into SQLite `LIMIT`/`OFFSET`, stop Python-filtered scans once their result window is full, and use payload-free `COUNT(*)` queries where possible.
- Route synchronous and asynchronous cursors through the same bounded-read path while preserving complete-candidate loading wherever correct sorting or indexed candidate merging requires it.
- Preserve optional third-party backend compatibility and application-level warning attribution.
- Add decode-count, memory, fallback, cursor lifecycle, sync/async parity, and legacy-hook regressions, along with README, changelog, and roadmap updates.

## Why

TM-011 bounded memory for projected SQLite sweeps, but unprojected `find_one({})`, `find({}).limit(1)`, and `count_documents({})` could still decode and materialize an entire collection. The cursor source was loaded before chained bounds were known, counts went through an eager cursor, and the async wrapper materialized results before applying its window.

That made simple single-document reads and counts consume collection-scale memory when documents were large.

## Developer impact

- Limited, unsorted SQLite reads now decode only the rows needed to fill the requested result window.
- SQL-compatible counts no longer fetch or decode document JSON.
- Python-only filters stream row by row without retaining the full collection.
- Sorted cursors still inspect every candidate so global ordering remains correct.
- Existing third-party backends require no changes; the optimized hooks remain optional.
- Synchronous and asynchronous APIs share the same behavior.

## Validation

- Focused cursor/backend/API tests: **102 passed, 36 deselected**
- Ruff: passed
- Black: passed
- mypy: passed
- `git diff --check`: passed

## Follow-up

Mike's private 559-transcript acceptance case remains listed in the roadmap for a post-merge rerun.
