### PR TITLE
Enforce exact remote SQL numeric uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,13 @@
   `bson_types` likewise changed from a Boolean to a structured mapping of
   dependency-free `native` families and installed optional `pymongo` types;
   inspect its `pymongo` tuple when detecting optional BSON support.
-- Remote SQL unique indexes fail closed for Decimal128 values, as they already
-  do for arrays, when their native JSON constraints cannot guarantee exact
-  MongoDB numeric identity across concurrent writers.
+- Remote SQL unique indexes now materialize versioned canonical BSON token
+  digests protected by native constraints, preserving exact int/float identity
+  across concurrent PostgreSQL and MariaDB/MySQL writers. Decimal128 and arrays
+  remain fail-closed until their native token and multikey behavior can be
+  derived safely.
 - Remote SQL unique indexes also fail closed for Binary, UUID, and regex values
-  whose exact cross-process BSON identity cannot be enforced by the native JSON
+  whose exact cross-process BSON identity cannot be enforced by the native token
   constraint.
 
 ### Fixed
@@ -72,6 +74,10 @@
   doubles, and Decimal128 values, including large exactly equivalent integers
   and integral-looking doubles; SQLite attempts a one-time rebuild of legacy
   expression indexes when upgrading the token format.
+- Legacy remote SQL unique indexes now upgrade lazily under a per-collection
+  database lock. TinyMongo preflights and backfills exact tokens before swapping
+  the native index, retries safely across concurrent clients, and leaves a
+  conflicting catalog entry stale so later operations continue to fail closed.
 - If that SQLite rebuild discovers values an older unique token incorrectly
   treated as distinct, TinyMongo raises `DuplicateKeyError`, removes the unsafe
   native expression constraint, and retains fail-closed catalog enforcement so

--- a/README.md
+++ b/README.md
@@ -505,10 +505,12 @@ Unique indexes support JSON scalar values, Decimal128, UUID/Binary, regex, and
 flat arrays on embedded backends; missing and `null` share one unique key.
 Object values, ObjectId, datetime, nested arrays, non-finite numbers, and array
 traversal inside a dotted index path are not supported for unique indexes yet.
-Remote SQL uses native constraints for ordinary JSON scalar races. It rejects
-array, Decimal128, UUID/Binary, and regex values under unique indexes because
-its native JSON indexes cannot yet guarantee cross-process MongoDB multikey,
-numeric, or BSON identity.
+Remote SQL stores a versioned canonical token digest beside each unique-indexed
+value and protects it with a native constraint. This preserves exact int/float
+numeric identity across processes, including very large integers and doubles,
+while keeping booleans distinct from numbers. Remote SQL still rejects array,
+Decimal128, UUID/Binary, and regex values under unique indexes because those
+tokens cannot yet guarantee MongoDB multikey or BSON identity.
 
 SQL, DuckDB, and Parquet storage uses typed physical `_id` keys for new rows.
 Existing databases with older stringified keys remain readable and mutable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,11 +129,14 @@ with the follow-up audit of his
 - [x] **TM-021:** Raise PyMongo-compatible `WriteError` code `2` when
   `$addToSet` targets a null or non-array field, without partially applying the
   update.
-- [ ] **Remote SQL numeric uniqueness:** Persist canonical BSON numeric tokens
-  for remote unique indexes so native constraints can enforce exact
-  cross-process equality for every int/float representation; Decimal128
-  remains fail-closed there until the same token can be derived safely from its
-  BID representation.
+- [x] **Remote SQL numeric uniqueness:** Persist versioned, fixed-width digests
+  of canonical BSON scalar tokens for PostgreSQL and MariaDB/MySQL unique
+  indexes. Native constraints now enforce exact cross-process equality for
+  every int/float representation while keeping booleans distinct. Legacy
+  unique indexes are locked, preflighted, backfilled, and upgraded lazily;
+  conflicting legacy values fail closed without advancing the catalog version.
+  Decimal128 remains fail-closed until the same token can be derived safely
+  from its BID representation.
 - [ ] Update Mike's agent guide against the `v1.2.1` tag and describe the
   expanded API as available from PyPI.
   Correct its list-only `insert_many()` signature

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -64,6 +64,14 @@ pip install ".[all]"
   JSONB may already have normalized field order in legacy rows. TinyMongo can
   recover a literal container `_id` from its legacy physical row key; other
   normalized embedded documents retain the order returned by PostgreSQL.
+- Remote SQL unique indexes now use private materialized token columns so native
+  constraints preserve exact BSON int/float identity without SQL numeric
+  rounding. Existing unique indexes upgrade lazily under a collection lock. The
+  upgrade preflights and backfills current rows before replacing the native
+  index; exact legacy duplicates raise `DuplicateKeyError` and keep the catalog
+  version stale for a fail-closed retry. The database account needs `ALTER
+  TABLE`, index creation, and index removal privileges. Stop older TinyMongo
+  writers before allowing the upgraded client to migrate these indexes.
 - Remote SQL and object-storage Parquet no longer create the unused local path
   passed for API/CLI compatibility. Environment-only object-storage URIs and
   remote DSNs participate in CLI database discovery and migration summaries.

--- a/docs/REMOTE_SQL.md
+++ b/docs/REMOTE_SQL.md
@@ -120,8 +120,13 @@ Each table has:
 
 TinyMongo also creates `__tinymongo_collections` to track database and
 collection names and `__tinymongo_indexes` to persist index definitions.
-Supported indexes are backed by native SQL indexes over the unchanged `data`
-JSON object.
+Non-unique indexes are backed by native SQL indexes derived from the unchanged
+`data` JSON object. Each unique index also has a private 64-character token
+column. TinyMongo derives that token from its canonical BSON scalar identity,
+so the database can enforce exact int/float equality across processes without
+rounding large values through a SQL numeric type. Booleans remain distinct
+from numbers. Arrays, Decimal128, UUID/Binary, and regex values remain
+fail-closed under remote unique indexes.
 
 When TinyMongo first opens a table created before 1.2.1, it adds
 `data_ordered` automatically. The database account therefore needs
@@ -132,6 +137,15 @@ may already have normalized field order in legacy rows. TinyMongo can recover a
 literal container `_id` from its legacy physical row key; other legacy mappings
 retain the order PostgreSQL returns, not necessarily the document's original
 application order.
+
+Older remote unique indexes are upgraded on first access. TinyMongo locks the
+collection, checks existing values under current BSON identity rules, adds and
+backfills the token column, swaps the native unique index, and records the new
+token version. If legacy values such as `int(1e23)` and `1e23` are exact BSON
+duplicates, the upgrade raises `DuplicateKeyError` and leaves the catalog row
+stale so a later retry also fails closed. The account needs permission to alter
+tables and create or drop indexes. Do not mix older and newer TinyMongo writers
+during this schema upgrade.
 
 ## Query Behavior
 

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -1,8 +1,10 @@
 import asyncio
 from collections import UserDict
+from concurrent.futures import ThreadPoolExecutor
 import os
 import math
 import re
+import threading
 from uuid import UUID, uuid4
 
 import pytest
@@ -15,7 +17,7 @@ from tinymongo.errors import (
     TinyMongoNotSupportedError,
     WriteError,
 )
-from tinymongo.table_backends import _json_dumps
+from tinymongo.table_backends import _json_dumps, _REMOTE_UNIQUE_TOKEN_VERSION
 
 
 pytestmark = pytest.mark.integration
@@ -672,6 +674,182 @@ def test_remote_sql_native_index_catalog_and_unique_enforcement(backend, env_nam
         multikey.drop()
         scalar.drop()
         client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_unique_indexes_preserve_exact_numeric_identity(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][prefix + "_numeric_identity"]
+
+    try:
+        docs.create_index("value", name="value_unique", unique=True)
+
+        # These pairs are distinct in BSON even though JSON/SQL numeric casts can
+        # round them onto the same database value.
+        docs.insert_many(
+            [
+                {"_id": "exact-integer", "value": 10**23},
+                {"_id": "rounded-double", "value": 1e23},
+                {"_id": "boolean", "value": True},
+                {"_id": "integer-one", "value": 1},
+                {"_id": "zero", "value": 0},
+                {"_id": "subnormal", "value": 5e-324},
+            ]
+        )
+        assert docs.count_documents({}) == 6
+
+        # Python exposes the double's exact integer value here. A native unique
+        # constraint must therefore reject it as the same BSON number as 1e23.
+        with pytest.raises(DuplicateKeyError):
+            docs.insert_one({"_id": "equivalent-integer", "value": int(1e23)})
+        with pytest.raises(DuplicateKeyError):
+            docs.insert_one({"_id": "negative-zero", "value": -0.0})
+
+        assert docs.count_documents({}) == 6
+    finally:
+        docs.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_async_unique_indexes_preserve_exact_numeric_identity(
+    backend, env_name
+):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_async_numeric_identity"
+
+    async def scenario():
+        client = AsyncTinyMongoClient(backend=backend, dsn=dsn)
+        docs = client[database][collection]
+        try:
+            await docs.create_index("value", name="value_unique", unique=True)
+            await docs.insert_many(
+                [
+                    {"_id": "exact-integer", "value": 10**23},
+                    {"_id": "rounded-double", "value": 1e23},
+                    {"_id": "boolean", "value": True},
+                    {"_id": "integer-one", "value": 1},
+                ]
+            )
+            with pytest.raises(DuplicateKeyError):
+                await docs.insert_one({"_id": "equivalent-integer", "value": int(1e23)})
+            assert await docs.count_documents({}) == 4
+        finally:
+            await docs.drop()
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_unique_numeric_constraint_wins_concurrent_duplicate_race(
+    backend, env_name
+):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_numeric_race"
+    owner = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = owner[database][collection]
+    contenders = [
+        tm.TinyMongoClient(backend=backend, dsn=dsn),
+        tm.TinyMongoClient(backend=backend, dsn=dsn),
+    ]
+    start = threading.Barrier(2)
+
+    def compete(client, row_id, value):
+        start.wait(timeout=15)
+        try:
+            client[database][collection].insert_one({"_id": row_id, "value": value})
+        except DuplicateKeyError as error:
+            assert error.code == 11000
+            return "duplicate"
+        return "inserted"
+
+    try:
+        docs.create_index("value", name="value_unique", unique=True)
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(compete, contenders[0], "integer", int(1e23)),
+                executor.submit(compete, contenders[1], "double", 1e23),
+            ]
+            outcomes = [future.result(timeout=30) for future in futures]
+
+        assert sorted(outcomes) == ["duplicate", "inserted"]
+        assert docs.count_documents({}) == 1
+    finally:
+        for contender in contenders:
+            contender.close()
+        docs.drop()
+        owner.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_unique_token_migration_is_durable_and_concurrent(backend, env_name):
+    dsn, database, prefix = _remote_target(backend, env_name)
+    collection = prefix + "_numeric_migration"
+    owner = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = owner[database][collection]
+    engine = docs.parent.engine
+    readers = [
+        tm.TinyMongoClient(backend=backend, dsn=dsn),
+        tm.TinyMongoClient(backend=backend, dsn=dsn),
+    ]
+    start = threading.Barrier(2)
+
+    def migrate(client):
+        start.wait(timeout=15)
+        return client[database][collection].index_information()
+
+    try:
+        docs.create_index("value", name="value_unique", unique=True)
+        docs.insert_one({"_id": "double", "value": 1e23})
+        conn = engine._connect()
+        try:
+            cursor = engine._execute(
+                conn,
+                "UPDATE {0} SET token_version = 0 "
+                "WHERE database_name = {1} AND collection_name = {1} "
+                "AND index_name = {1}".format(
+                    engine._quote(engine.index_catalog_table), engine.placeholder
+                ),
+                (database, collection, "value_unique"),
+            )
+            engine._close_cursor(cursor)
+            engine._commit(conn)
+        finally:
+            conn.close()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(migrate, reader) for reader in readers]
+            catalogs = [future.result(timeout=30) for future in futures]
+        assert all("value_unique" in catalog for catalog in catalogs)
+
+        conn = engine._connect()
+        try:
+            cursor = engine._execute(
+                conn,
+                "SELECT token_version FROM {0} "
+                "WHERE database_name = {1} AND collection_name = {1} "
+                "AND index_name = {1}".format(
+                    engine._quote(engine.index_catalog_table), engine.placeholder
+                ),
+                (database, collection, "value_unique"),
+            )
+            version = cursor.fetchone()[0]
+            engine._close_cursor(cursor)
+        finally:
+            conn.close()
+        assert version == _REMOTE_UNIQUE_TOKEN_VERSION
+
+        with pytest.raises(DuplicateKeyError):
+            docs.insert_one({"_id": "integer", "value": int(1e23)})
+        docs.insert_one({"_id": "decimal", "value": 10**23})
+        assert docs.count_documents({}) == 2
+    finally:
+        for reader in readers:
+            reader.close()
+        docs.drop()
+        owner.close()
 
 
 @pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)

--- a/tests/test_table_backend_id_and_error_edges.py
+++ b/tests/test_table_backend_id_and_error_edges.py
@@ -252,6 +252,7 @@ def test_remote_backend_maps_insert_conflicts_and_ignores_missing_replacements(
     monkeypatch.setattr(backend, "create_collection", lambda _collection: None)
     monkeypatch.setattr(backend, "_all_docs_unfiltered", lambda _collection: [])
     monkeypatch.setattr(backend, "validate_unique_post_image", lambda *_args: None)
+    monkeypatch.setattr(backend, "_index_specs_on_connection", lambda *_args: [])
     monkeypatch.setattr(backend, "_connect", _RemoteConnection)
     monkeypatch.setattr(
         backend,

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -35,6 +35,8 @@ from tinymongo.table_backends import (
     _json_loads,
     _join_uri,
     _reject_remote_unique_values,
+    _remote_unique_token,
+    _REMOTE_UNIQUE_TOKEN_VERSION,
     _SQLITE_UNIQUE_TOKEN_VERSION,
     matches_filter,
     requires_python_filter,
@@ -114,6 +116,8 @@ class FakeRemoteStore:
         self.columns = {}
         self.metadata = set()
         self.indexes = {}
+        self.native_indexes = set()
+        self.tokens = {}
         self.index_ddl = []
         self.schema_ddl = []
 
@@ -128,7 +132,23 @@ class FakeRemoteCursor:
         upper = normalized.upper()
         if upper.startswith("CREATE TABLE"):
             table = self._table_from_create(normalized)
-            if "TINYMONGO_" not in table.upper():
+            if "TINYMONGO_INDEXES" in table.upper():
+                self.store.columns.setdefault(
+                    table,
+                    {
+                        "database_name",
+                        "collection_name",
+                        "index_name",
+                        "field_name",
+                        "unique_flag",
+                        "token_version",
+                    },
+                )
+            elif "TINYMONGO_COLLECTIONS" in table.upper():
+                self.store.columns.setdefault(
+                    table, {"database_name", "collection_name"}
+                )
+            else:
                 if table not in self.store.tables:
                     self.store.tables[table] = {}
                     self.store.columns[table] = {"_id", "data"}
@@ -136,34 +156,85 @@ class FakeRemoteCursor:
                         self.store.columns[table].add("data_ordered")
         elif upper.startswith(("CREATE INDEX", "CREATE UNIQUE INDEX")):
             self.store.index_ddl.append(normalized)
+            self.store.native_indexes.add(
+                (
+                    self._table_after(normalized, "ON"),
+                    self._index_from_create(normalized),
+                )
+            )
+        elif upper.startswith("LOCK TABLE"):
+            self.store.schema_ddl.append(normalized)
         elif upper.startswith("ALTER TABLE") and "DATA_ORDERED" in upper:
             table = self._table_after(normalized, "TABLE")
             self.store.columns.setdefault(table, {"_id", "data"}).add("data_ordered")
             self.store.schema_ddl.append(normalized)
-        elif upper.startswith(("ALTER TABLE", "DROP INDEX")):
+        elif upper.startswith("ALTER TABLE"):
+            table = self._table_after(normalized, "TABLE")
+            if " ADD COLUMN " in upper:
+                column = self._column_after(normalized, "ADD COLUMN")
+                self.store.columns.setdefault(table, set()).add(column)
+            for column in self._drop_columns(normalized):
+                self.store.columns.setdefault(table, set()).discard(column)
+                self.store.tokens = {
+                    key: value
+                    for key, value in self.store.tokens.items()
+                    if not (key[0] == table and key[1] == column)
+                }
+            for index in self._drop_indexes(normalized):
+                self.store.native_indexes.discard((table, index))
+            self.store.index_ddl.append(normalized)
+        elif upper.startswith("DROP INDEX"):
+            index = self._index_from_drop(normalized)
+            self.store.native_indexes = {
+                item for item in self.store.native_indexes if item[1] != index
+            }
             self.store.index_ddl.append(normalized)
         elif upper.startswith("INSERT") and "TINYMONGO_INDEXES" in upper:
-            database, collection, name, field, unique = params
-            self.store.indexes[(database, collection, name)] = (field, bool(unique))
+            database, collection, name, field, unique, token_version = params
+            self.store.indexes[(database, collection, name)] = (
+                field,
+                bool(unique),
+                token_version,
+            )
         elif upper.startswith("INSERT") and "TINYMONGO_COLLECTIONS" in upper:
             self.store.metadata.add(tuple(params))
         elif upper.startswith("SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS"):
             table = params[0]
-            self.rows = (
-                [(1,)] if "data_ordered" in self.store.columns.get(table, set()) else []
-            )
+            if "COLUMN_NAME = 'TOKEN_VERSION'" in upper:
+                column = "token_version"
+            else:
+                column = params[1] if len(params) > 1 else "data_ordered"
+            self.rows = [(1,)] if column in self.store.columns.get(table, set()) else []
+        elif upper.startswith("SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS"):
+            self.rows = [(1,)] if tuple(params) in self.store.native_indexes else []
+        elif upper.startswith("SELECT GET_LOCK"):
+            self.rows = [(1,)]
+        elif upper.startswith("SELECT RELEASE_LOCK"):
+            self.rows = [(1,)]
         elif upper.startswith("SELECT DISTINCT"):
             self.rows = sorted({(database,) for database, _ in self.store.metadata})
         elif upper.startswith("SELECT INDEX_NAME"):
-            database, collection = params
-            self.rows = sorted(
-                (name, field, unique)
-                for (index_database, index_collection, name), (
-                    field,
-                    unique,
-                ) in self.store.indexes.items()
-                if index_database == database and index_collection == collection
-            )
+            database, collection = params[:2]
+            if "TOKEN_VERSION <" in upper:
+                target_version = params[3]
+                self.rows = sorted(
+                    (name, value[0])
+                    for (index_database, index_collection, name), value in (
+                        self.store.indexes.items()
+                    )
+                    if index_database == database
+                    and index_collection == collection
+                    and bool(value[1])
+                    and (value[2] if len(value) > 2 else 0) < target_version
+                )
+            else:
+                self.rows = sorted(
+                    (name, value[0], value[1])
+                    for (index_database, index_collection, name), value in (
+                        self.store.indexes.items()
+                    )
+                    if index_database == database and index_collection == collection
+                )
         elif upper.startswith("SELECT COLLECTION_NAME"):
             database = params[0]
             self.rows = sorted(
@@ -175,6 +246,11 @@ class FakeRemoteCursor:
             table = self._table_after(normalized, "TABLE IF EXISTS")
             self.store.tables.pop(table, None)
             self.store.columns.pop(table, None)
+            self.store.tokens = {
+                key: value
+                for key, value in self.store.tokens.items()
+                if key[0] != table
+            }
         elif upper.startswith("DELETE FROM") and "TINYMONGO_COLLECTIONS" in upper:
             self.store.metadata.discard(tuple(params))
         elif upper.startswith("DELETE FROM") and "TINYMONGO_INDEXES" in upper:
@@ -191,9 +267,13 @@ class FakeRemoteCursor:
                 database, collection, name = params
                 self.store.indexes.pop((database, collection, name), None)
         elif upper.startswith("DELETE FROM"):
-            self.store.tables.setdefault(self._table_after(normalized, "FROM"), {}).pop(
-                params[0], None
-            )
+            table = self._table_after(normalized, "FROM")
+            self.store.tables.setdefault(table, {}).pop(params[0], None)
+            self.store.tokens = {
+                key: value
+                for key, value in self.store.tokens.items()
+                if not (key[0] == table and key[2] == params[0])
+            }
         elif upper.startswith("SELECT _ID, DATA_ORDERED, DATA"):
             table = self._table_after(normalized, "FROM")
             self.rows = [
@@ -229,10 +309,22 @@ class FakeRemoteCursor:
                 (self._payload_columns(value)[0],)
                 for value in self.store.tables.get(table, {}).values()
             ]
+        elif upper.startswith("UPDATE") and "TINYMONGO_INDEXES" in upper:
+            token_version, database, collection, name = params
+            key = (database, collection, name)
+            value = self.store.indexes[key]
+            self.store.indexes[key] = (value[0], value[1], token_version)
         elif upper.startswith("UPDATE"):
             table = self._table_after(normalized, "UPDATE")
-            if len(params) == 3:
-                data, ordered_data, doc_id = params
+            if len(params) >= 3:
+                data, ordered_data, doc_id = params[0], params[1], params[-1]
+                assignments = normalized.split(" SET ", 1)[1].split(" WHERE ", 1)[0]
+                token_columns = [
+                    self._clean(item.split("=", 1)[0].strip())
+                    for item in assignments.split(",")[2:]
+                ]
+                for column, token in zip(token_columns, params[2:-1]):
+                    self._store_unique_token(table, column, doc_id, token)
                 self.store.tables.setdefault(table, {})[doc_id] = (
                     data,
                     ordered_data,
@@ -243,15 +335,30 @@ class FakeRemoteCursor:
         return self
 
     def executemany(self, sql, rows):
-        if sql.upper().startswith("DELETE FROM"):
-            table = self._table_after(" ".join(sql.split()), "FROM")
+        normalized = " ".join(sql.split())
+        upper = normalized.upper()
+        if upper.startswith("DELETE FROM"):
+            table = self._table_after(normalized, "FROM")
             target = self.store.tables.setdefault(table, {})
             for (doc_id,) in rows:
                 target.pop(doc_id, None)
+                self.store.tokens = {
+                    key: value
+                    for key, value in self.store.tokens.items()
+                    if not (key[0] == table and key[2] == doc_id)
+                }
             return
 
-        table = self._table_after(" ".join(sql.split()), "INTO")
+        if upper.startswith("UPDATE"):
+            table = self._table_after(normalized, "UPDATE")
+            column = self._column_after(normalized, "SET")
+            for token, doc_id in rows:
+                self._store_unique_token(table, column, doc_id, token)
+            return
+
+        table = self._table_after(normalized, "INTO")
         target = self.store.tables.setdefault(table, {})
+        columns = self._insert_columns(normalized)
         for row in rows:
             doc_id, data = row[:2]
             if (
@@ -260,7 +367,9 @@ class FakeRemoteCursor:
                 and "REPLACE" not in sql.upper()
             ):
                 raise RuntimeError("duplicate key")
-            target[doc_id] = (data, row[2]) if len(row) == 3 else data
+            for column, token in zip(columns[3:], row[3:]):
+                self._store_unique_token(table, column, doc_id, token)
+            target[doc_id] = (data, row[2]) if len(row) >= 3 else data
 
     def fetchone(self):
         return self.rows[0] if self.rows else None
@@ -285,6 +394,59 @@ class FakeRemoteCursor:
     def _clean(self, value):
         return value.strip().strip('"').strip("`")
 
+    def _index_from_create(self, sql):
+        return self._clean(sql.split("INDEX", 1)[1].strip().split()[0])
+
+    def _index_from_drop(self, sql):
+        remainder = sql.split("INDEX", 1)[1].strip()
+        if remainder.upper().startswith("IF EXISTS"):
+            remainder = remainder[len("IF EXISTS") :].strip()
+        return self._clean(remainder.split()[0])
+
+    def _column_after(self, sql, marker):
+        remainder = sql.split(marker, 1)[1].strip()
+        if remainder.upper().startswith("IF NOT EXISTS"):
+            remainder = remainder[len("IF NOT EXISTS") :].strip()
+        return self._clean(remainder.split()[0])
+
+    def _drop_columns(self, sql):
+        columns = []
+        for part in sql.split("DROP COLUMN")[1:]:
+            remainder = part.strip()
+            if remainder.upper().startswith("IF EXISTS"):
+                remainder = remainder[len("IF EXISTS") :].strip()
+            columns.append(self._clean(remainder.split()[0].rstrip(",")))
+        return columns
+
+    def _drop_indexes(self, sql):
+        return [
+            self._clean(part.strip().split()[0].rstrip(","))
+            for part in sql.split("DROP INDEX")[1:]
+        ]
+
+    def _insert_columns(self, sql):
+        values_at = sql.upper().index(" VALUES ")
+        before_values = sql[:values_at]
+        start = before_values.index("(") + 1
+        return [
+            self._clean(value.strip()) for value in before_values[start:].split(",")
+        ]
+
+    def _store_unique_token(self, table, column, doc_id, token):
+        for (
+            other_table,
+            other_column,
+            other_id,
+        ), other_token in self.store.tokens.items():
+            if (
+                other_table == table
+                and other_column == column
+                and other_id != doc_id
+                and other_token == token
+            ):
+                raise RuntimeError("duplicate key")
+        self.store.tokens[(table, column, doc_id)] = token
+
 
 class FakeRemoteConnection:
     def __init__(self, store):
@@ -296,6 +458,9 @@ class FakeRemoteConnection:
 
     def commit(self):
         self.commits += 1
+
+    def rollback(self):
+        pass
 
     def close(self):
         pass
@@ -1259,9 +1424,9 @@ def test_postgres_indexes_are_native_durable_unique_and_droppable(monkeypatch):
 
     spec = parse_index_spec("email", unique=True)
     assert backend.create_index("users", spec) == "email_1"
-    ddl_count = len(store.index_ddl)
+    ddl_count = sum("CREATE UNIQUE INDEX" in sql for sql in store.index_ddl)
     assert backend.create_index("users", spec) == "email_1"
-    assert len(store.index_ddl) == ddl_count
+    assert sum("CREATE UNIQUE INDEX" in sql for sql in store.index_ddl) == ddl_count
     assert backend.list_indexes("users") == [
         {"name": "_id_", "key": [("_id", 1)]},
         {"name": "email_1", "key": [("email", 1)], "unique": True},
@@ -1269,12 +1434,14 @@ def test_postgres_indexes_are_native_durable_unique_and_droppable(monkeypatch):
     assert _postgres_backend(monkeypatch, store).list_indexes("users") == (
         backend.list_indexes("users")
     )
+    token_column = backend._unique_token_column("users", spec)
     assert any(
         "CREATE UNIQUE INDEX" in sql
-        and "COALESCE(jsonb_extract_path(data, 'email'), 'null'::jsonb)" in sql
-        and "jsonb_typeof(data)" not in sql
+        and '"{0}"'.format(token_column) in sql
+        and "jsonb_extract_path" not in sql
         for sql in store.index_ddl
     )
+    assert token_column in store.columns[backend._table_name("users")]
 
     with pytest.raises(DuplicateKeyError):
         backend.insert_many("users", [{"_id": 3, "email": "one@example.com"}])
@@ -1302,7 +1469,8 @@ def test_remote_unique_creation_preflights_and_drop_cleans_catalog(monkeypatch):
     with pytest.raises(DuplicateKeyError):
         backend.create_index("users", parse_index_spec("email", unique=True))
     assert backend.list_indexes("users") == [{"name": "_id_", "key": [("_id", 1)]}]
-    assert not store.index_ddl
+    assert not any("CREATE UNIQUE INDEX" in sql for sql in store.index_ddl)
+    assert not store.native_indexes
 
     backend.create_index("users", parse_index_spec("email"))
     with pytest.raises(OperationFailure, match="different options"):
@@ -1367,10 +1535,12 @@ def test_remote_native_errors_are_mapped_without_hiding_other_failures(monkeypat
     with pytest.raises(RuntimeError, match="syntax error"):
         backend.create_index("users", spec)
 
-    def fail_insert(conn, collection, rows, bypass_document_validation):
+    def fail_insert(conn, collection, rows, unique_specs, bypass_document_validation):
         raise RuntimeError("insert syntax error")
 
-    def fail_duplicate_insert(conn, collection, rows, bypass_document_validation):
+    def fail_duplicate_insert(
+        conn, collection, rows, unique_specs, bypass_document_validation
+    ):
         raise RuntimeError("duplicate key")
 
     monkeypatch.setattr(backend, "_insert_rows", fail_duplicate_insert)
@@ -1382,7 +1552,67 @@ def test_remote_native_errors_are_mapped_without_hiding_other_failures(monkeypat
         backend.insert_many("users", [{"_id": 4, "email": "four@example.com"}])
 
 
-def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
+def test_remote_schema_races_and_cleanup_errors_preserve_original_failure(
+    monkeypatch,
+):
+    store = FakeRemoteStore()
+    backend = _postgres_backend(monkeypatch, store)
+    unique_spec = parse_index_spec("email", unique=True)
+    backend.create_collection("users")
+
+    def compatibility(_collection, spec, specs=None):
+        return spec if specs is not None else None
+
+    monkeypatch.setattr(backend, "_check_index_compatibility", compatibility)
+    assert backend.create_index("users", unique_spec) == unique_spec.name
+    assert not store.native_indexes
+
+    backend = _postgres_backend(monkeypatch, store)
+    monkeypatch.setattr(
+        backend,
+        "_create_native_index",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("create syntax error")),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_cleanup_failed_native_index_creation",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("cleanup syntax error")),
+    )
+    with pytest.raises(RuntimeError, match="create syntax error"):
+        backend.create_index("users", unique_spec)
+
+    with pytest.raises(RuntimeError, match="create syntax error"):
+        backend.create_index("users", parse_index_spec("lookup"))
+
+
+def test_remote_delete_and_drop_index_errors_roll_back(monkeypatch):
+    store = FakeRemoteStore()
+    backend = _postgres_backend(monkeypatch, store)
+    backend.insert_many("users", [{"_id": 1, "value": "one"}])
+    backend.create_index("users", parse_index_spec("value"))
+    backend.drop_index("users", "value_1")
+
+    monkeypatch.setattr(
+        backend,
+        "_executemany",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("delete syntax error")),
+    )
+    with pytest.raises(RuntimeError, match="delete syntax error"):
+        backend.delete_ids("users", [1])
+
+    monkeypatch.undo()
+    backend = _postgres_backend(monkeypatch, store)
+    backend.create_index("users", parse_index_spec("other"))
+    monkeypatch.setattr(
+        backend,
+        "_drop_native_index",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("drop syntax error")),
+    )
+    with pytest.raises(RuntimeError, match="drop syntax error"):
+        backend.drop_index("users", "other_1")
+
+
+def test_mysql_uses_materialized_unique_token_and_rejects_multikey_unique(
     monkeypatch,
 ):
     store = FakeRemoteStore()
@@ -1396,6 +1626,7 @@ def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
     )
 
     backend.create_index("items", parse_index_spec("value", unique=True))
+    backend.create_index("items", parse_index_spec("lookup"))
     with pytest.raises(TinyMongoNotSupportedError, match="does not support array"):
         backend.create_index(
             "items", parse_index_spec("tags", unique=True, name="unique_tags")
@@ -1403,16 +1634,23 @@ def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
 
     assert _mysql_backend(monkeypatch, store).list_indexes("items") == [
         {"name": "_id_", "key": [("_id", 1)]},
+        {"name": "lookup_1", "key": [("lookup", 1)]},
         {"name": "value_1", "key": [("value", 1)], "unique": True},
     ]
+    token_column = backend._unique_token_column(
+        "items", parse_index_spec("value", unique=True)
+    )
+    assert token_column in store.columns[backend._table_name("items")]
+    assert any(
+        "CREATE UNIQUE INDEX" in sql
+        and "`{0}`".format(token_column) in sql
+        and "JSON_EXTRACT" not in sql
+        for sql in store.index_ddl
+    )
     assert any(
         "GENERATED ALWAYS AS" in sql
-        and "JSON_TYPE(JSON_EXTRACT(data, '$.\"value\"'))" in sql
-        and "JSON_TYPE(data)" not in sql
-        and "CONCAT('bool:'" in sql
-        and "AS DECIMAL(65, 30)" in sql
+        and "JSON_TYPE(JSON_EXTRACT(data, '$.\"lookup\"'))" in sql
         and "SHA2(CASE" in sql
-        and "CHAR(64) CHARACTER SET ascii COLLATE ascii_bin" in sql
         for sql in store.index_ddl
     )
     assert sum("CREATE UNIQUE INDEX" in sql for sql in store.index_ddl) == 1
@@ -1423,10 +1661,251 @@ def test_mysql_uses_type_aware_generated_column_and_rejects_multikey_unique(
     backend.drop_index("items", "value_1")
     assert any(sql.startswith("DROP INDEX") for sql in store.index_ddl)
     assert any("DROP COLUMN" in sql for sql in store.index_ddl)
+    backend.drop_index("items", "lookup_1")
 
     backend.insert_many("numbers", [{"_id": 1, "value": 1}, {"_id": 2, "value": 1.0}])
     with pytest.raises(DuplicateKeyError):
         backend.create_index("numbers", parse_index_spec("value", unique=True))
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "same_token"),
+    [
+        (1, 1.0, True),
+        (0, -0.0, True),
+        (2**60, float(2**60), True),
+        (int(1e23), 1e23, True),
+        (2**53 + 1, float(2**53 + 1), False),
+        (10**23, 1e23, False),
+        (0, 5e-324, False),
+        (True, 1, False),
+    ],
+)
+def test_remote_unique_tokens_preserve_exact_bson_numeric_identity(
+    left, right, same_token
+):
+    spec = parse_index_spec("value", unique=True)
+
+    left_token = _remote_unique_token({"value": left}, spec)
+    right_token = _remote_unique_token({"value": right}, spec)
+
+    assert (left_token == right_token) is same_token
+    assert len(left_token) == len(right_token) == 64
+
+
+def test_remote_unique_token_rejects_future_multitoken_expansion(monkeypatch):
+    spec = parse_index_spec("value", unique=True)
+    monkeypatch.setattr(
+        "tinymongo.table_backends.index_tokens", lambda _document, _field: ["a", "b"]
+    )
+
+    with pytest.raises(TinyMongoNotSupportedError, match="exactly one scalar token"):
+        _remote_unique_token({"value": "scalar"}, spec)
+
+
+def test_remote_base_schema_hooks_and_migration_errors(monkeypatch):
+    backend = RemoteSQLTableBackend("", database="app", dsn="remote")
+    conn = FakeRemoteConnection(FakeRemoteStore())
+    spec = parse_index_spec("value", unique=True)
+    dropped = []
+
+    with backend._collection_schema_lock(conn, "items"):
+        pass
+    monkeypatch.setattr(
+        backend,
+        "_drop_native_index",
+        lambda active_conn, collection, active_spec: dropped.append(
+            (active_conn, collection, active_spec)
+        ),
+    )
+    backend._drop_legacy_native_index(conn, "items", spec)
+    assert dropped == [(conn, "items", spec)]
+
+    monkeypatch.setattr(backend, "_legacy_unique_specs", lambda *_args: [spec])
+    monkeypatch.setattr(
+        backend,
+        "_prepare_unique_token_column",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("migration syntax error")),
+    )
+    with pytest.raises(RuntimeError, match="migration syntax error"):
+        backend._migrate_legacy_unique_indexes(conn, "items")
+
+
+@pytest.mark.parametrize("backend_factory", [_postgres_backend, _mysql_backend])
+def test_remote_unique_tokens_handle_large_numeric_writes_and_replacements(
+    monkeypatch, backend_factory
+):
+    store = FakeRemoteStore()
+    backend = backend_factory(monkeypatch, store)
+    spec = parse_index_spec("value", unique=True)
+    backend.create_index("numbers", spec)
+
+    backend.insert_many(
+        "numbers",
+        [
+            {"_id": "integer", "value": 10**23},
+            {"_id": "double", "value": 1e23},
+            {"_id": "boolean", "value": True},
+            {"_id": "one", "value": 1},
+            {"_id": "zero", "value": 0},
+            {"_id": "subnormal", "value": 5e-324},
+        ],
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        backend.insert_many("numbers", [{"_id": "exact-double", "value": int(1e23)}])
+    backend.replace_one("numbers", "integer", {"_id": "integer", "value": 2**53 + 1})
+    backend.insert_many("numbers", [{"_id": "rounded", "value": float(2**53 + 1)}])
+    with pytest.raises(DuplicateKeyError):
+        backend.replace_one(
+            "numbers", "rounded", {"_id": "rounded", "value": int(1e23)}
+        )
+
+    token_column = backend._unique_token_column("numbers", spec)
+    assert token_column in store.columns[backend._table_name("numbers")]
+    assert all(len(token) == 64 for token in store.tokens.values())
+
+
+@pytest.mark.parametrize("backend_factory", [_postgres_backend, _mysql_backend])
+def test_remote_unique_token_migration_backfills_and_advances_catalog(
+    monkeypatch, backend_factory
+):
+    store = FakeRemoteStore()
+    backend = backend_factory(monkeypatch, store)
+    collection = "legacy_numbers"
+    spec = parse_index_spec("value", unique=True)
+    backend.insert_many(collection, [{"_id": "double", "value": 1e23}])
+    catalog_key = (backend.database, collection, spec.name)
+    store.indexes[catalog_key] = (spec.field, True, 0)
+    store.native_indexes.add(
+        (
+            backend._table_name(collection),
+            backend._physical_index_name(collection, spec),
+        )
+    )
+    if backend.dialect == "mysql":
+        store.columns[backend._table_name(collection)].add(
+            backend._generated_index_column(collection, spec)
+        )
+
+    reopened = backend_factory(monkeypatch, store)
+    assert reopened.get_index_specs(collection) == [spec]
+
+    assert store.indexes[catalog_key][2] == _REMOTE_UNIQUE_TOKEN_VERSION
+    token_column = reopened._unique_token_column(collection, spec)
+    table_name = reopened._table_name(collection)
+    stored_id = next(iter(store.tables[table_name]))
+    assert token_column in store.columns[table_name]
+    assert store.tokens[(table_name, token_column, stored_id)] == _remote_unique_token(
+        {"_id": "double", "value": 1e23}, spec
+    )
+    with pytest.raises(DuplicateKeyError):
+        reopened.insert_many(collection, [{"_id": "integer", "value": int(1e23)}])
+    reopened.insert_many(collection, [{"_id": "decimal", "value": 10**23}])
+
+    assert backend_factory(monkeypatch, store).get_index_specs(collection) == [spec]
+
+
+@pytest.mark.parametrize("backend_factory", [_postgres_backend, _mysql_backend])
+def test_remote_unique_token_migration_retries_conflicts_fail_closed(
+    monkeypatch, backend_factory
+):
+    store = FakeRemoteStore()
+    backend = backend_factory(monkeypatch, store)
+    collection = "conflicting_numbers"
+    spec = parse_index_spec("value", unique=True)
+    backend.insert_many(
+        collection,
+        [
+            {"_id": "integer", "value": int(1e23)},
+            {"_id": "double", "value": 1e23},
+        ],
+    )
+    catalog_key = (backend.database, collection, spec.name)
+    store.indexes[catalog_key] = (spec.field, True, 0)
+
+    for _attempt in range(2):
+        reopened = backend_factory(monkeypatch, store)
+        with pytest.raises(DuplicateKeyError, match="exact BSON numeric identity"):
+            reopened.get_index_specs(collection)
+        assert store.indexes[catalog_key][2] == 0
+        assert len(store.tables[backend._table_name(collection)]) == 2
+        assert not any(
+            index == backend._physical_index_name(collection, spec)
+            for _table, index in store.native_indexes
+        )
+
+
+@pytest.mark.parametrize("backend_factory", [_postgres_backend, _mysql_backend])
+def test_remote_upgrades_legacy_catalog_token_version_column(
+    monkeypatch, backend_factory
+):
+    store = FakeRemoteStore()
+    store.columns["__tinymongo_indexes"] = {
+        "database_name",
+        "collection_name",
+        "index_name",
+        "field_name",
+        "unique_flag",
+    }
+    backend = backend_factory(monkeypatch, store)
+
+    assert backend.get_index_specs("items") == []
+    assert "token_version" in store.columns[backend.index_catalog_table]
+
+
+def test_mysql_token_schema_defensive_branches(monkeypatch):
+    store = FakeRemoteStore()
+    backend = _mysql_backend(monkeypatch, store)
+    conn = FakeRemoteConnection(store)
+    spec = parse_index_spec("value", unique=True)
+    original_execute = backend._execute
+
+    def lock_timeout(_conn, sql, params=None):
+        if sql.startswith("SELECT GET_LOCK"):
+            return FakeRemoteCursor(store)
+        return original_execute(_conn, sql, params)
+
+    monkeypatch.setattr(backend, "_execute", lock_timeout)
+    with pytest.raises(OperationFailure, match="collection lock"):
+        with backend._collection_schema_lock(conn, "items"):
+            pass
+
+    def release_failure(_conn, sql, params=None):
+        if sql.startswith("SELECT GET_LOCK"):
+            cursor = FakeRemoteCursor(store)
+            cursor.rows = [(1,)]
+            return cursor
+        if sql.startswith("SELECT RELEASE_LOCK"):
+            raise RuntimeError("connection closed")
+        return original_execute(_conn, sql, params)
+
+    monkeypatch.setattr(backend, "_execute", release_failure)
+    with backend._collection_schema_lock(conn, "items"):
+        pass
+    monkeypatch.setattr(backend, "_execute", original_execute)
+
+    monkeypatch.setattr(backend, "_mysql_column_exists", lambda *_args: False)
+
+    def duplicate_column(*_args):
+        raise RuntimeError(1060, "duplicate column")
+
+    monkeypatch.setattr(backend, "_execute", duplicate_column)
+    backend._ensure_index_catalog_token_version(conn)
+    backend._add_unique_token_column(conn, "items", spec)
+
+    def bad_column(*_args):
+        raise RuntimeError("bad alter")
+
+    monkeypatch.setattr(backend, "_execute", bad_column)
+    with pytest.raises(RuntimeError, match="bad alter"):
+        backend._ensure_index_catalog_token_version(conn)
+    with pytest.raises(RuntimeError, match="bad alter"):
+        backend._add_unique_token_column(conn, "items", spec)
+
+    monkeypatch.setattr(backend, "_execute", original_execute)
+    backend._drop_unique_token_column(conn, "items", spec)
+    backend._drop_legacy_native_index(conn, "items", spec)
 
 
 def test_remote_array_guard_ignores_nonunique_specs():

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -57,6 +57,7 @@ _DECIMAL128 = decimal128_type()
 _ID_RATIO_HEX_TAG = "exact-ratio-hex-v1"
 _SAFE_JSON_INTEGER_BITS = 1800
 _SQLITE_UNIQUE_TOKEN_VERSION = 3
+_REMOTE_UNIQUE_TOKEN_VERSION = 1
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
 _PHYSICAL_ID_PREFIX = "__tinymongo_id_v2__:"
 _LOGICAL_FILTER_OPERATOR_NAMES = ("$and", "$or", "$nor")
@@ -619,17 +620,38 @@ def _reject_remote_unique_values(documents, specs):
             if _DECIMAL128 is not None and isinstance(value, _DECIMAL128):
                 raise TinyMongoNotSupportedError(
                     "Remote SQL unique index {0!r} does not support Decimal128 "
-                    "values; its native JSON constraint cannot guarantee "
-                    "cross-process MongoDB numeric uniqueness".format(spec.name)
+                    "values; TinyMongo cannot yet derive the same safe native "
+                    "token from Decimal128 BID data".format(spec.name)
                 )
             identity = bson_identity_key(value)
             if identity is not None and identity[0] in ("binary", "regex"):
                 raise TinyMongoNotSupportedError(
                     "Remote SQL unique index {0!r} does not support UUID, "
-                    "Binary, or regular-expression values; its native JSON "
-                    "constraint cannot guarantee cross-process BSON "
-                    "identity".format(spec.name)
+                    "Binary, or regular-expression values; its native token "
+                    "constraint cannot guarantee cross-process BSON identity".format(
+                        spec.name
+                    )
                 )
+
+
+def _remote_unique_token(document, spec):
+    """Return one fixed-width exact BSON token for a remote unique index."""
+
+    _reject_remote_unique_values([document], [spec])
+    tokens = index_tokens(document, spec.field)
+    if len(tokens) != 1:
+        # Arrays are rejected above. Keep this guard explicit so a future
+        # multikey expansion cannot silently weaken the one-column native
+        # constraint used by the remote backends.
+        raise TinyMongoNotSupportedError(
+            "Remote SQL unique index {0!r} requires exactly one scalar token "
+            "per document".format(spec.name)
+        )
+    canonical = "remote-unique-v{0}\x00{1}".format(
+        _REMOTE_UNIQUE_TOKEN_VERSION,
+        tokens[0],
+    )
+    return hashlib.sha256(canonical.encode("utf8")).hexdigest()
 
 
 def _comparison_matches(actual, operand, comparison, exact=False):
@@ -1710,8 +1732,9 @@ class TableBackend(object):
     def _coerce_index_spec(self, spec):
         return spec if isinstance(spec, IndexSpec) else parse_index_spec(spec)
 
-    def _check_index_compatibility(self, collection, spec):
-        specs = self.get_index_specs(collection)
+    def _check_index_compatibility(self, collection, spec, specs=None):
+        if specs is None:
+            specs = self.get_index_specs(collection)
         by_name = next(
             (current for current in specs if current.name == spec.name),
             None,
@@ -3315,6 +3338,12 @@ class RemoteSQLTableBackend(TableBackend):
     def _commit(self, conn):
         conn.commit()
 
+    def _rollback(self, conn):
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+
     def _close_cursor(self, cursor):
         try:
             cursor.close()
@@ -3353,32 +3382,55 @@ class RemoteSQLTableBackend(TableBackend):
             "index_name VARCHAR(255) NOT NULL, "
             "field_name VARCHAR(512) NOT NULL, "
             "unique_flag BOOLEAN NOT NULL, "
+            "token_version INTEGER NOT NULL DEFAULT 0, "
             "PRIMARY KEY (database_name, collection_name, index_name))".format(
                 self._quote(self.index_catalog_table)
             ),
         )
+        self._ensure_index_catalog_token_version(conn)
         self._commit(conn)
+
+    def _ensure_index_catalog_token_version(self, conn):
+        """Upgrade the remote index catalog in a dialect-safe way."""
+
+        raise NotImplementedError  # pragma: no cover - implemented by drivers
+
+    @contextmanager
+    def _collection_schema_lock(self, conn, collection):
+        """Serialize per-collection index DDL in the concrete database."""
+
+        yield
+
+    @contextmanager
+    def _collection_write_lock(self, conn, collection):
+        """Coordinate writes with non-transactional index DDL when required."""
+
+        yield
+
+    def _index_specs_on_connection(self, conn, collection):
+        cursor = self._execute(
+            conn,
+            "SELECT index_name, field_name, unique_flag FROM {0} "
+            "WHERE database_name = {1} AND collection_name = {1} "
+            "ORDER BY index_name".format(
+                self._quote(self.index_catalog_table), self.placeholder
+            ),
+            (self.database, collection),
+        )
+        try:
+            return [
+                IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
+                for row in cursor.fetchall()
+            ]
+        finally:
+            self._close_cursor(cursor)
 
     def get_index_specs(self, collection):
         conn = self._connect()
         try:
             self._ensure_index_catalog(conn)
-            cursor = self._execute(
-                conn,
-                "SELECT index_name, field_name, unique_flag FROM {0} "
-                "WHERE database_name = {1} AND collection_name = {1} "
-                "ORDER BY index_name".format(
-                    self._quote(self.index_catalog_table), self.placeholder
-                ),
-                (self.database, collection),
-            )
-            try:
-                return [
-                    IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
-                    for row in cursor.fetchall()
-                ]
-            finally:
-                self._close_cursor(cursor)
+            self._migrate_legacy_unique_indexes(conn, collection)
+            return self._index_specs_on_connection(conn, collection)
         finally:
             conn.close()
 
@@ -3388,6 +3440,151 @@ class RemoteSQLTableBackend(TableBackend):
         )
         digest = hashlib.sha256(identity.encode("utf8")).hexdigest()[:32]
         return "__tm_idx_{0}".format(digest)
+
+    def _unique_token_column(self, collection, spec):
+        identity = "{0}\x00{1}\x00{2}".format(
+            self.database or "default", collection, spec.name
+        )
+        digest = hashlib.sha256(identity.encode("utf8")).hexdigest()[:32]
+        return "__tm_utk_{0}".format(digest)
+
+    def _add_unique_token_column(self, conn, collection, spec):
+        raise NotImplementedError  # pragma: no cover - implemented by drivers
+
+    def _set_unique_token_not_null(self, conn, collection, spec):
+        raise NotImplementedError  # pragma: no cover - implemented by drivers
+
+    def _drop_unique_token_column(self, conn, collection, spec):
+        raise NotImplementedError  # pragma: no cover - implemented by drivers
+
+    def _drop_legacy_native_index(self, conn, collection, spec):
+        """Remove the pre-token native index during a catalog migration."""
+
+        self._drop_native_index(conn, collection, spec)
+
+    def _remove_orphan_native_index(self, conn, collection, spec):
+        """Clean an incomplete non-transactional build before retrying."""
+
+    def _cleanup_failed_native_index_creation(self, conn, collection, spec):
+        """Undo non-transactional DDL while the collection lock is held."""
+
+    def _legacy_unique_specs(self, conn, collection):
+        cursor = self._execute(
+            conn,
+            "SELECT index_name, field_name FROM {0} "
+            "WHERE database_name = {1} AND collection_name = {1} "
+            "AND unique_flag = {1} AND token_version < {1} "
+            "ORDER BY index_name".format(
+                self._quote(self.index_catalog_table), self.placeholder
+            ),
+            (
+                self.database,
+                collection,
+                True,
+                _REMOTE_UNIQUE_TOKEN_VERSION,
+            ),
+        )
+        try:
+            return [
+                IndexSpec(field=row[1], name=row[0], unique=True)
+                for row in cursor.fetchall()
+            ]
+        finally:
+            self._close_cursor(cursor)
+
+    def _stored_documents_on_connection(self, conn, collection):
+        cursor = self._execute(
+            conn,
+            "SELECT _id, data_ordered, data FROM {0}".format(
+                self._quote(self._table_name(collection))
+            ),
+        )
+        try:
+            rows = cursor.fetchall()
+        finally:
+            self._close_cursor(cursor)
+        return [
+            (
+                row[0],
+                _restore_legacy_document_id(
+                    row[0],
+                    self._decode_data_value(
+                        row[-1],
+                        ordered_data=row[1] if len(row) > 2 else None,
+                    ),
+                ),
+            )
+            for row in rows
+        ]
+
+    def _prepare_unique_token_column(self, conn, collection, spec):
+        # PostgreSQL's ADD COLUMN takes an ACCESS EXCLUSIVE lock that remains
+        # held through this transaction. Adding before the scan prevents a
+        # concurrent insert from appearing after backfill with a NULL token.
+        # MariaDB uses the named collection lock implemented below.
+        self._add_unique_token_column(conn, collection, spec)
+        stored_documents = self._stored_documents_on_connection(conn, collection)
+        documents = [document for _stored_id, document in stored_documents]
+        _reject_remote_unique_values(documents, [spec])
+        validate_unique_documents(documents, [spec])
+        if stored_documents:
+            self._executemany(
+                conn,
+                "UPDATE {0} SET {1} = {2} WHERE _id = {2}".format(
+                    self._quote(self._table_name(collection)),
+                    self._quote(self._unique_token_column(collection, spec)),
+                    self.placeholder,
+                ),
+                [
+                    (_remote_unique_token(document, spec), stored_id)
+                    for stored_id, document in stored_documents
+                ],
+            )
+        self._set_unique_token_not_null(conn, collection, spec)
+
+    def _migrate_legacy_unique_indexes(self, conn, collection):
+        # The overwhelmingly common path must not take a table/advisory lock.
+        # If a stale row is observed, acquire the database lock and then query
+        # again because another client may complete the upgrade while we wait.
+        if not self._legacy_unique_specs(conn, collection):
+            return
+        # End the optimistic read transaction before waiting. In particular,
+        # MariaDB's default repeatable-read isolation must not carry the stale
+        # catalog snapshot into the locked recheck.
+        self._commit(conn)
+        try:
+            with self._collection_schema_lock(conn, collection):
+                # Re-read after taking the database lock. Another client may
+                # have completed the migration while this one was waiting.
+                stale = self._legacy_unique_specs(conn, collection)
+                for spec in stale:
+                    self._prepare_unique_token_column(conn, collection, spec)
+                    self._drop_legacy_native_index(conn, collection, spec)
+                    self._create_native_index(conn, collection, spec)
+                    self._execute(
+                        conn,
+                        "UPDATE {0} SET token_version = {1} "
+                        "WHERE database_name = {1} AND collection_name = {1} "
+                        "AND index_name = {1}".format(
+                            self._quote(self.index_catalog_table), self.placeholder
+                        ),
+                        (
+                            _REMOTE_UNIQUE_TOKEN_VERSION,
+                            self.database,
+                            collection,
+                            spec.name,
+                        ),
+                    )
+                self._commit(conn)
+        except Exception as exc:
+            self._rollback(conn)
+            if self._is_duplicate_error(exc) or isinstance(exc, DuplicateKeyError):
+                raise DuplicateKeyError(
+                    "Cannot upgrade remote unique indexes on collection {0!r}: "
+                    "existing values conflict under exact BSON numeric "
+                    "identity".format(collection)
+                ) from exc
+            raise
 
     def _create_native_index(self, conn, collection, spec):
         raise NotImplementedError  # pragma: no cover - implemented by drivers
@@ -3462,6 +3659,8 @@ class RemoteSQLTableBackend(TableBackend):
             needs_ordered_data = collection not in self._ordered_data_collections
             if needs_ordered_data:
                 self._ensure_ordered_data_column(conn, collection, table)
+            self._ensure_index_catalog(conn)
+            self._migrate_legacy_unique_indexes(conn, collection)
             self._record_collection(conn, collection)
             self._commit(conn)
             if needs_ordered_data:
@@ -3514,20 +3713,47 @@ class RemoteSQLTableBackend(TableBackend):
         current = self._all_docs_unfiltered(collection)
         self.validate_unique_post_image(collection, current + docs)
         _validate_physical_ids(current, docs)
-        rows = [(_physical_id_key(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
-            self._insert_rows(conn, collection, rows, bypass_document_validation)
-            self._commit(conn)
+            with self._collection_write_lock(conn, collection):
+                unique_specs = tuple(
+                    spec
+                    for spec in self._index_specs_on_connection(conn, collection)
+                    if spec.unique
+                )
+                rows = [
+                    (
+                        _physical_id_key(doc["_id"]),
+                        _json_dumps(doc),
+                        tuple(_remote_unique_token(doc, spec) for spec in unique_specs),
+                    )
+                    for doc in docs
+                ]
+                self._insert_rows(
+                    conn,
+                    collection,
+                    rows,
+                    unique_specs,
+                    bypass_document_validation,
+                )
+                self._commit(conn)
             return list(range(len(rows)))
         except Exception as exc:
+            self._rollback(conn)
             if self._is_duplicate_error(exc):
                 raise DuplicateKeyError(str(exc))
             raise
         finally:
             conn.close()
 
-    def _insert_rows(self, conn, collection, rows, bypass_document_validation):
+    def _insert_rows(
+        self,
+        conn,
+        collection,
+        rows,
+        unique_specs,
+        bypass_document_validation,
+    ):
         raise NotImplementedError  # pragma: no cover - implemented by drivers
 
     def _data_placeholder(self):
@@ -3670,22 +3896,40 @@ class RemoteSQLTableBackend(TableBackend):
         conn = self._connect()
         try:
             try:
-                self._execute(
-                    conn,
-                    "UPDATE {0} SET data = {1}, data_ordered = {2} "
-                    "WHERE _id = {2}".format(
-                        self._quote(self._table_name(collection)),
-                        self._data_placeholder(),
-                        self.placeholder,
-                    ),
-                    (
-                        _json_dumps(replacement),
-                        _json_dumps(replacement),
-                        stored_id,
-                    ),
-                )
-                self._commit(conn)
+                with self._collection_write_lock(conn, collection):
+                    unique_specs = tuple(
+                        spec
+                        for spec in self._index_specs_on_connection(conn, collection)
+                        if spec.unique
+                    )
+                    token_assignments = "".join(
+                        ", {0} = {1}".format(
+                            self._quote(self._unique_token_column(collection, spec)),
+                            self.placeholder,
+                        )
+                        for spec in unique_specs
+                    )
+                    self._execute(
+                        conn,
+                        "UPDATE {0} SET data = {1}, data_ordered = {2}{3} "
+                        "WHERE _id = {2}".format(
+                            self._quote(self._table_name(collection)),
+                            self._data_placeholder(),
+                            self.placeholder,
+                            token_assignments,
+                        ),
+                        tuple(
+                            [_json_dumps(replacement), _json_dumps(replacement)]
+                            + [
+                                _remote_unique_token(replacement, spec)
+                                for spec in unique_specs
+                            ]
+                            + [stored_id]
+                        ),
+                    )
+                    self._commit(conn)
             except Exception as exc:
+                self._rollback(conn)
                 if self._is_duplicate_error(exc):
                     raise DuplicateKeyError(str(exc))
                 raise
@@ -3699,14 +3943,18 @@ class RemoteSQLTableBackend(TableBackend):
         stored_ids = [self._stored_row_by_id(collection, doc_id)[0] for doc_id in ids]
         conn = self._connect()
         try:
-            self._executemany(
-                conn,
-                "DELETE FROM {0} WHERE _id = {1}".format(
-                    self._quote(self._table_name(collection)), self.placeholder
-                ),
-                [(stored_id,) for stored_id in stored_ids if stored_id is not None],
-            )
-            self._commit(conn)
+            with self._collection_write_lock(conn, collection):
+                self._executemany(
+                    conn,
+                    "DELETE FROM {0} WHERE _id = {1}".format(
+                        self._quote(self._table_name(collection)), self.placeholder
+                    ),
+                    [(stored_id,) for stored_id in stored_ids if stored_id is not None],
+                )
+                self._commit(conn)
+        except Exception:
+            self._rollback(conn)
+            raise
         finally:
             conn.close()
 
@@ -3716,26 +3964,55 @@ class RemoteSQLTableBackend(TableBackend):
         existing = self._check_index_compatibility(collection, spec)
         if existing is not None:
             return existing.name
-        if spec.unique:
-            documents = self.find(collection, {})
-            _reject_remote_unique_values(documents, [spec])
-            validate_unique_documents(documents, [spec])
 
         conn = self._connect()
         try:
             self._ensure_index_catalog(conn)
-            self._create_native_index(conn, collection, spec)
-            self._execute(
-                conn,
-                "INSERT INTO {0} "
-                "(database_name, collection_name, index_name, field_name, unique_flag) "
-                "VALUES ({1}, {1}, {1}, {1}, {1})".format(
-                    self._quote(self.index_catalog_table), self.placeholder
-                ),
-                (self.database, collection, spec.name, spec.field, spec.unique),
-            )
-            self._commit(conn)
+            with self._collection_schema_lock(conn, collection):
+                # The optimistic check above avoids DDL for ordinary retries;
+                # this locked recheck closes the cross-client creation race.
+                existing = self._check_index_compatibility(
+                    collection,
+                    spec,
+                    specs=self._index_specs_on_connection(conn, collection),
+                )
+                if existing is not None:
+                    return existing.name
+                self._remove_orphan_native_index(conn, collection, spec)
+                try:
+                    if spec.unique:
+                        self._prepare_unique_token_column(conn, collection, spec)
+                    self._create_native_index(conn, collection, spec)
+                    self._execute(
+                        conn,
+                        "INSERT INTO {0} "
+                        "(database_name, collection_name, index_name, field_name, "
+                        "unique_flag, token_version) "
+                        "VALUES ({1}, {1}, {1}, {1}, {1}, {1})".format(
+                            self._quote(self.index_catalog_table), self.placeholder
+                        ),
+                        (
+                            self.database,
+                            collection,
+                            spec.name,
+                            spec.field,
+                            spec.unique,
+                            _REMOTE_UNIQUE_TOKEN_VERSION if spec.unique else 0,
+                        ),
+                    )
+                    self._commit(conn)
+                except Exception:
+                    self._rollback(conn)
+                    try:
+                        self._cleanup_failed_native_index_creation(
+                            conn, collection, spec
+                        )
+                        self._commit(conn)
+                    except Exception:
+                        self._rollback(conn)
+                    raise
         except Exception as exc:
+            self._rollback(conn)
             if spec.unique and self._is_duplicate_error(exc):
                 raise DuplicateKeyError(str(exc))
             raise
@@ -3758,16 +4035,20 @@ class RemoteSQLTableBackend(TableBackend):
         conn = self._connect()
         try:
             self._ensure_index_catalog(conn)
-            self._drop_native_index(conn, collection, spec)
-            self._execute(
-                conn,
-                "DELETE FROM {0} WHERE database_name = {1} "
-                "AND collection_name = {1} AND index_name = {1}".format(
-                    self._quote(self.index_catalog_table), self.placeholder
-                ),
-                (self.database, collection, spec.name),
-            )
-            self._commit(conn)
+            with self._collection_schema_lock(conn, collection):
+                self._drop_native_index(conn, collection, spec)
+                self._execute(
+                    conn,
+                    "DELETE FROM {0} WHERE database_name = {1} "
+                    "AND collection_name = {1} AND index_name = {1}".format(
+                        self._quote(self.index_catalog_table), self.placeholder
+                    ),
+                    (self.database, collection, spec.name),
+                )
+                self._commit(conn)
+        except Exception:
+            self._rollback(conn)
+            raise
         finally:
             conn.close()
 
@@ -3797,16 +4078,99 @@ class PostgresTableBackend(RemoteSQLTableBackend):
     def _data_placeholder(self):
         return self.placeholder + "::jsonb"
 
-    def _create_native_index(self, conn, collection, spec):
-        path = ", ".join(_sql_literal(part) for part in spec.field.split("."))
-        expression = "COALESCE(jsonb_extract_path(data, {0}), 'null'::jsonb)".format(
-            path
+    @contextmanager
+    def _collection_schema_lock(self, conn, collection):
+        cursor = self._execute(
+            conn,
+            "LOCK TABLE {0} IN ACCESS EXCLUSIVE MODE".format(
+                self._quote(self._table_name(collection))
+            ),
         )
-        # JSONB equality is type-aware and normalizes equivalent numbers. Arrays
-        # are indexed whole; Python validation supplies Mongo-like multikey fan-out.
+        self._close_cursor(cursor)
+        yield
+
+    @contextmanager
+    def _collection_write_lock(self, conn, collection):
+        # ROW EXCLUSIVE locks are compatible with one another, so writers stay
+        # concurrent while schema changes wait for (or precede) the write.
+        cursor = self._execute(
+            conn,
+            "LOCK TABLE {0} IN ROW EXCLUSIVE MODE".format(
+                self._quote(self._table_name(collection))
+            ),
+        )
+        self._close_cursor(cursor)
+        yield
+
+    def _ensure_index_catalog_token_version(self, conn):
+        cursor = self._execute(
+            conn,
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = {0} "
+            "AND column_name = 'token_version' LIMIT 1".format(self.placeholder),
+            (self.index_catalog_table,),
+        )
+        try:
+            exists = cursor.fetchone() is not None
+        finally:
+            self._close_cursor(cursor)
+        if exists:
+            return
         self._execute(
             conn,
-            "CREATE {0}INDEX {1} ON {2} (({3}))".format(
+            "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS "
+            "token_version INTEGER NOT NULL DEFAULT 0".format(
+                self._quote(self.index_catalog_table)
+            ),
+        )
+
+    def _add_unique_token_column(self, conn, collection, spec):
+        self._execute(
+            conn,
+            "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS {1} VARCHAR(64)".format(
+                self._quote(self._table_name(collection)),
+                self._quote(self._unique_token_column(collection, spec)),
+            ),
+        )
+
+    def _set_unique_token_not_null(self, conn, collection, spec):
+        self._execute(
+            conn,
+            "ALTER TABLE {0} ALTER COLUMN {1} SET NOT NULL".format(
+                self._quote(self._table_name(collection)),
+                self._quote(self._unique_token_column(collection, spec)),
+            ),
+        )
+
+    def _drop_unique_token_column(self, conn, collection, spec):
+        self._execute(
+            conn,
+            "ALTER TABLE {0} DROP COLUMN IF EXISTS {1}".format(
+                self._quote(self._table_name(collection)),
+                self._quote(self._unique_token_column(collection, spec)),
+            ),
+        )
+
+    def _drop_legacy_native_index(self, conn, collection, spec):
+        self._execute(
+            conn,
+            "DROP INDEX IF EXISTS {0}".format(
+                self._quote(self._physical_index_name(collection, spec))
+            ),
+        )
+
+    def _create_native_index(self, conn, collection, spec):
+        if spec.unique:
+            expression = self._quote(self._unique_token_column(collection, spec))
+        else:
+            path = ", ".join(_sql_literal(part) for part in spec.field.split("."))
+            expression = (
+                "(COALESCE(jsonb_extract_path(data, {0}), "
+                "'null'::jsonb))".format(path)
+            )
+        self._execute(
+            conn,
+            "CREATE {0}INDEX {1} ON {2} ({3})".format(
                 "UNIQUE " if spec.unique else "",
                 self._quote(self._physical_index_name(collection, spec)),
                 self._quote(self._table_name(collection)),
@@ -3821,6 +4185,8 @@ class PostgresTableBackend(RemoteSQLTableBackend):
                 self._quote(self._physical_index_name(collection, spec))
             ),
         )
+        if spec.unique:
+            self._drop_unique_token_column(conn, collection, spec)
 
     def _insert_metadata(self, conn, collection):
         self._execute(
@@ -3832,18 +4198,37 @@ class PostgresTableBackend(RemoteSQLTableBackend):
             (self.database, collection),
         )
 
-    def _insert_rows(self, conn, collection, rows, bypass_document_validation):
+    def _insert_rows(
+        self,
+        conn,
+        collection,
+        rows,
+        unique_specs,
+        bypass_document_validation,
+    ):
+        token_columns = "".join(
+            ", {0}".format(self._quote(self._unique_token_column(collection, spec)))
+            for spec in unique_specs
+        )
+        token_placeholders = "".join(
+            ", {0}".format(self.placeholder) for _ in unique_specs
+        )
         sql = (
-            "INSERT INTO {0} (_id, data, data_ordered) " "VALUES ({1}, {2}, {1})"
+            "INSERT INTO {0} (_id, data, data_ordered{1}) " "VALUES ({2}, {3}, {2}{4})"
         ).format(
             self._quote(self._table_name(collection)),
+            token_columns,
             self.placeholder,
             self._data_placeholder(),
+            token_placeholders,
         )
         self._executemany(
             conn,
             sql,
-            [(doc_id, data, data) for doc_id, data in rows],
+            [
+                tuple([doc_id, data, data] + list(tokens))
+                for doc_id, data, tokens in rows
+            ],
         )
 
 
@@ -3885,8 +4270,131 @@ class MySQLTableBackend(RemoteSQLTableBackend):
             return self.pymysql.connect(**kwargs)
         return self.pymysql.connect(host=self.dsn)
 
+    def _collection_lock_name(self, collection):
+        identity = "{0}\x00{1}".format(self.database or "default", collection)
+        return "tinymongo:{0}".format(
+            hashlib.sha256(identity.encode("utf8")).hexdigest()[:48]
+        )
+
+    @contextmanager
+    def _mysql_collection_lock(self, conn, collection):
+        name = self._collection_lock_name(collection)
+        cursor = self._execute(
+            conn,
+            "SELECT GET_LOCK({0}, {0})".format(self.placeholder),
+            (name, 60),
+        )
+        try:
+            row = cursor.fetchone()
+        finally:
+            self._close_cursor(cursor)
+        if row is None or row[0] != 1:
+            raise OperationFailure(
+                "Timed out waiting for the remote SQL collection lock"
+            )
+        try:
+            yield
+        finally:
+            try:
+                cursor = self._execute(
+                    conn,
+                    "SELECT RELEASE_LOCK({0})".format(self.placeholder),
+                    (name,),
+                )
+                self._close_cursor(cursor)
+            except Exception:
+                # Closing the connection also releases named locks. Preserve
+                # the operation's original exception if the connection broke.
+                pass
+
+    def _collection_schema_lock(self, conn, collection):
+        return self._mysql_collection_lock(conn, collection)
+
+    def _collection_write_lock(self, conn, collection):
+        return self._mysql_collection_lock(conn, collection)
+
+    def _mysql_column_exists(self, conn, table, column):
+        cursor = self._execute(
+            conn,
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = {0} "
+            "AND column_name = {0} LIMIT 1".format(self.placeholder),
+            (table, column),
+        )
+        try:
+            return cursor.fetchone() is not None
+        finally:
+            self._close_cursor(cursor)
+
+    def _mysql_index_exists(self, conn, table, index):
+        cursor = self._execute(
+            conn,
+            "SELECT 1 FROM information_schema.statistics "
+            "WHERE table_schema = DATABASE() AND table_name = {0} "
+            "AND index_name = {0} LIMIT 1".format(self.placeholder),
+            (table, index),
+        )
+        try:
+            return cursor.fetchone() is not None
+        finally:
+            self._close_cursor(cursor)
+
+    def _ensure_index_catalog_token_version(self, conn):
+        if self._mysql_column_exists(conn, self.index_catalog_table, "token_version"):
+            return
+        try:
+            self._execute(
+                conn,
+                "ALTER TABLE {0} ADD COLUMN token_version INTEGER "
+                "NOT NULL DEFAULT 0".format(self._quote(self.index_catalog_table)),
+            )
+        except Exception as exc:
+            code = exc.args[0] if getattr(exc, "args", ()) else None
+            if code != 1060 and "duplicate column" not in str(exc).lower():
+                raise
+
     def _generated_index_column(self, collection, spec):
         return self._physical_index_name(collection, spec).replace("_idx_", "_key_")
+
+    def _add_unique_token_column(self, conn, collection, spec):
+        table_name = self._table_name(collection)
+        column_name = self._unique_token_column(collection, spec)
+        if self._mysql_column_exists(conn, table_name, column_name):
+            return
+        try:
+            self._execute(
+                conn,
+                "ALTER TABLE {0} ADD COLUMN {1} CHAR(64) "
+                "CHARACTER SET ascii COLLATE ascii_bin NULL".format(
+                    self._quote(table_name), self._quote(column_name)
+                ),
+            )
+        except Exception as exc:
+            code = exc.args[0] if getattr(exc, "args", ()) else None
+            if code != 1060 and "duplicate column" not in str(exc).lower():
+                raise
+
+    def _set_unique_token_not_null(self, conn, collection, spec):
+        self._execute(
+            conn,
+            "ALTER TABLE {0} MODIFY COLUMN {1} CHAR(64) "
+            "CHARACTER SET ascii COLLATE ascii_bin NOT NULL".format(
+                self._quote(self._table_name(collection)),
+                self._quote(self._unique_token_column(collection, spec)),
+            ),
+        )
+
+    def _drop_unique_token_column(self, conn, collection, spec):
+        table_name = self._table_name(collection)
+        column_name = self._unique_token_column(collection, spec)
+        if not self._mysql_column_exists(conn, table_name, column_name):
+            return
+        self._execute(
+            conn,
+            "ALTER TABLE {0} DROP COLUMN {1}".format(
+                self._quote(table_name), self._quote(column_name)
+            ),
+        )
 
     def _ensure_ordered_data_column(self, conn, collection, table):
         # MySQL 8 does not accept ADD COLUMN IF NOT EXISTS. Querying the active
@@ -3918,6 +4426,16 @@ class MySQLTableBackend(RemoteSQLTableBackend):
                 raise
 
     def _create_native_index(self, conn, collection, spec):
+        if spec.unique:
+            self._execute(
+                conn,
+                "CREATE UNIQUE INDEX {0} ON {1} ({2})".format(
+                    self._quote(self._physical_index_name(collection, spec)),
+                    self._quote(self._table_name(collection)),
+                    self._quote(self._unique_token_column(collection, spec)),
+                ),
+            )
+            return
         json_path = "$" + "".join(
             "." + json.dumps(part, ensure_ascii=False) for part in spec.field.split(".")
         )
@@ -3957,19 +4475,42 @@ class MySQLTableBackend(RemoteSQLTableBackend):
         )
 
     def _drop_native_index(self, conn, collection, spec):
-        table = self._quote(self._table_name(collection))
-        self._execute(
-            conn,
-            "DROP INDEX {0} ON {1}".format(
-                self._quote(self._physical_index_name(collection, spec)), table
-            ),
-        )
-        self._execute(
-            conn,
-            "ALTER TABLE {0} DROP COLUMN {1}".format(
-                table, self._quote(self._generated_index_column(collection, spec))
-            ),
-        )
+        table_name = self._table_name(collection)
+        physical_name = self._physical_index_name(collection, spec)
+        table = self._quote(table_name)
+        if self._mysql_index_exists(conn, table_name, physical_name):
+            self._execute(
+                conn,
+                "DROP INDEX {0} ON {1}".format(self._quote(physical_name), table),
+            )
+        if spec.unique:
+            self._drop_unique_token_column(conn, collection, spec)
+            return
+        generated = self._generated_index_column(collection, spec)
+        if self._mysql_column_exists(conn, table_name, generated):
+            self._execute(
+                conn,
+                "ALTER TABLE {0} DROP COLUMN {1}".format(table, self._quote(generated)),
+            )
+
+    def _drop_legacy_native_index(self, conn, collection, spec):
+        table_name = self._table_name(collection)
+        physical_name = self._physical_index_name(collection, spec)
+        table = self._quote(table_name)
+        generated = self._generated_index_column(collection, spec)
+        clauses = []
+        if self._mysql_index_exists(conn, table_name, physical_name):
+            clauses.append("DROP INDEX {0}".format(self._quote(physical_name)))
+        if self._mysql_column_exists(conn, table_name, generated):
+            clauses.append("DROP COLUMN {0}".format(self._quote(generated)))
+        if clauses:
+            self._execute(conn, "ALTER TABLE {0} {1}".format(table, ", ".join(clauses)))
+
+    def _remove_orphan_native_index(self, conn, collection, spec):
+        self._drop_native_index(conn, collection, spec)
+
+    def _cleanup_failed_native_index_creation(self, conn, collection, spec):
+        self._drop_native_index(conn, collection, spec)
 
     def _insert_metadata(self, conn, collection):
         self._execute(
@@ -3981,12 +4522,34 @@ class MySQLTableBackend(RemoteSQLTableBackend):
             (self.database, collection),
         )
 
-    def _insert_rows(self, conn, collection, rows, bypass_document_validation):
+    def _insert_rows(
+        self,
+        conn,
+        collection,
+        rows,
+        unique_specs,
+        bypass_document_validation,
+    ):
+        token_columns = "".join(
+            ", {0}".format(self._quote(self._unique_token_column(collection, spec)))
+            for spec in unique_specs
+        )
+        token_placeholders = "".join(
+            ", {0}".format(self.placeholder) for _ in unique_specs
+        )
         sql = (
-            "INSERT INTO {0} (_id, data, data_ordered) " "VALUES ({1}, {1}, {1})"
-        ).format(self._quote(self._table_name(collection)), self.placeholder)
+            "INSERT INTO {0} (_id, data, data_ordered{1}) " "VALUES ({2}, {2}, {2}{3})"
+        ).format(
+            self._quote(self._table_name(collection)),
+            token_columns,
+            self.placeholder,
+            token_placeholders,
+        )
         self._executemany(
             conn,
             sql,
-            [(doc_id, data, data) for doc_id, data in rows],
+            [
+                tuple([doc_id, data, data] + list(tokens))
+                for doc_id, data, tokens in rows
+            ],
         )


### PR DESCRIPTION
## Summary

This PR makes remote PostgreSQL and MariaDB/MySQL unique indexes enforce TinyMongo's exact BSON numeric equality rules across processes.

- Materializes one private, fixed-width token column per remote unique index.
- Derives each token from TinyMongo's canonical BSON scalar identity instead of a SQL numeric cast.
- Preserves MongoDB-equivalent int/float duplicates while keeping booleans distinct from numbers.
- Updates insert, replace, and update statements to write document data and every affected uniqueness token together.
- Lazily upgrades legacy remote unique indexes under database-level coordination.
- Keeps Decimal128, arrays, UUID/Binary, and regex values fail-closed where a safe one-column native constraint is not yet available.

The branch is current with `master`, including PR #155.

## Why

The original remote unique indexes depended on each SQL engine's JSON/numeric normalization. That cannot represent Python/BSON numeric identity exactly at every boundary:

- `int(1e23)` and `1e23` are BSON-equivalent and must conflict, but a database expression can miss that duplicate.
- `10**23` and `1e23` are BSON-distinct and must both be allowed, but decimal normalization can collapse them.
- `True` and `1` compare equal in Python but are distinct BSON types.
- An application-level preflight cannot close the race between two independent writers.

The database therefore needs a native constraint over a value generated from the same lossless identity TinyMongo uses in Python.

## Design

### Canonical token

Each unique index gets a private 64-character token column. TinyMongo:

1. obtains the single scalar identity from the shared `index_tokens()` implementation;
2. namespaces it with the remote token version;
3. stores its SHA-256 digest; and
4. protects that column with a native unique index.

The fixed-width digest avoids sending large integers through a lossy SQL numeric type and gives PostgreSQL and MariaDB/MySQL the same comparison input.

### Write behavior

- Inserts calculate tokens for every current unique index and send them with the row.
- Replacements and updates refresh all corresponding tokens in the same database statement.
- Native constraints arbitrate concurrent writers, and duplicate native errors remain `DuplicateKeyError(code=11000)`.
- Unique index creation rechecks the catalog while holding the schema lock so two clients cannot create conflicting metadata or native indexes.
- Partial non-transactional DDL is cleaned up before a retry.

### Legacy migration

The remote index catalog now records `token_version`. When an old unique index is first used, TinyMongo:

1. detects the stale catalog row without taking the expensive lock on the normal path;
2. acquires the collection schema lock and rechecks the catalog;
3. adds the token column;
4. scans and validates existing values under current BSON equality rules;
5. backfills tokens and makes the column non-null;
6. swaps the legacy native index for the token index; and
7. advances the catalog version only after success.

PostgreSQL uses table locks inside the DDL transaction. MariaDB/MySQL uses a per-collection named lock because its DDL commits implicitly. Writers use the corresponding collection lock during a MySQL schema change.

If legacy data contains values that conflict under exact BSON identity, migration raises `DuplicateKeyError`, leaves the documents intact, and does not advance `token_version`, so later attempts continue to fail closed.

## Compatibility and limits

- Existing non-unique remote indexes keep their JSON expression behavior.
- Existing remote unique indexes upgrade lazily; no separate migration command is required.
- The database account needs permission to alter tables and create/drop indexes.
- Older and newer TinyMongo writers should not be mixed during the schema upgrade.
- Arrays and Decimal128 remain unsupported under remote unique indexes until safe native multikey and BID-derived tokens are available.
- UUID/Binary and regex values also continue to fail closed rather than claim unsafe cross-process enforcement.

The README, remote SQL guide, migration guide, changelog, and roadmap document the new layout and upgrade requirements.

## Validation

Full local unit and contract suite after merging current `master`:

```text
2768 passed, 389 deselected
```

Branch coverage:

```text
7191 statements, 0 missed
2942 branches, 0 partial
100% total coverage
```

Additional checks:

- `ruff check tinymongo tests`
- `black --check tinymongo tests`
- `git diff --check`

The test suite includes fake-driver coverage for PostgreSQL and MySQL DDL, locked rechecks, catalog upgrades, failed-build cleanup, write token refresh, and migration retries. Opt-in live tests cover both PostgreSQL and MariaDB for numeric edge pairs, concurrent duplicate races, durable/concurrent legacy migration, and Decimal128 fail-closed behavior; those live tests run in the repository's remote-SQL CI jobs.
