### PR TITLE
Fix TM-022 through TM-025 compatibility gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,11 @@
   value. The value therefore changed from falsey `False` to a truthy structured
   mapping; use `client.supports("aggregation")` for a Boolean check or inspect
   the mapping when selecting individual features.
-- Query capability reporting now enumerates logical and field operators.
-  `bson_types` likewise changed from a Boolean to a structured mapping of
-  dependency-free `native` families and installed optional `pymongo` types;
-  inspect its `pymongo` tuple when detecting optional BSON support.
+- Query capability reporting now enumerates logical, field, and
+  accepted-but-ignored metadata operators. `bson_types` likewise changed from
+  a Boolean to a structured mapping of dependency-free `native` families and
+  installed optional `pymongo` types; inspect its `pymongo` tuple when detecting
+  optional BSON support.
 - Remote SQL unique indexes fail closed for Decimal128 values, as they already
   do for arrays, when their native JSON constraints cannot guarantee exact
   MongoDB numeric identity across concurrent writers.
@@ -55,6 +56,17 @@
 - **TM-021:** Applying `$addToSet` to a null or non-array field now raises
   PyMongo-compatible `WriteError` code `2` instead of a bare `ValueError`, while
   preserving update atomicity.
+- **TM-022:** Top-level `$comment` metadata is accepted and ignored while
+  matching, including filters that contain only a comment.
+- **TM-023:** Query-validation and regex `OperationFailure` exceptions now
+  expose MongoDB-compatible codes, as do conflicting or missing index
+  operations and attempts to drop the `_id` index.
+- **TM-024:** Legacy synchronous and asynchronous clients now honor
+  `tinymongo_folder` as a `foldername` alias, detect conflicting values, and
+  reject unknown constructor keywords instead of silently ignoring them.
+- **TM-025:** `$not` now rejects bare scalars, lists, and empty documents with
+  `OperationFailure` code `2`, while continuing to accept non-empty query
+  documents and compiled native or BSON regexes.
 - Aggregation field references no longer cross a raw array nested directly
   inside another array before reaching the requested field.
 - Aggregation projections preserve source BSON field order for retained fields

--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ You can select another backend with the `backend` argument:
     )
 ```
 
+`TinyMongoClient` and `AsyncTinyMongoClient` also accept
+`tinymongo_folder=` as an alias for `foldername`. If a non-default
+`foldername` is also supplied, the two values must agree. Unknown constructor
+keywords raise `TypeError` instead of being silently ignored. The other
+supported backend configuration keywords are `threads`, `storage_uri`,
+`duckdb_config`, and `dsn`.
+
 Parquet can also store collection files in object storage by passing
 `storage_uri` or setting `TINYMONGO_STORAGE_URI`. Object-storage Parquet is
 experimental and currently uses one Parquet file per collection, so
@@ -418,15 +425,19 @@ Query support includes equality (including scalar matches against array
 members), nested document paths, `$gt`, `$gte`, `$lt`, `$lte`, `$ne`,
 `$nin`, `$in`, `$all`, `$and`, `$or`, `$nor`, `$not`, `$regex`,
 case-insensitive `$options`, `$exists`, `$size`, `$elemMatch`, `$type`, and
-`$mod`. `$size` matches an exact array length, while `$elemMatch` requires one
-array member to satisfy the complete nested condition. `$type` accepts MongoDB
-type names, numeric codes, or a list of either; `$mod` follows MongoDB's
+`$mod`. Top-level `$comment` metadata is accepted and ignored while matching.
+`$size` matches an exact array length, while `$elemMatch` requires one array
+member to satisfy the complete nested condition. `$type` accepts MongoDB type
+names, numeric codes, or a list of either; `$mod` follows MongoDB's
 integer-truncation and array-member matching rules.
 
 Every CRUD method that accepts a filter validates it before reading or changing
 storage. Unsupported or misspelled `$`-prefixed query operators raise
 `TinyMongoNotSupportedError` instead of silently returning no matches, and
 malformed operands for recognized operators raise `OperationFailure`.
+`$not` accepts a non-empty query document or a compiled native/BSON regex;
+bare strings, numbers, lists, and empty documents raise `OperationFailure`
+with MongoDB error code `2`.
 
 MongoDB treats missing fields differently depending on the negated value.
 `{"field": {"$ne": None}}` and `$nin` lists containing `None` exclude
@@ -762,6 +773,7 @@ client = TinyMongoClient("./data", backend="sqlite")
 capabilities = client.capabilities()
 print(capabilities)
 print(capabilities["query_operators"]["field"])
+print(capabilities["query_operators"]["ignored"])
 print(capabilities["bson_types"]["pymongo"])
 print(client.supports("multiprocess_writes"))
 ```
@@ -770,11 +782,12 @@ The capability map covers persistence, remote and object storage, table-native
 storage, multiprocess writes, native indexes, projections, bulk writes,
 aggregation, query operators, BSON types, sessions, transactions, and change
 streams. `query_operators` separates top-level logical operators from field
-operators. `bson_types` separates dependency-free `native` families from the
-richer `pymongo` types available when the optional BSON extra is installed.
-These values are structured mappings; use `client.supports()` for a Boolean
-feature check or inspect their tuples when selecting a particular operator or
-type. Unknown capability names raise `ValueError` so configuration mistakes are
+operators and accepted-but-ignored metadata operators such as `$comment`.
+`bson_types` separates dependency-free `native` families from the richer
+`pymongo` types available when the optional BSON extra is installed. These
+values are structured mappings; use `client.supports()` for a Boolean feature
+check or inspect their tuples when selecting a particular operator or type.
+Unknown capability names raise `ValueError` so configuration mistakes are
 visible.
 
 For local persistent backends, `multiprocess_writes=True` promises safe writes,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,6 +129,20 @@ with the follow-up audit of his
 - [x] **TM-021:** Raise PyMongo-compatible `WriteError` code `2` when
   `$addToSet` targets a null or non-array field, without partially applying the
   update.
+
+#### Mike's [TM-022 through TM-025 follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5156142848)
+
+- [x] **TM-022:** Accept top-level `$comment` metadata and ignore it while
+  matching, including filters that contain only a comment.
+- [x] **TM-023:** Add MongoDB-compatible codes to query-validation, regex, and
+  index `OperationFailure` paths.
+- [x] **TM-024:** Honor `tinymongo_folder` as the legacy sync/async client's
+  `foldername` alias, detect conflicting values, and reject unknown constructor
+  keywords instead of silently ignoring them.
+- [x] **TM-025:** Reject bare scalar, list, and empty-document `$not` operands
+  with `OperationFailure` code `2` while retaining non-empty query-document and
+  compiled-regex forms.
+
 - [ ] **Remote SQL numeric uniqueness:** Persist canonical BSON numeric tokens
   for remote unique indexes so native constraints can enforce exact
   cross-process equality for every int/float representation; Decimal128

--- a/tests/contracts/test_query_operator_contract.py
+++ b/tests/contracts/test_query_operator_contract.py
@@ -1,9 +1,11 @@
 """Query-validation and write-error contracts shared by every target."""
 
+import re
 from collections import UserDict
 
 import pytest
 
+from tinymongo.bson_types import regex_type
 from tinymongo.errors import DuplicateKeyError as TinyMongoDuplicateKeyError
 from tinymongo.errors import OperationFailure as TinyMongoOperationFailure
 from tinymongo.errors import TinyMongoNotSupportedError
@@ -457,6 +459,91 @@ def test_recognized_query_operators_reject_malformed_operands(contract_target):
     for query in malformed_queries:
         with pytest.raises(_OPERATION_ERRORS):
             list(collection.find(query))
+
+
+def test_comment_is_accepted_and_ignored_while_matching(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "first", "value": 1},
+            {"_id": "second", "value": 2},
+        ]
+    )
+
+    assert _ids(collection.find({"$comment": "application context"})) == [
+        "first",
+        "second",
+    ]
+    assert _ids(collection.find({"value": 2, "$comment": "application context"})) == [
+        "second"
+    ]
+
+
+@pytest.mark.parametrize("operand", ["text", 7, ["text"], {}, {"literal": 1}])
+def test_not_rejects_non_regex_and_empty_operands_with_code_2(
+    contract_target,
+    operand,
+):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "value": "text"})
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(collection.find({"value": {"$not": operand}}))
+
+    assert caught.value.code == 2
+
+
+def test_not_accepts_operator_documents_and_compiled_regexes(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "text", "value": "text"},
+            {"_id": "other", "value": "other"},
+            {"_id": "missing"},
+        ]
+    )
+
+    expected = ["missing", "other"]
+    assert _ids(collection.find({"value": {"$not": {"$eq": "text"}}})) == expected
+    assert _ids(collection.find({"value": {"$not": {"$regex": "^text$"}}})) == expected
+    assert _ids(collection.find({"value": {"$not": re.compile("^text$")}})) == expected
+    bson_regex = regex_type()
+    if bson_regex is not None:
+        assert (
+            _ids(collection.find({"value": {"$not": bson_regex("^text$")}})) == expected
+        )
+
+
+def test_every_filtering_crud_entrypoint_rejects_invalid_not_operands(
+    contract_target,
+):
+    collection = contract_target.collection
+    original = {"_id": "original", "value": "text"}
+    collection.insert_one(original)
+    operations = (
+        "find",
+        "find_one",
+        "count_documents",
+        "distinct",
+        "update_one",
+        "update_many",
+        "replace_one",
+        "delete_one",
+        "delete_many",
+        "find_one_and_update",
+        "find_one_and_replace",
+        "find_one_and_delete",
+    )
+
+    for operation in operations:
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            _run_filter_operation(
+                collection,
+                operation,
+                {"value": {"$not": "text"}},
+            )
+        assert caught.value.code == 2
+        assert collection.find_one({"_id": "original"}) == original
 
 
 def test_find_rejects_top_level_and_field_operator_typos(contract_target):

--- a/tests/test_client_configuration.py
+++ b/tests/test_client_configuration.py
@@ -1,0 +1,84 @@
+import asyncio
+
+import pytest
+
+from tinymongo import AsyncMongoClient, AsyncTinyMongoClient, TinyMongoClient
+
+
+def test_tiny_client_honors_tinymongo_folder_alias(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    configured = tmp_path / "configured"
+    client = TinyMongoClient(tinymongo_folder=configured)
+    try:
+        client.app.items.insert_one({"_id": 1})
+    finally:
+        client.close()
+
+    assert client._foldername == configured
+    assert (configured / "app.json").is_file()
+    assert not (tmp_path / "tinydb").exists()
+
+
+def test_async_tiny_client_honors_tinymongo_folder_alias(tmp_path, monkeypatch):
+    async def scenario():
+        configured = tmp_path / "async-configured"
+        client = AsyncTinyMongoClient(tinymongo_folder=configured)
+        try:
+            await client.app.items.insert_one({"_id": 1})
+            assert await client.app.items.count_documents({}) == 1
+        finally:
+            await client.close()
+        return configured
+
+    monkeypatch.chdir(tmp_path)
+    configured = asyncio.run(scenario())
+
+    assert (configured / "app.json").is_file()
+    assert not (tmp_path / "tinydb").exists()
+
+
+def test_tiny_client_accepts_matching_folder_options(tmp_path):
+    configured = tmp_path / "configured"
+    client = TinyMongoClient(configured, tinymongo_folder=configured)
+    try:
+        assert client._foldername == configured
+    finally:
+        client.close()
+
+
+def test_async_mongo_client_accepts_default_configuration():
+    client = AsyncMongoClient()
+
+    asyncio.run(client.close())
+
+
+@pytest.mark.parametrize("client_class", [TinyMongoClient, AsyncTinyMongoClient])
+def test_tiny_clients_reject_unexpected_options(client_class):
+    with pytest.raises(
+        TypeError, match="unexpected keyword argument 'tinymongo_fodler'"
+    ):
+        client_class(tinymongo_fodler="misspelled")
+
+
+@pytest.mark.parametrize("client_class", [TinyMongoClient, AsyncTinyMongoClient])
+def test_tiny_clients_reject_conflicting_folder_options(tmp_path, client_class):
+    with pytest.raises(TypeError, match="different values for foldername"):
+        client_class(
+            tmp_path / "foldername",
+            tinymongo_folder=tmp_path / "alias",
+        )
+
+
+def test_tiny_client_keeps_supported_backend_options(tmp_path):
+    client = TinyMongoClient(
+        tmp_path / "configured",
+        threads=2,
+        storage_uri="s3://ignored-for-tinydb",
+        duckdb_config={"memory_limit": "1GB"},
+        dsn="postgresql://ignored-for-tinydb",
+    )
+    try:
+        assert client._threads == 2
+        assert client._duckdb_config == {"memory_limit": "1GB"}
+    finally:
+        client.close()

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -695,7 +695,7 @@ def test_query_operator_branches_without_mongo(tmp_path):
     assert c.find({"count": {"$gte": 5, "$lte": 10}}).count() == 2
     assert c.find({"name": {"$ne": "alpha"}}).count() == 2
     assert c.find({"name": {"$regex": "^a"}}).count() == 1
-    assert c.find({"name": {"$not": "alpha"}}).count() == 2
+    assert c.find({"name": {"$not": {"$eq": "alpha"}}}).count() == 2
     assert c.find({"count": {"$not": {"$gt": 5}}}).count() == 2
     assert c.find({"tags": {"$in": ["c", "missing"]}}).count() == 1
     assert (

--- a/tests/test_durable_indexes.py
+++ b/tests/test_durable_indexes.py
@@ -131,10 +131,12 @@ def test_index_metadata_is_collection_scoped_and_drop_persists(
         ]
     )
     assert audit.drop_index("created_at") is None
-    with pytest.raises(OperationFailure, match="not found"):
+    with pytest.raises(OperationFailure, match="not found") as missing:
         audit.drop_index("created_at")
-    with pytest.raises(OperationFailure, match="cannot be dropped"):
+    assert missing.value.code == 27
+    with pytest.raises(OperationFailure, match="cannot be dropped") as builtin:
         audit.drop_index("_id_")
+    assert builtin.value.code == 72
 
 
 def test_catalog_identity_cannot_collide_across_collection_and_index_names(
@@ -368,10 +370,14 @@ def test_index_creation_is_idempotent_and_rejects_conflicts(
     with pytest.raises(OperationFailure, match="different name") as different_name:
         users.create_index("email", name="other_name", unique=True)
     assert different_name.value.code == 85
-    with pytest.raises(OperationFailure, match="different options"):
+    with pytest.raises(OperationFailure, match="different options") as different_key:
         users.create_index("username", name="login_email", unique=True)
-    with pytest.raises(OperationFailure, match="different options"):
+    assert different_key.value.code == 86
+    with pytest.raises(
+        OperationFailure, match="different options"
+    ) as different_options:
         users.create_index("email", name="login_email", unique=False)
+    assert different_options.value.code == 85
 
     assert set(_indexes_by_name(users)) == {"_id_", "login_email"}
 

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -157,6 +157,7 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
     }
     assert capabilities["query_operators"] == {
         "logical": ("$and", "$or", "$nor"),
+        "ignored": ("$comment",),
         "field": (
             "$all",
             "$elemMatch",

--- a/tests/test_query_operator_coverage_edges.py
+++ b/tests/test_query_operator_coverage_edges.py
@@ -88,6 +88,23 @@ def test_type_names_cover_unregistered_and_decimal_values():
     assert backends.matches_filter({"value": value}, {"value": {"$type": 19}})
 
 
+@pytest.mark.parametrize(
+    ("query", "message"),
+    [
+        ({1: "value"}, "field names must be strings"),
+        ({"$and": []}, "requires a non-empty array"),
+        ({"value": {"$eq": 1, "literal": 1}}, "cannot mix operators"),
+        ({"value": {"$in": 1}}, "requires an array"),
+        ({"value": {"$options": "i"}}, "requires.*regex"),
+    ],
+)
+def test_malformed_query_shapes_use_mongodb_parse_error_code(query, message):
+    with pytest.raises(OperationFailure, match=message) as caught:
+        backends.validate_filter_operators(query)
+
+    assert caught.value.code == 2
+
+
 def test_empty_elem_match_matches_only_container_array_members():
     query = {"value": {"$elemMatch": {}}}
     backends.validate_filter_operators(query)
@@ -227,5 +244,7 @@ def test_get_nested_returns_custom_default_for_missing_paths():
 def test_regex_compatibility_validator_rejects_operator_documents_in_arrays(
     operator,
 ):
-    with pytest.raises(OperationFailure, match="accepts regex values"):
+    with pytest.raises(OperationFailure, match="accepts regex values") as caught:
         backends.validate_regex_filter({"value": {operator: [{"$regex": "^value"}]}})
+
+    assert caught.value.code == 2

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -319,8 +319,8 @@ def test_matches_filter_operator_edges():
     assert not matches_filter(doc, {"name": {"$nin": ["Ada"]}})
     assert matches_filter(doc, {"name": {"$regex": "^A"}})
     assert not matches_filter(doc, {"name": {"$regex": "^Z"}})
-    assert matches_filter(doc, {"name": {"$not": "Grace"}})
-    assert not matches_filter(doc, {"name": {"$not": "Ada"}})
+    assert matches_filter(doc, {"name": {"$not": {"$eq": "Grace"}}})
+    assert not matches_filter(doc, {"name": {"$not": {"$eq": "Ada"}}})
     assert matches_filter(doc, {"nested.x": 2})
     assert not matches_filter(doc, {"tags": "missing"})
     assert not matches_filter(doc, {"missing": {"$in": ["Ada"]}})
@@ -464,8 +464,9 @@ def test_table_backend_abstract_methods(tmp_path):
     )
     assert backend.drop_index("anything", "email_nonunique") is None
     assert backend.drop_index("anything", "email") is None
-    with pytest.raises(OperationFailure, match="Index not found"):
+    with pytest.raises(OperationFailure, match="Index not found") as missing:
         backend.drop_index("anything", "missing")
+    assert missing.value.code == 27
     assert backend.drop_index("anything", "field") is None
     assert backend.list_indexes("anything") == [{"name": "_id_", "key": [("_id", 1)]}]
     with pytest.raises(NotImplementedError):
@@ -1284,8 +1285,9 @@ def test_postgres_indexes_are_native_durable_unique_and_droppable(monkeypatch):
     backend.drop_index("users", "email_1")
     assert backend.list_indexes("users") == [{"name": "_id_", "key": [("_id", 1)]}]
     assert any(sql.startswith("DROP INDEX IF EXISTS") for sql in store.index_ddl)
-    with pytest.raises(OperationFailure, match="Index not found"):
+    with pytest.raises(OperationFailure, match="Index not found") as missing:
         backend.drop_index("users", "email")
+    assert missing.value.code == 27
 
 
 def test_remote_unique_creation_preflights_and_drop_cleans_catalog(monkeypatch):
@@ -1305,8 +1307,9 @@ def test_remote_unique_creation_preflights_and_drop_cleans_catalog(monkeypatch):
     assert not store.index_ddl
 
     backend.create_index("users", parse_index_spec("email"))
-    with pytest.raises(OperationFailure, match="different options"):
+    with pytest.raises(OperationFailure, match="different options") as conflict:
         backend.create_index("users", parse_index_spec("email", unique=True))
+    assert conflict.value.code == 85
     assert backend.drop_collection("users") is True
     assert not store.indexes
 

--- a/tests/test_uuid_regex.py
+++ b/tests/test_uuid_regex.py
@@ -64,17 +64,20 @@ def test_regex_options_validation_accepts_u_and_rejects_invalid_combinations():
         {"value": {"$regex": bson.Regex("x", 0), "$options": "i"}}
     )
 
-    for options in ("l", "z", 1):
-        with pytest.raises(OperationFailure, match="supports only"):
+    for options, code in (("l", 51108), ("z", 51108), (1, 2)):
+        with pytest.raises(OperationFailure, match="supports only") as caught:
             validate_filter_operators({"value": {"$regex": "x", "$options": options}})
+        assert caught.value.code == code
 
-    with pytest.raises(OperationFailure, match="embedded"):
+    with pytest.raises(OperationFailure, match="embedded") as caught:
         validate_filter_operators(
             {"value": {"$regex": bson.Regex("x", "i"), "$options": "m"}}
         )
-    with pytest.raises(OperationFailure, match="supports only"):
+    assert caught.value.code == 2
+    with pytest.raises(OperationFailure, match="supports only") as caught:
         matches_filter({"value": "x"}, {"value": {"$regex": "x", "$options": "z"}})
-    with pytest.raises(OperationFailure, match="embedded"):
+    assert caught.value.code == 51108
+    with pytest.raises(OperationFailure, match="embedded") as caught:
         matches_filter(
             {"value": "x"},
             {
@@ -84,6 +87,7 @@ def test_regex_options_validation_accepts_u_and_rejects_invalid_combinations():
                 }
             },
         )
+    assert caught.value.code == 2
 
 
 def test_regex_locale_flag_can_still_match_an_exact_stored_regex():
@@ -94,31 +98,39 @@ def test_regex_locale_flag_can_still_match_an_exact_stored_regex():
 
 
 @pytest.mark.parametrize(
-    "query",
+    ("query", "code"),
     [
-        {"value": {"$regex": 42}},
-        {"value": {"$regex": b"bytes"}},
-        {"value": {"$regex": "["}},
-        {"value": {"$regex": "nul\x00pattern"}},
-        {"value": bson.Regex("[")},
-        {"value": bson.Regex("nul\x00pattern")},
-        {"value": bson.Regex(b"\xff")},
-        {"value": {"$in": [bson.Regex("[")]}},
-        {"value": {"$nin": [bson.Regex("[")]}},
-        {"value": {"$all": [bson.Regex("[")]}},
-        {"value": {"$not": bson.Regex("[")}},
-        {"value": {"$not": {"$regex": None}}},
-        {"value": {"$in": [{"$regex": "valid"}]}},
-        {"value": {"$nin": [{"$regex": "valid"}]}},
-        {"value": {"$all": [{"$regex": "valid"}]}},
+        ({"value": {"$regex": 42}}, 2),
+        ({"value": {"$regex": b"bytes"}}, 2),
+        ({"value": {"$regex": "["}}, 51091),
+        ({"value": {"$regex": "nul\x00pattern"}}, 2),
+        ({"value": bson.Regex("[")}, 51091),
+        ({"value": bson.Regex("nul\x00pattern")}, 2),
+        ({"value": bson.Regex(b"\xff")}, 2),
+        ({"value": {"$in": [bson.Regex("[")]}}, 51091),
+        ({"value": {"$nin": [bson.Regex("[")]}}, 51091),
+        ({"value": {"$all": [bson.Regex("[")]}}, 51091),
+        ({"value": {"$not": bson.Regex("[")}}, 51091),
+        ({"value": {"$not": {"$regex": None}}}, 2),
+        ({"value": {"$in": [{"$regex": "valid"}]}}, 2),
+        ({"value": {"$nin": [{"$regex": "valid"}]}}, 2),
+        ({"value": {"$all": [{"$regex": "valid"}]}}, 2),
     ],
 )
-def test_malformed_regex_queries_fail_before_persistent_storage_reads(tmp_path, query):
+def test_malformed_regex_queries_fail_before_persistent_storage_reads(
+    tmp_path,
+    query,
+    code,
+):
     client = tinymongo.TinyMongoClient(str(tmp_path / "invalid"), backend="sqlite")
     collection = client.app.items
 
-    with pytest.raises(OperationFailure, match="(?i)regex|regular.expression"):
+    with pytest.raises(
+        OperationFailure,
+        match="(?i)regex|regular.expression",
+    ) as caught:
         collection.find(query)
+    assert caught.value.code == code
 
     assert client.app.list_collection_names() == []
     client.close()
@@ -147,8 +159,9 @@ def test_regex_only_preflight_ignores_non_query_documents():
 
 
 def test_full_filter_validation_rejects_operator_documents_inside_regex_arrays():
-    with pytest.raises(OperationFailure, match="accepts regex values"):
+    with pytest.raises(OperationFailure, match="accepts regex values") as caught:
         validate_filter_operators({"value": {"$in": [{"$regex": "valid"}]}})
+    assert caught.value.code == 2
 
 
 def test_remote_unique_indexes_fail_closed_for_extended_binary_identities():

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -21,6 +21,7 @@ from .tinymongo import (
     TinyMongoClient,
     TinyMongoCollection,
     TinyMongoCursor,
+    _resolve_tiny_client_folder,
 )
 from .warning_context import (
     WarningOrigin,
@@ -194,6 +195,27 @@ class AsyncTinyMongoClient(_AsyncClientBase):
     """Async counterpart to :class:`~tinymongo.TinyMongoClient`."""
 
     _sync_client_class = TinyMongoClient
+
+    def __init__(
+        self,
+        foldername: Any = "tinydb",
+        backend: Any = "tinydb",
+        *,
+        tinymongo_folder: Any = None,
+        threads: Any = None,
+        storage_uri: Any = None,
+        duckdb_config: Any = None,
+        dsn: Any = None,
+    ):
+        foldername = _resolve_tiny_client_folder(foldername, tinymongo_folder)
+        super().__init__(
+            foldername,
+            backend,
+            threads=threads,
+            storage_uri=storage_uri,
+            duckdb_config=duckdb_config,
+            dsn=dsn,
+        )
 
 
 class AsyncMongoClient(_AsyncClientBase):

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -60,6 +60,7 @@ _SQLITE_UNIQUE_TOKEN_VERSION = 3
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
 _PHYSICAL_ID_PREFIX = "__tinymongo_id_v2__:"
 _LOGICAL_FILTER_OPERATOR_NAMES = ("$and", "$or", "$nor")
+_IGNORED_FILTER_OPERATOR_NAMES = ("$comment",)
 _FIELD_FILTER_OPERATOR_NAMES = (
     "$all",
     "$elemMatch",
@@ -80,6 +81,7 @@ _FIELD_FILTER_OPERATOR_NAMES = (
     "$type",
 )
 _LOGICAL_FILTER_OPERATORS = frozenset(_LOGICAL_FILTER_OPERATOR_NAMES)
+_IGNORED_FILTER_OPERATORS = frozenset(_IGNORED_FILTER_OPERATOR_NAMES)
 _FIELD_FILTER_OPERATORS = frozenset(_FIELD_FILTER_OPERATOR_NAMES)
 _BSON_QUERY_TYPE_CODES = {
     -1: "minKey",
@@ -665,14 +667,27 @@ def _comparison_matches(actual, operand, comparison, exact=False):
     return False
 
 
+def _validate_regex_options(options):
+    if not isinstance(options, str):
+        raise OperationFailure(
+            "$options supports only i, m, s, u, and x",
+            code=2,
+        )
+    if any(option not in "imsxu" for option in options):
+        raise OperationFailure(
+            "$options supports only i, m, s, u, and x",
+            code=51108,
+        )
+
+
 def _regex_matches(actual, pattern, options="", exact=False):
-    if not isinstance(options, str) or any(option not in "imsxu" for option in options):
-        raise OperationFailure("$options supports only i, m, s, u, and x")
+    _validate_regex_options(options)
     flags = 0
     if is_bson_regex(pattern):
         if options and regex_flags_text(pattern.flags):
             raise OperationFailure(
-                "$options cannot be combined with flags embedded in $regex"
+                "$options cannot be combined with flags embedded in $regex",
+                code=2,
             )
         pattern, flags = regex_compile_components(pattern)
     for option, flag in (
@@ -919,6 +934,24 @@ def _field_path_matches(candidates, expected, exact=False, indexed_endpoints=Non
     return True
 
 
+def _normalize_not_operand(operand):
+    """Return a matcher expression for one MongoDB-valid ``$not`` operand."""
+
+    if is_bson_regex(operand):
+        return {"$regex": operand}
+    if not isinstance(operand, Mapping):
+        raise OperationFailure(
+            "$not argument must be a regex or an object",
+            code=2,
+        )
+    if not operand:
+        raise OperationFailure(
+            "$not argument must be a non-empty object",
+            code=2,
+        )
+    return operand
+
+
 def _field_matches(actual, expected, exact=False):
     exists = actual is not _MISSING
 
@@ -1012,11 +1045,7 @@ def _field_matches(actual, expected, exact=False):
             if not exists or not _regex_matches(actual, operand, options, exact=exact):
                 return False
         elif operator == "$not":
-            nested = (
-                operand
-                if isinstance(operand, Mapping)
-                else {("$regex" if is_bson_regex(operand) else "$eq"): operand}
-            )
+            nested = _normalize_not_operand(operand)
             if _field_matches(actual, nested, exact=exact):
                 return False
         elif operator == "$eq":
@@ -1056,6 +1085,8 @@ def matches_filter(doc, filter_doc, _array_document=False):
         elif key == "$nor":
             if any(matches_filter(doc, spec, _array_document) for spec in expected):
                 return False
+        elif key in _IGNORED_FILTER_OPERATORS:
+            continue
         else:
             parts = key.split(".")
             resolved = (
@@ -1084,10 +1115,14 @@ def _validate_regex_literal(value):
         pattern, options = regex_components(value)
     except (TypeError, UnicodeDecodeError) as error:
         raise OperationFailure(
-            "Regular-expression patterns must be valid UTF-8 BSON text"
+            "Regular-expression patterns must be valid UTF-8 BSON text",
+            code=2,
         ) from error
     if "\x00" in pattern:
-        raise OperationFailure("Regular-expression patterns cannot contain NUL")
+        raise OperationFailure(
+            "Regular-expression patterns cannot contain NUL",
+            code=2,
+        )
     if is_native_regex(value) or "l" in options:
         return
     compile_pattern, flags = regex_compile_components(value)
@@ -1095,7 +1130,8 @@ def _validate_regex_literal(value):
         re.compile(compile_pattern, flags)
     except (TypeError, ValueError, re.error) as error:
         raise OperationFailure(
-            "Regular expression is not valid for TinyMongo's Python regex engine"
+            "Regular expression is not valid for TinyMongo's Python regex engine",
+            code=51091,
         ) from error
 
 
@@ -1111,8 +1147,7 @@ def _validate_regex_literals(value):
 
 
 def _regex_query_flags(options):
-    if not isinstance(options, str) or any(option not in "imsxu" for option in options):
-        raise OperationFailure("$options supports only i, m, s, u, and x")
+    _validate_regex_options(options)
     flags = 0
     for option, flag in (
         ("i", re.IGNORECASE),
@@ -1132,18 +1167,26 @@ def _validate_regex_query_operand(operand, options=""):
         _validate_regex_literal(operand)
         if options and regex_flags_text(operand.flags):
             raise OperationFailure(
-                "$options cannot be combined with flags embedded in $regex"
+                "$options cannot be combined with flags embedded in $regex",
+                code=2,
             )
         return
     if not isinstance(operand, str):
-        raise OperationFailure("$regex requires a string or compiled regex value")
+        raise OperationFailure(
+            "$regex requires a string or compiled regex value",
+            code=2,
+        )
     if "\x00" in operand:
-        raise OperationFailure("Regular-expression patterns cannot contain NUL")
+        raise OperationFailure(
+            "Regular-expression patterns cannot contain NUL",
+            code=2,
+        )
     try:
         re.compile(operand, flags)
     except (TypeError, ValueError, re.error) as error:
         raise OperationFailure(
-            "$regex pattern is not valid for TinyMongo's Python regex engine"
+            "$regex pattern is not valid for TinyMongo's Python regex engine",
+            code=51091,
         ) from error
 
 
@@ -1157,13 +1200,17 @@ def _validate_field_filter_operators(expression):
                     "Query operator {0} is not supported by TinyMongo".format(operator)
                 )
             raise OperationFailure(
-                "Field query documents cannot mix operators and literal fields"
+                "Field query documents cannot mix operators and literal fields",
+                code=2,
             )
         _validate_regex_literals(operand)
         if operator in ("$all", "$in", "$nin") and not isinstance(
             operand, (list, tuple)
         ):
-            raise OperationFailure("{0} requires an array".format(operator))
+            raise OperationFailure(
+                "{0} requires an array".format(operator),
+                code=2,
+            )
         if operator in ("$in", "$nin"):
             nested_operator_documents = [
                 item
@@ -1209,15 +1256,15 @@ def _validate_field_filter_operators(expression):
         if operator == "$regex":
             _validate_regex_query_operand(operand, expression.get("$options", ""))
         if operator == "$options" and "$regex" not in expression:
-            raise OperationFailure("$options requires $regex in the same query")
+            raise OperationFailure(
+                "$options requires $regex in the same query",
+                code=2,
+            )
         if operator == "$options":
             _validate_regex_query_operand(expression["$regex"], operand)
-        if (
-            operator == "$not"
-            and isinstance(operand, Mapping)
-            and any(str(key).startswith("$") for key in operand)
-        ):
-            _validate_field_filter_operators(operand)
+        if operator == "$not":
+            nested = _normalize_not_operand(operand)
+            _validate_field_filter_operators(nested)
         if operator == "$elemMatch":
             _validate_elem_match_operand(operand)
         if operator == "$mod":
@@ -1247,14 +1294,17 @@ def validate_filter_operators(filter_doc):
 
     for key, expected in filter_doc.items():
         if not isinstance(key, str):
-            raise OperationFailure("Filter field names must be strings")
+            raise OperationFailure("Filter field names must be strings", code=2)
         if key in _LOGICAL_FILTER_OPERATORS:
             if not isinstance(expected, (list, tuple)) or not expected:
                 raise OperationFailure(
-                    "{0} requires a non-empty array of query documents".format(key)
+                    "{0} requires a non-empty array of query documents".format(key),
+                    code=2,
                 )
             for specification in expected:
                 validate_filter_operators(specification)
+            continue
+        if key in _IGNORED_FILTER_OPERATORS:
             continue
         if key.startswith("$"):
             raise TinyMongoNotSupportedError(
@@ -1274,6 +1324,7 @@ def query_operator_capabilities():
 
     return {
         "logical": _LOGICAL_FILTER_OPERATOR_NAMES,
+        "ignored": _IGNORED_FILTER_OPERATOR_NAMES,
         "field": _FIELD_FILTER_OPERATOR_NAMES,
     }
 
@@ -1293,7 +1344,8 @@ def _validate_regex_field_expression(expression):
             raise OperationFailure(
                 "{0} accepts regex values, not $regex operator documents".format(
                     operator
-                )
+                ),
+                code=2,
             )
         _validate_regex_literals(operand)
     not_operand = expression.get("$not")
@@ -1717,8 +1769,13 @@ class TableBackend(object):
             None,
         )
         if by_name is not None and by_name != spec:
+            same_key = (by_name.field, by_name.direction) == (
+                spec.field,
+                spec.direction,
+            )
             raise OperationFailure(
-                "An index with the same name or key has different options"
+                "An index with the same name or key has different options",
+                code=85 if same_key else 86,
             )
         if by_name is not None:
             # Older releases allowed equivalent specs under different names.
@@ -1757,7 +1814,10 @@ class TableBackend(object):
             if name_or_field in (name, spec.field):
                 indexes.pop(name, None)
                 return None
-        raise OperationFailure("Index not found: {0}".format(name_or_field))
+        raise OperationFailure(
+            "Index not found: {0}".format(name_or_field),
+            code=27,
+        )
 
     def list_indexes(self, collection):
         indexes = [{"name": "_id_", "key": [("_id", 1)]}]
@@ -2612,7 +2672,10 @@ class SQLiteTableBackend(TableBackend):
             None,
         )
         if spec is None:
-            raise OperationFailure("Index not found: {0}".format(name_or_field))
+            raise OperationFailure(
+                "Index not found: {0}".format(name_or_field),
+                code=27,
+            )
         physical_name = self._physical_index_name(collection, spec)
         conn = self._connect()
         try:
@@ -2935,7 +2998,10 @@ class DuckDBTableBackend(TableBackend):
             None,
         )
         if spec is None:
-            raise OperationFailure("Index not found: {0}".format(name_or_field))
+            raise OperationFailure(
+                "Index not found: {0}".format(name_or_field),
+                code=27,
+            )
         conn = self._connect()
         try:
             self._ensure_index_catalog(conn)
@@ -3237,7 +3303,10 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
                 None,
             )
             if spec is None:
-                raise OperationFailure("Index not found: {0}".format(name_or_field))
+                raise OperationFailure(
+                    "Index not found: {0}".format(name_or_field),
+                    code=27,
+                )
             rows = [
                 row
                 for row in self._read_all_rows(INDEX_CATALOG_TABLE)
@@ -3753,7 +3822,10 @@ class RemoteSQLTableBackend(TableBackend):
             None,
         )
         if spec is None:
-            raise OperationFailure("Index not found: {0}".format(name_or_field))
+            raise OperationFailure(
+                "Index not found: {0}".format(name_or_field),
+                code=27,
+            )
 
         conn = self._connect()
         try:

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -786,6 +786,23 @@ def _folder_from_mongo_client_args(host, port, kwargs):
     return host
 
 
+def _resolve_tiny_client_folder(foldername, tinymongo_folder):
+    """Resolve the legacy client's documented PyMongo-style folder alias."""
+
+    if tinymongo_folder is None:
+        return foldername
+
+    configured_folder = os.fspath(foldername)
+    aliased_folder = os.fspath(tinymongo_folder)
+
+    if configured_folder != "tinydb" and configured_folder != aliased_folder:
+        raise TypeError(
+            "TinyMongoClient received different values for foldername and "
+            "tinymongo_folder"
+        )
+    return tinymongo_folder
+
+
 def _memory_namespace(foldername):
     """Return an isolated or explicitly shared process-memory namespace."""
     address = str(foldername or "").strip()
@@ -821,8 +838,19 @@ def _engine_write_locked(method):
 class TinyMongoClient(object):
     """Represents the Tiny `db` client"""
 
-    def __init__(self, foldername="tinydb", backend="tinydb", **kwargs):
+    def __init__(
+        self,
+        foldername="tinydb",
+        backend="tinydb",
+        *,
+        tinymongo_folder=None,
+        threads=None,
+        storage_uri=None,
+        duckdb_config=None,
+        dsn=None,
+    ):
         """Initialize container folder and choose a storage backend."""
+        foldername = _resolve_tiny_client_folder(foldername, tinymongo_folder)
         self._foldername = foldername
         self._backend = backend or "tinydb"
         # Reject unknown names at construction instead of waiting for the first
@@ -834,16 +862,14 @@ class TinyMongoClient(object):
         if backend_name == "memory":
             self._memory_namespace, self._shared_memory = _memory_namespace(foldername)
             self._foldername = self._memory_namespace
-        self._threads = kwargs.get("threads")
-        storage_uri = kwargs.get("storage_uri")
+        self._threads = threads
         if backend_name in ("parquet", "parquetv2"):
             if storage_uri is None:
                 storage_uri = os.environ.get("TINYMONGO_STORAGE_URI")
             self._storage_uri = storage_uri or None
         else:
             self._storage_uri = None
-        self._duckdb_config = kwargs.get("duckdb_config")
-        dsn = kwargs.get("dsn")
+        self._duckdb_config = duckdb_config
         if is_remote_sql_backend(backend_name):
             if dsn is None:
                 dsn = self._dsn_from_env(backend_name)
@@ -1453,8 +1479,13 @@ class TinyMongoCollection(object):
     def _validate_index_compatibility(self, spec):
         by_name = self._index_specs.get(spec.name)
         if by_name is not None and by_name != spec:
+            same_key = (by_name.field, by_name.direction) == (
+                spec.field,
+                spec.direction,
+            )
             raise OperationFailure(
-                "An index with the same name or key has different options"
+                "An index with the same name or key has different options",
+                code=85 if same_key else 86,
             )
         if by_name is not None:
             # Preserve idempotent retries for legacy catalogs which may still
@@ -1592,7 +1623,7 @@ class TinyMongoCollection(object):
     def drop_index(self, key):
         """Drop a durable index by its name or legacy field name."""
         if key in ("_id", "_id_"):
-            raise OperationFailure("The _id index cannot be dropped")
+            raise OperationFailure("The _id index cannot be dropped", code=72)
         if self.parent.engine is not None:
             return self.parent.engine.drop_index(self.tablename, key)
 
@@ -1603,7 +1634,10 @@ class TinyMongoCollection(object):
             self._refresh_table()
             spec = self._find_index_spec(key)
             if spec is None:
-                raise OperationFailure("Index not found: {0}".format(key))
+                raise OperationFailure(
+                    "Index not found: {0}".format(key),
+                    code=27,
+                )
             catalog = self.parent.tinydb.table(INDEX_CATALOG_TABLE)
             self._set_storage_merge_writes(False)
             try:


### PR DESCRIPTION
## Summary

This PR implements Mike's four latest compatibility findings from #136 in one branch:

- **TM-022:** accept top-level `$comment` metadata and ignore it during matching, including comment-only filters.
- **TM-023:** attach MongoDB-compatible codes to query-validation, regex, and index `OperationFailure` paths.
- **TM-024:** let `TinyMongoClient` and `AsyncTinyMongoClient` accept `tinymongo_folder` as a `foldername` alias, while rejecting unknown or misspelled constructor keywords.
- **TM-025:** reject invalid `$not` operands instead of silently treating them like `$eq`.

The README, changelog, capability contract, and roadmap are updated with the new behavior.

## Why

The validator added for TM-018 correctly rejected unknown operator names, but `$not` still accepted malformed operands. A bare value such as `{"v": {"$not": "text"}}` was converted into an equality expression and returned a plausible result even though MongoDB rejects the query.

Separately, `$comment` was rejected even though MongoDB treats it as non-matching metadata; several `OperationFailure` paths raised the right exception without the server's error code; and the legacy client's catch-all `**kwargs` silently swallowed `tinymongo_folder` or misspelled options and could open the default `./tinydb` location.

## Implementation

### Query behavior

- Adds `$comment` to an explicit accepted-but-ignored operator family.
- Skips comments in both validation and the shared matcher.
- Deliberately keeps comment filters on the shared Python filtering path so SQL and TinyDB compilers do not need unsafe empty-predicate special cases.
- Adds one shared `$not` normalizer used by validation and matching.
- Accepts non-empty operator documents, native compiled regexes, and BSON regexes.
- Rejects strings, numbers, lists, empty documents, and literal-only documents with `OperationFailure(code=2)`.
- Preserves valid `$not: {"$eq": ...}`, `$not: {"$regex": ...}`, `re.Pattern`, and `bson.Regex` behavior.

### Error metadata

The affected paths now distinguish the MongoDB codes rather than applying one generic value:

- query and operand parse failures: `2`
- missing index: `27`
- attempting to drop `_id_`: `72`
- index options conflict: `85`
- index key specification conflict: `86`
- malformed regex pattern: `51091`
- invalid regex option letter: `51108`

Missing-index behavior is covered across memory, TinyDB JSON, SQLite, DuckDB, Parquet, and the shared PostgreSQL/MySQL backend. The regex values follow MongoDB 8.0's more precise pattern/option codes.

### Client configuration

- Adds explicit supported keyword arguments to the legacy sync and async clients:
  - `tinymongo_folder`
  - `threads`
  - `storage_uri`
  - `duckdb_config`
  - `dsn`
- Rejects unknown keywords immediately with `TypeError`.
- Rejects conflicting non-default `foldername` and `tinymongo_folder` values.
- Leaves the PyMongo-shaped `MongoClient` and `AsyncMongoClient` connection-argument behavior unchanged.

### Capability and documentation updates

- Adds `query_operators["ignored"] == ("$comment",)`.
- Documents the client alias, strict keyword behavior, `$comment`, and `$not` validation.
- Checks off TM-022 through TM-025 in `ROADMAP.md`.
- Adds all four fixes to the unreleased changelog.

## Validation

Full local unit and contract suite:

```text
2747 passed, 381 deselected
```

Branch coverage:

```text
6965 statements, 0 missed
2896 branches, 0 partial
100% total coverage
```

Additional checks:

- `ruff check tinymongo tests`
- `black --check tinymongo tests`
- `git diff --check`

The shared contracts exercise both synchronous and asynchronous clients across memory, TinyDB JSON, SQLite, DuckDB, and Parquet. The opt-in real-MongoDB comparison runs in the repository's MongoDB 8.0 CI job.
