### PR TITLE
Fix TM-026 through TM-029 compatibility gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@
 - **TM-025:** `$not` now rejects bare scalars, lists, and empty documents with
   `OperationFailure` code `2`, while continuing to accept non-empty query
   documents and compiled native or BSON regexes.
+- **TM-026:** PyMongo-shaped synchronous and asynchronous clients now reject
+  unknown or misspelled connection kwargs with `ConfigurationError` before
+  opening storage, while continuing to accept recognized PyMongo options.
+- **TM-027:** Same-name index conflicts now consistently report MongoDB error
+  code `86`; same-key specifications requested under another name retain code
+  `85`.
+- **TM-028:** Combining `$options` with flags embedded in a native or BSON regex
+  now reports MongoDB error code `51075`.
+- **TM-029:** `$comment` is now accepted and ignored inside document-form
+  `$elemMatch` filters, while field-operator use raises `OperationFailure` code
+  `2`.
 - Aggregation field references no longer cross a raw array nested directly
   inside another array before reaching the requested field.
 - Aggregation projections preserve source BSON field order for retained fields

--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ rows = list(users.find({}).sort("score", pymongo.DESCENDING))
 
 This is intended for the supported TinyMongo subset of PyMongo operations, not
 for server features such as authentication, replica sets, sessions, or network
-connections. MongoDB URIs, host names, ports, and common connection kwargs are
-accepted and ignored so existing code can be tried locally.
+connections. MongoDB URIs, host names, ports, and recognized PyMongo connection
+kwargs are accepted and ignored so existing code can be tried locally. Unknown
+or misspelled kwargs fail eagerly with `ConfigurationError`, matching PyMongo's
+configuration behavior instead of silently selecting the wrong local storage.
 Set `TINYMONGO_HOME` or pass `tinymongo_folder=` to choose where TinyMongo stores
 files. See `examples/pymongo_dropin.py` for a runnable example.
 
@@ -195,6 +197,10 @@ You can select another backend with the `backend` argument:
 keywords raise `TypeError` instead of being silently ignored. The other
 supported backend configuration keywords are `threads`, `storage_uri`,
 `duckdb_config`, and `dsn`.
+
+The PyMongo-shaped `MongoClient` and `AsyncMongoClient` accept recognized
+PyMongo connection kwargs for drop-in use and ignore their network effects.
+Unknown or misspelled kwargs raise `ConfigurationError` before storage opens.
 
 Parquet can also store collection files in object storage by passing
 `storage_uri` or setting `TINYMONGO_STORAGE_URI`. Object-storage Parquet is
@@ -425,11 +431,13 @@ Query support includes equality (including scalar matches against array
 members), nested document paths, `$gt`, `$gte`, `$lt`, `$lte`, `$ne`,
 `$nin`, `$in`, `$all`, `$and`, `$or`, `$nor`, `$not`, `$regex`,
 case-insensitive `$options`, `$exists`, `$size`, `$elemMatch`, `$type`, and
-`$mod`. Top-level `$comment` metadata is accepted and ignored while matching.
-`$size` matches an exact array length, while `$elemMatch` requires one array
-member to satisfy the complete nested condition. `$type` accepts MongoDB type
-names, numeric codes, or a list of either; `$mod` follows MongoDB's
-integer-truncation and array-member matching rules.
+`$mod`. `$comment` metadata is accepted and ignored at the top level and inside
+document-form `$elemMatch` filters; using `$comment` as a field operator raises
+`OperationFailure` with MongoDB error code `2`. `$size` matches an exact array
+length, while `$elemMatch` requires one array member to satisfy the complete
+nested condition. `$type` accepts MongoDB type names, numeric codes, or a list
+of either; `$mod` follows MongoDB's integer-truncation and array-member matching
+rules.
 
 Every CRUD method that accepts a filter validates it before reading or changing
 storage. Unsupported or misspelled `$`-prefixed query operators raise

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,7 +105,9 @@ with the follow-up audit of his
   sync and async regressions verify that `find_one({})` and
   `find({}).limit(1)` decode one row, `count_documents({})` decodes none, and
   sorted cursors still consider the complete candidate set.
-  - [ ] Rerun Mike's private 559-transcript acceptance case after merge.
+  - [x] Mike's private 559-transcript rerun remained bounded on both clients:
+    `find_one({})` peaked near 0.1 MB and `count_documents({})` near 0.0 MB,
+    with the correct count of 559.
 - [x] **TM-001:** When a degraded index resolves to an effective key
   specification that already exists, warn once and skip the duplicate native
   index instead of creating redundant metadata or storage work.
@@ -142,6 +144,18 @@ with the follow-up audit of his
 - [x] **TM-025:** Reject bare scalar, list, and empty-document `$not` operands
   with `OperationFailure` code `2` while retaining non-empty query-document and
   compiled-regex forms.
+
+#### Mike's [TM-026 through TM-029 follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5159109461)
+
+- [x] **TM-026:** Reject unknown or misspelled PyMongo-shaped connection kwargs
+  on synchronous and asynchronous `MongoClient` with `ConfigurationError`,
+  while retaining recognized connection options for drop-in use.
+- [x] **TM-027:** Report code `86` for every same-name index conflict while
+  preserving code `85` for the same key specification under a different name.
+- [x] **TM-028:** Report code `51075` when `$options` is combined with flags
+  already embedded in a native or BSON regex.
+- [x] **TM-029:** Accept and ignore `$comment` in document-form `$elemMatch`
+  filters, and reject it as a field operator with `OperationFailure` code `2`.
 
 - [x] **Remote SQL numeric uniqueness:** Persist versioned, fixed-width digests
   of canonical BSON scalar tokens for PostgreSQL and MariaDB/MySQL unique

--- a/tests/contracts/test_query_operator_contract.py
+++ b/tests/contracts/test_query_operator_contract.py
@@ -479,6 +479,133 @@ def test_comment_is_accepted_and_ignored_while_matching(contract_target):
     ]
 
 
+def test_comment_inside_document_elem_match_is_accepted(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "scalars", "tags": ["a", "b"]},
+            {"_id": "documents", "tags": [{"kind": "match"}]},
+            {"_id": "nested-array", "tags": [["nested"]]},
+            {"_id": "empty", "tags": []},
+        ]
+    )
+
+    assert _ids(collection.find({"tags": {"$elemMatch": {"$comment": "context"}}})) == [
+        "documents",
+        "nested-array",
+    ]
+    assert _ids(
+        collection.find(
+            {
+                "tags": {
+                    "$elemMatch": {
+                        "kind": "match",
+                        "$comment": "context",
+                    }
+                }
+            }
+        )
+    ) == ["documents"]
+    assert _ids(
+        collection.aggregate(
+            [{"$match": {"tags": {"$elemMatch": {"$comment": "context"}}}}]
+        )
+    ) == ["documents", "nested-array"]
+    assert _ids(
+        collection.find(
+            {
+                "tags": {
+                    "$all": [
+                        {"$elemMatch": {"$comment": "context"}},
+                    ]
+                }
+            }
+        )
+    ) == ["documents", "nested-array"]
+
+
+def test_comment_remains_invalid_as_a_field_operator(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "original", "value": 1}
+    collection.insert_one(original)
+
+    operations = (
+        "find",
+        "find_one",
+        "count_documents",
+        "distinct",
+        "update_one",
+        "update_many",
+        "replace_one",
+        "delete_one",
+        "delete_many",
+        "find_one_and_update",
+        "find_one_and_replace",
+        "find_one_and_delete",
+    )
+    for operation in operations:
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            _run_filter_operation(
+                collection,
+                operation,
+                {"value": {"$comment": "context"}},
+            )
+        assert caught.value.code == 2
+        assert collection.find_one({"_id": "original"}) == original
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(
+            collection.find(
+                {
+                    "value": {
+                        "$elemMatch": {
+                            "$gt": 0,
+                            "$comment": "context",
+                        }
+                    }
+                }
+            )
+        )
+    assert caught.value.code == 2
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(collection.aggregate([{"$match": {"value": {"$comment": "context"}}}]))
+    assert caught.value.code == 2
+
+
+def test_embedded_regex_flags_and_options_report_code_51075(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "text", "value": "text"})
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(
+            collection.find(
+                {
+                    "value": {
+                        "$regex": re.compile("te", re.IGNORECASE),
+                        "$options": "i",
+                    }
+                }
+            )
+        )
+    assert caught.value.code == 51075
+
+
+def test_index_name_and_key_conflict_codes_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.create_index("value", name="ix")
+
+    conflicts = (
+        ("value", {"name": "ix", "unique": True}, 86),
+        ("other", {"name": "ix"}, 86),
+        ("value", {"name": "other_ix"}, 85),
+    )
+    for key, options, code in conflicts:
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            collection.create_index(key, **options)
+        assert caught.value.code == code
+
+
 @pytest.mark.parametrize("operand", ["text", 7, ["text"], {}, {"literal": 1}])
 def test_not_rejects_non_regex_and_empty_operands_with_code_2(
     contract_target,

--- a/tests/test_client_configuration.py
+++ b/tests/test_client_configuration.py
@@ -2,7 +2,13 @@ import asyncio
 
 import pytest
 
-from tinymongo import AsyncMongoClient, AsyncTinyMongoClient, TinyMongoClient
+from tinymongo import (
+    AsyncMongoClient,
+    AsyncTinyMongoClient,
+    MongoClient,
+    TinyMongoClient,
+)
+from tinymongo.errors import ConfigurationError
 
 
 def test_tiny_client_honors_tinymongo_folder_alias(tmp_path, monkeypatch):
@@ -58,6 +64,44 @@ def test_tiny_clients_reject_unexpected_options(client_class):
         TypeError, match="unexpected keyword argument 'tinymongo_fodler'"
     ):
         client_class(tinymongo_fodler="misspelled")
+
+
+@pytest.mark.parametrize("client_class", [MongoClient, AsyncMongoClient])
+def test_pymongo_shaped_clients_reject_unknown_options_immediately(
+    tmp_path,
+    monkeypatch,
+    client_class,
+):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ConfigurationError, match="Unknown option: tinymongo_fodler"):
+        client_class(tinymongo_fodler=str(tmp_path / "configured"))
+
+    assert not (tmp_path / "configured").exists()
+    assert not (tmp_path / "tinydb").exists()
+
+
+@pytest.mark.parametrize("client_class", [MongoClient, AsyncMongoClient])
+def test_pymongo_shaped_clients_keep_recognized_connection_options(
+    tmp_path,
+    client_class,
+):
+    client = client_class(
+        "mongodb://localhost:27017",
+        tinymongo_folder=str(tmp_path / "configured"),
+        serverSelectionTimeoutMS=50,
+        connectTimeoutMS=50,
+        retryWrites=False,
+        appName="tinymongo-tests",
+        event_listeners=[],
+        server_selector=lambda servers: servers,
+        server_api=None,
+    )
+
+    if client_class is AsyncMongoClient:
+        asyncio.run(client.close())
+    else:
+        client.close()
 
 
 @pytest.mark.parametrize("client_class", [TinyMongoClient, AsyncTinyMongoClient])

--- a/tests/test_durable_indexes.py
+++ b/tests/test_durable_indexes.py
@@ -377,7 +377,7 @@ def test_index_creation_is_idempotent_and_rejects_conflicts(
         OperationFailure, match="different options"
     ) as different_options:
         users.create_index("email", name="login_email", unique=False)
-    assert different_options.value.code == 85
+    assert different_options.value.code == 86
 
     assert set(_indexes_by_name(users)) == {"_id_", "login_email"}
 

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -1477,7 +1477,7 @@ def test_remote_unique_creation_preflights_and_drop_cleans_catalog(monkeypatch):
     backend.create_index("users", parse_index_spec("email"))
     with pytest.raises(OperationFailure, match="different options") as conflict:
         backend.create_index("users", parse_index_spec("email", unique=True))
-    assert conflict.value.code == 85
+    assert conflict.value.code == 86
     assert backend.drop_collection("users") is True
     assert not store.indexes
 

--- a/tests/test_uuid_regex.py
+++ b/tests/test_uuid_regex.py
@@ -69,25 +69,27 @@ def test_regex_options_validation_accepts_u_and_rejects_invalid_combinations():
             validate_filter_operators({"value": {"$regex": "x", "$options": options}})
         assert caught.value.code == code
 
-    with pytest.raises(OperationFailure, match="embedded") as caught:
-        validate_filter_operators(
-            {"value": {"$regex": bson.Regex("x", "i"), "$options": "m"}}
-        )
-    assert caught.value.code == 2
+    for expression in (bson.Regex("x", "i"), re.compile("x", re.IGNORECASE)):
+        with pytest.raises(OperationFailure, match="embedded") as caught:
+            validate_filter_operators(
+                {"value": {"$regex": expression, "$options": "m"}}
+            )
+        assert caught.value.code == 51075
     with pytest.raises(OperationFailure, match="supports only") as caught:
         matches_filter({"value": "x"}, {"value": {"$regex": "x", "$options": "z"}})
     assert caught.value.code == 51108
-    with pytest.raises(OperationFailure, match="embedded") as caught:
-        matches_filter(
-            {"value": "x"},
-            {
-                "value": {
-                    "$regex": bson.Regex("x", "i"),
-                    "$options": "m",
-                }
-            },
-        )
-    assert caught.value.code == 2
+    for expression in (bson.Regex("x", "i"), re.compile("x", re.IGNORECASE)):
+        with pytest.raises(OperationFailure, match="embedded") as caught:
+            matches_filter(
+                {"value": "x"},
+                {
+                    "value": {
+                        "$regex": expression,
+                        "$options": "m",
+                    }
+                },
+            )
+        assert caught.value.code == 51075
 
 
 def test_regex_locale_flag_can_still_match_an_exact_stored_regex():

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -22,6 +22,7 @@ from .tinymongo import (
     TinyMongoCollection,
     TinyMongoCursor,
     _resolve_tiny_client_folder,
+    _validate_mongo_client_kwargs,
 )
 from .warning_context import (
     WarningOrigin,
@@ -223,6 +224,10 @@ class AsyncMongoClient(_AsyncClientBase):
 
     _sync_client_class = MongoClient
     _backend_position = None
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        _validate_mongo_client_kwargs(kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class AsyncTinyMongoDatabase:

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -709,7 +709,7 @@ def _regex_matches(actual, pattern, options="", exact=False):
         if options and regex_flags_text(pattern.flags):
             raise OperationFailure(
                 "$options cannot be combined with flags embedded in $regex",
-                code=2,
+                code=51075,
             )
         pattern, flags = regex_compile_components(pattern)
     for option, flag in (
@@ -1190,7 +1190,7 @@ def _validate_regex_query_operand(operand, options=""):
         if options and regex_flags_text(operand.flags):
             raise OperationFailure(
                 "$options cannot be combined with flags embedded in $regex",
-                code=2,
+                code=51075,
             )
         return
     if not isinstance(operand, str):
@@ -1216,6 +1216,8 @@ def _validate_field_filter_operators(expression):
     """Validate one field's operator document, including nested ``$not``."""
 
     for operator, operand in expression.items():
+        if operator in _IGNORED_FILTER_OPERATORS:
+            raise OperationFailure("unknown operator: {0}".format(operator), code=2)
         if operator not in _FIELD_FILTER_OPERATORS:
             if isinstance(operator, str) and operator.startswith("$"):
                 raise TinyMongoNotSupportedError(
@@ -1302,7 +1304,7 @@ def _validate_elem_match_operand(operand):
         raise OperationFailure("$elemMatch requires a query document", code=2)
     if any(key in _LOGICAL_FILTER_OPERATORS for key in operand):
         validate_filter_operators(operand)
-    elif any(str(key).startswith("$") for key in operand):
+    elif any(key in _FIELD_FILTER_OPERATORS for key in operand):
         _validate_field_filter_operators(operand)
     else:
         validate_filter_operators(operand)
@@ -1792,13 +1794,9 @@ class TableBackend(object):
             None,
         )
         if by_name is not None and by_name != spec:
-            same_key = (by_name.field, by_name.direction) == (
-                spec.field,
-                spec.direction,
-            )
             raise OperationFailure(
                 "An index with the same name or key has different options",
-                code=85 if same_key else 86,
+                code=86,
             )
         if by_name is not None:
             # Older releases allowed equivalent specs under different names.

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -51,6 +51,7 @@ from .storage_backends import (
 from .results import InsertOneResult, InsertManyResult, UpdateResult, DeleteResult
 from .errors import (
     BulkWriteError,
+    ConfigurationError,
     DuplicateKeyError,
     InvalidDocument as InvalidDocument,
     InvalidOperation,
@@ -786,6 +787,66 @@ def _folder_from_mongo_client_args(host, port, kwargs):
     return host
 
 
+_TINYMONGO_MONGO_CLIENT_OPTIONS = frozenset(
+    (
+        "backend",
+        "storage_uri",
+        "threads",
+        "duckdb_config",
+        "dsn",
+        "tinymongo_folder",
+        "tinymongo_path",
+        "foldername",
+    )
+)
+_PYMONGO_CLIENT_PARAMETERS = frozenset(
+    (
+        "host",
+        "port",
+        "document_class",
+        "tz_aware",
+        "connect",
+        "type_registry",
+    )
+)
+_PYMONGO_CONNECTION_OPTIONS = frozenset(
+    """
+    appname authmechanism authmechanismproperties authoidcallowedhosts
+    authsource auto_encryption_opts compressors connect connecttimeoutms
+    datetime_conversion directconnection document_class driver
+    enable_overload_retargeting enableoverloadretargeting event_listeners fsync
+    heartbeatfrequencyms journal loadbalanced localthresholdms
+    max_adaptive_retries maxadaptiveretries maxconnecting maxidletimems
+    maxpoolsize maxstalenessseconds minpoolsize password read_preference
+    readconcernlevel readpreference readpreferencetags replicaset retryreads
+    retrywrites server_api server_selector servermonitoringmode
+    serverselectiontimeoutms sockettimeoutms srvmaxhosts srvservicename ssl
+    timeoutms tls tlsallowinvalidcertificates tlsallowinvalidhostnames
+    tlscafile tlscertificatekeyfile tlscertificatekeyfilepassword tlscrlfile
+    tlsdisableocspendpointcheck tlsinsecure type_registry tz_aware tzinfo
+    unicode_decode_error_handler username uuidrepresentation w
+    waitqueuemultiple waitqueuetimeoutms wtimeoutms zlibcompressionlevel
+    """.split()
+)
+
+
+def _validate_mongo_client_kwargs(options):
+    """Reject unknown PyMongo-shaped options before storage can be opened."""
+
+    unknown = next(
+        (
+            name
+            for name in options
+            if name not in _TINYMONGO_MONGO_CLIENT_OPTIONS
+            and name not in _PYMONGO_CLIENT_PARAMETERS
+            and name.lower() not in _PYMONGO_CONNECTION_OPTIONS
+        ),
+        None,
+    )
+    if unknown is not None:
+        raise ConfigurationError("Unknown option: {0}".format(unknown))
+
+
 def _resolve_tiny_client_folder(foldername, tinymongo_folder):
     """Resolve the legacy client's documented PyMongo-style folder alias."""
 
@@ -1149,6 +1210,7 @@ class MongoClient(TinyMongoClient):
         type_registry=None,
         **kwargs,
     ):
+        _validate_mongo_client_kwargs(kwargs)
         backend = kwargs.pop("backend", "tinydb")
         storage_uri = kwargs.pop("storage_uri", None)
         threads = kwargs.pop("threads", None)
@@ -1479,13 +1541,9 @@ class TinyMongoCollection(object):
     def _validate_index_compatibility(self, spec):
         by_name = self._index_specs.get(spec.name)
         if by_name is not None and by_name != spec:
-            same_key = (by_name.field, by_name.direction) == (
-                spec.field,
-                spec.direction,
-            )
             raise OperationFailure(
                 "An index with the same name or key has different options",
-                code=85 if same_key else 86,
+                code=86,
             )
         if by_name is not None:
             # Preserve idempotent retries for legacy catalogs which may still


### PR DESCRIPTION
## Summary

This fixes the four low-severity compatibility gaps Michael reported in [his latest Talk Python follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5159109461):

- **TM-026:** validate PyMongo-shaped `MongoClient` kwargs eagerly for both sync and async clients. Recognized PyMongo 4.9–4.17 connection options remain accepted and ignored for drop-in use, while unknown or misspelled names raise `ConfigurationError` before storage opens.
- **TM-027:** return error code `86` for every same-name index conflict, including option-only changes. Same-key/different-name conflicts continue to return `85`.
- **TM-028:** return MongoDB error code `51075` when `$options` is combined with flags already embedded in a native or BSON regex.
- **TM-029:** accept and ignore `$comment` inside document-form `$elemMatch`, while rejecting field-operator use with `OperationFailure` code `2`.

The README, changelog, and roadmap are updated, including Michael's completed post-merge TM-015 memory rerun.

## Root causes

- The PyMongo-shaped clients retained unrestricted `**kwargs` for connection compatibility but never validated leftover names.
- Index conflict handling selected between codes `85` and `86` using key equality after already resolving a collision by name.
- The regex matcher and validator both used the generic malformed-query code instead of MongoDB's dedicated embedded-options code.
- `$elemMatch` validation classified every dollar-prefixed key as a scalar field expression, while the matcher classified only recognized field operators that way.

## Impact

The changes apply consistently across synchronous and asynchronous clients and the TinyDB/shared table-backend paths. They tighten failure compatibility without removing any query shapes MongoDB accepts.

## Validation

- `2812 passed, 397 deselected` in the complete core suite
- 100% statement and branch coverage: 7,202 statements and 2,946 branches
- Live MongoDB contracts: `324 passed, 2 skipped` across sync and async targets
- Black and Ruff clean
- `git diff --check` clean

Tracks #136. TM-019 remains separate and is not changed here.
