### PR TITLE
Implement MongoDB-compatible BSON comparison semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@
   constraint.
 
 ### Fixed
+- **#94:** `$gt`, `$gte`, `$lt`, and `$lte` now share recursive BSON
+  type-bracketed comparison semantics across queries, aggregation `$match`,
+  and `$pull`, including direct array-member matching. Datetimes compare at
+  signed UTC millisecond precision, legacy Binary subtype 2 uses its encoded
+  length for ordering, and regex values are validated according to whether
+  they are executable predicates or nested comparison data. A focused
+  sync/async contract matrix verifies all five embedded backends against live
+  MongoDB and feeds the deterministic compatibility-report generator.
 - **TM-016:** `distinct()` now collapses BSON-equivalent numeric values across
   integers, doubles, and Decimal128 while keeping booleans distinct.
 - **TM-018:** Every CRUD filter now rejects unsupported or misspelled query

--- a/README.md
+++ b/README.md
@@ -537,11 +537,23 @@ BSON-equivalent IDs share one key (`1` and `1.0`, or native bytes and Binary
 subtype 0), while BSON-distinct values such as `True` and `1` or identical
 binary data with different subtypes remain separate.
 
-Cursor sorting follows MongoDB's comparison order for the currently supported
-scalar families, including BinData, `ObjectId`, booleans, and datetimes.
-The same recursive BSON order is used by aggregation `$min` and `$max`.
-Broader BSON comparison across query ranges and indexes remains tracked in
-[#94](https://github.com/schapman1974/tinymongo/issues/94).
+Cursor sorting follows MongoDB's recursive comparison order for the supported
+BSON scalar, document, and array families, including BinData, `ObjectId`,
+booleans, and datetimes. The same order is used by aggregation `$min` and
+`$max` and by the `$gt`, `$gte`, `$lt`, and `$lte` query operators, including
+range predicates inside `$pull`. Range queries apply MongoDB's BSON type
+bracketing: numeric representations share one family, while values from other
+type families do not compare with one another. Array fields expose both the
+whole array and its direct members where MongoDB does, and documents and arrays
+are compared recursively. Values with equal comparison keys retain their input
+order for ascending and descending sorts. TinyMongo uses its shared Python
+matcher whenever a backend-native or indexed predicate cannot guarantee these
+rules. Extending unique-index identity to the remaining supported BSON values
+is still tracked separately in the roadmap and continues to fail closed where
+exact enforcement is unavailable. The update `$min` and `$max` modifiers remain
+tracked under
+[#77](https://github.com/schapman1974/tinymongo/issues/77); aggregation `$min`
+and `$max` are already part of the supported aggregation subset.
 
 ## Aggregation core subset
 
@@ -679,6 +691,10 @@ the pattern plus MongoDB's canonical option string. Preserving a native
 same wire value as `bson.Regex`. An implicit regex filter,
 `$regex`, `$in`, `$nin`, `$all`, or `$not` pattern-matches strings and exact
 stored regex values, while explicit `$eq` compares only stored regex identity.
+Regex values used directly as operands of `$gt`, `$gte`, `$lt`, or `$lte` are
+rejected with MongoDB error code `2`. A regex nested inside a document or array
+range operand is comparison data instead, so TinyMongo validates its BSON
+transport shape without compiling it as an executable pattern.
 TinyMongo evaluates patterns with Python's `re` engine rather than MongoDB's
 PCRE2 engine, so a pattern must be valid Python syntax and some advanced syntax
 or matching details can differ between the two engines. A stored BSON regex
@@ -693,10 +709,12 @@ rewriting one populates its ordered copy.
 
 Sorts normalize naive datetimes as UTC and convert aware datetimes to UTC.
 BinData—including UUID—sorts by length, subtype, and then unsigned bytes,
-matching MongoDB. Regex values sort by pattern and canonical options after the
-other supported scalar families. Numeric `NaN` sorts below every other numeric
-value, matching MongoDB. TinyMongo retains Python microseconds, so it can
-distinguish two datetimes that MongoDB would store in the same millisecond.
+matching MongoDB; legacy subtype 2 includes its four-byte inner-length prefix
+when its comparison length is calculated. Regex values sort by pattern and
+canonical options after the other supported scalar families. Numeric `NaN`
+sorts below every other numeric value, matching MongoDB. TinyMongo can retain
+Python microseconds on round-trip, but BSON equality, range comparisons, and
+sorting use MongoDB's signed UTC millisecond precision.
 
 Decimal128 values retain their exact BSON representation and participate in
 numeric equality and range queries, sorting, embedded-backend unique indexes,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -186,8 +186,11 @@ with the follow-up audit of his
   unsupported query operators with `TinyMongoNotSupportedError` instead of
   silently returning no matches, and implement `$size`, `$elemMatch`, `$type`,
   and `$mod`.
-- [ ] Under [#94](https://github.com/schapman1974/tinymongo/issues/94), complete
-  the remaining BSON-aware range-comparison contracts.
+- [x] Under [#94](https://github.com/schapman1974/tinymongo/issues/94), complete
+  the BSON-aware `$gt`, `$gte`, `$lt`, and `$lte` contracts across recursive
+  documents and arrays, BSON type bracketing, query and `$pull` paths, and
+  MongoDB-compatible datetime, BinData, and regex boundaries. The focused
+  sync/async matrix covers all five embedded backends plus live MongoDB.
 - [ ] Extend unique-index tokens to supported BSON values through
   [#75](https://github.com/schapman1974/tinymongo/issues/75) and
   [#76](https://github.com/schapman1974/tinymongo/issues/76).
@@ -223,7 +226,7 @@ Application-compatibility work:
   - [x] Reject unsupported or misspelled query operators across CRUD filters and
     add `$size`, `$elemMatch`, `$type`, and `$mod`.
   - [ ] Prioritize the remaining update candidates from measured application
-    failures.
+    failures, including the `$min` and `$max` update modifiers.
 - [ ] [#102: Optional PyMongo-version adaptation](https://github.com/schapman1974/tinymongo/issues/102)
   - [x] TinyMongo errors conditionally inherit matching PyMongo errors.
   - [ ] Add version-matrix CI plus broader signature and result adaptation.
@@ -316,7 +319,7 @@ Exit criteria:
 - [ ] [#81: MongoDB document and key validation](https://github.com/schapman1974/tinymongo/issues/81)
 - [ ] [#83: Remaining common BSON types](https://github.com/schapman1974/tinymongo/issues/83)
 - [ ] [#93: Backend concurrency and compatibility stress tests](https://github.com/schapman1974/tinymongo/issues/93)
-- [ ] [#94: BSON comparison and sort order](https://github.com/schapman1974/tinymongo/issues/94)
+- [x] [#94: BSON comparison and sort order](https://github.com/schapman1974/tinymongo/issues/94)
 
 Exit criteria:
 

--- a/docs/COMPATIBILITY_REPORTS.md
+++ b/docs/COMPATIBILITY_REPORTS.md
@@ -46,6 +46,30 @@ python scripts/generate_compatibility_report.py \
 Without output options, the default filenames are
 `compatibility-report.json` and `compatibility-report.md`.
 
+## Generate the BSON comparison report
+
+Issue #94 has a focused contract slice for recursive, type-bracketed BSON
+range comparison and sorting. Run it through both APIs and all six configured
+targets—the five embedded backends plus live MongoDB—and generate its reports
+with:
+
+```bash
+TINYMONGO_MONGODB_URI='mongodb://127.0.0.1:27017/?directConnection=true' \
+TINYMONGO_REQUIRE_MONGODB=1 \
+pytest -o addopts='' -q -m contract \
+  tests/contracts/test_bson_comparison_contract.py \
+  --junitxml=bson-comparison-results.xml
+
+python scripts/generate_compatibility_report.py \
+  bson-comparison-results.xml \
+  --json-output=bson-comparison-matrix.json \
+  --markdown-output=bson-comparison-matrix.md
+```
+
+The resulting suite is attributed as `bson-comparison`, so its score can be
+inspected independently while retaining the same completeness and
+live-reference requirements as the full report.
+
 ## JUnit dimensions
 
 Contract tests attach these properties to every testcase:

--- a/tests/contracts/README.md
+++ b/tests/contracts/README.md
@@ -31,6 +31,22 @@ To generate those reports locally, add
 python scripts/generate_compatibility_report.py contract-results.xml
 ```
 
+Run only the BSON comparison slice and generate its two-API, six-target report
+(memory, JSON, SQLite, DuckDB, Parquet, and the live MongoDB reference) with:
+
+```bash
+TINYMONGO_MONGODB_URI='mongodb://127.0.0.1:27017/?directConnection=true' \
+TINYMONGO_REQUIRE_MONGODB=1 \
+pytest -o addopts='' -q -m contract \
+  tests/contracts/test_bson_comparison_contract.py \
+  --junitxml=bson-comparison-results.xml
+
+python scripts/generate_compatibility_report.py \
+  bson-comparison-results.xml \
+  --json-output=bson-comparison-matrix.json \
+  --markdown-output=bson-comparison-matrix.md
+```
+
 The scoring rules, complete command, report schema, and CI failure behavior are
 documented in [Compatibility reports](../../docs/COMPATIBILITY_REPORTS.md).
 

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -142,6 +142,8 @@ def _async_mongo_client(uri, runner):
 def _contract_suite(request):
     if "test_talkpython_contract.py" in request.node.nodeid:
         return "talkpython"
+    if "test_bson_comparison_contract.py" in request.node.nodeid:
+        return "bson-comparison"
     return "core"
 
 

--- a/tests/contracts/test_bson_comparison_contract.py
+++ b/tests/contracts/test_bson_comparison_contract.py
@@ -1,0 +1,528 @@
+"""Issue #94 contracts for MongoDB-compatible BSON range comparison."""
+
+from datetime import datetime, timezone
+import re
+
+import pytest
+
+from tinymongo.errors import OperationFailure as TinyMongoOperationFailure
+from tinymongo.errors import WriteError as TinyMongoWriteError
+
+
+pytestmark = pytest.mark.contract
+bson = pytest.importorskip("bson")
+Binary = bson.Binary
+ObjectId = bson.ObjectId
+Regex = bson.Regex
+
+_OPERATION_ERRORS = (TinyMongoOperationFailure,)
+_WRITE_ERRORS = (TinyMongoWriteError,)
+try:
+    from pymongo.errors import OperationFailure as PyMongoOperationFailure
+    from pymongo.errors import WriteError as PyMongoWriteError
+except ImportError:  # pragma: no cover - optional dependency guard
+    pass
+else:
+    _OPERATION_ERRORS += (PyMongoOperationFailure,)
+    _WRITE_ERRORS += (PyMongoWriteError,)
+
+
+def _ids(rows):
+    return {document["_id"] for document in rows}
+
+
+@pytest.mark.parametrize(
+    ("documents", "operand", "expected"),
+    [
+        pytest.param(
+            [
+                {"_id": "lower", "value": -1},
+                {"_id": "integer-equal", "value": 1},
+                {"_id": "double-equal", "value": 1.0},
+                {"_id": "decimal-equal", "value": bson.Decimal128("1.00")},
+                {"_id": "higher", "value": 2},
+                {"_id": "array-higher", "value": [2]},
+                {"_id": "boolean", "value": True},
+                {"_id": "string", "value": "2"},
+            ],
+            bson.Decimal128("1"),
+            {
+                "$gt": {"higher", "array-higher"},
+                "$gte": {
+                    "integer-equal",
+                    "double-equal",
+                    "decimal-equal",
+                    "higher",
+                    "array-higher",
+                },
+                "$lt": {"lower"},
+                "$lte": {
+                    "lower",
+                    "integer-equal",
+                    "double-equal",
+                    "decimal-equal",
+                },
+            },
+            id="numeric-family",
+        ),
+        pytest.param(
+            [
+                {"_id": "lower", "value": "a"},
+                {"_id": "equal", "value": "b"},
+                {"_id": "higher", "value": "c"},
+                {"_id": "array-higher", "value": ["c"]},
+                {"_id": "number", "value": 99},
+                {"_id": "object", "value": {"value": "c"}},
+            ],
+            "b",
+            {
+                "$gt": {"higher", "array-higher"},
+                "$gte": {"equal", "higher", "array-higher"},
+                "$lt": {"lower"},
+                "$lte": {"lower", "equal"},
+            },
+            id="string-family",
+        ),
+        pytest.param(
+            [
+                {"_id": "false", "value": False},
+                {"_id": "true", "value": True},
+                {"_id": "array-true", "value": [True]},
+                {"_id": "zero", "value": 0},
+                {"_id": "one", "value": 1},
+            ],
+            False,
+            {
+                "$gt": {"true", "array-true"},
+                "$gte": {"false", "true", "array-true"},
+                "$lt": set(),
+                "$lte": {"false"},
+            },
+            id="boolean-family",
+        ),
+    ],
+)
+def test_generated_scalar_range_matrix(
+    contract_target,
+    documents,
+    operand,
+    expected,
+):
+    collection = contract_target.collection
+    collection.insert_many(documents)
+
+    assert {
+        operator: _ids(collection.find({"value": {operator: operand}}))
+        for operator in ("$gt", "$gte", "$lt", "$lte")
+    } == expected
+
+
+def test_null_range_queries_include_missing_and_array_members(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "missing"},
+            {"_id": "null", "value": None},
+            {"_id": "array-null", "value": [None, 1]},
+            {"_id": "empty-array", "value": []},
+            {"_id": "zero", "value": 0},
+        ]
+    )
+
+    expected = {"missing", "null", "array-null"}
+    assert _ids(collection.find({"value": {"$gte": None}})) == expected
+    assert _ids(collection.find({"value": {"$lte": None}})) == expected
+    assert _ids(collection.find({"value": {"$gt": None}})) == set()
+    assert _ids(collection.find({"value": {"$lt": None}})) == set()
+
+
+def test_array_range_queries_compare_whole_and_direct_nested_arrays(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "both", "value": [0, [2]]},
+            {"_id": "opposite", "value": [[0], 0]},
+            {"_id": "equal", "value": [1]},
+            {"_id": "longer", "value": [1, 2]},
+            {"_id": "higher", "value": [2]},
+            {"_id": "empty", "value": []},
+            {"_id": "scalar", "value": 2},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$gt": [1]}})) == {
+        "both",
+        "opposite",
+        "longer",
+        "higher",
+    }
+    assert _ids(collection.find({"value": {"$gte": [1]}})) == {
+        "both",
+        "opposite",
+        "equal",
+        "longer",
+        "higher",
+    }
+    assert _ids(collection.find({"value": {"$lt": [1]}})) == {
+        "both",
+        "opposite",
+        "empty",
+    }
+    assert _ids(collection.find({"value": {"$lte": [1]}})) == {
+        "both",
+        "opposite",
+        "equal",
+        "empty",
+    }
+    assert _ids(collection.find({"value": {"$elemMatch": {"$gt": [1]}}})) == {"both"}
+    assert _ids(collection.find({"value": {"$elemMatch": {"$lt": [1]}}})) == {
+        "opposite"
+    }
+
+
+def test_embedded_id_fields_use_normal_array_comparison_semantics(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "array-id", "value": [{"_id": [1, 2]}]},
+            {"_id": "scalar-id", "value": [{"_id": 2}]},
+            {"_id": "lower-id", "value": [{"_id": 1}]},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$elemMatch": {"_id": 2}}})) == {
+        "array-id",
+        "scalar-id",
+    }
+    assert _ids(collection.find({"value": {"$elemMatch": {"_id": {"$gt": 1}}}})) == {
+        "array-id",
+        "scalar-id",
+    }
+
+
+def test_object_range_queries_use_recursive_bson_field_order(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "empty", "value": {}},
+            {"_id": "lower", "value": {"a": 0}},
+            {"_id": "equal", "value": {"a": 1}},
+            {"_id": "higher-value", "value": {"a": 2}},
+            {"_id": "higher-key", "value": {"b": 0}},
+            {"_id": "higher-type", "value": {"a": "text"}},
+            {
+                "_id": "array-members",
+                "value": [{"a": 0}, {"a": 2}],
+            },
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$gt": {"a": 1}}})) == {
+        "higher-value",
+        "higher-key",
+        "higher-type",
+        "array-members",
+    }
+    assert _ids(collection.find({"value": {"$lt": {"a": 1}}})) == {
+        "empty",
+        "lower",
+        "array-members",
+    }
+
+
+def test_scalar_ranges_share_bson_keys_and_dates_use_milliseconds(
+    contract_target,
+):
+    collection = contract_target.collection
+    boundary = datetime(2026, 8, 2, 12, 0, 0, 123100, tzinfo=timezone.utc)
+    same_millisecond = boundary.replace(microsecond=123900)
+    next_millisecond = boundary.replace(microsecond=124000)
+    collection.insert_many(
+        [
+            {"_id": "binary-low", "binary": Binary(b"a", subtype=0)},
+            {"_id": "binary-long", "binary": Binary(b"bb", subtype=0)},
+            {"_id": "binary-subtype", "binary": Binary(b"a", subtype=128)},
+            {
+                "_id": "objectid-low",
+                "objectid": ObjectId("000000000000000000000001"),
+            },
+            {
+                "_id": "objectid-high",
+                "objectid": ObjectId("000000000000000000000002"),
+            },
+            {"_id": "false", "flag": False},
+            {"_id": "true", "flag": True},
+            {"_id": "same-ms", "when": same_millisecond},
+            {"_id": "next-ms", "when": next_millisecond},
+        ]
+    )
+
+    assert _ids(collection.find({"binary": {"$gt": Binary(b"a", subtype=0)}})) == {
+        "binary-long",
+        "binary-subtype",
+    }
+    assert _ids(
+        collection.find({"objectid": {"$gt": ObjectId("000000000000000000000001")}})
+    ) == {"objectid-high"}
+    assert _ids(collection.find({"flag": {"$gt": False}})) == {"true"}
+    assert _ids(collection.find({"when": {"$gt": boundary}})) == {"next-ms"}
+    assert _ids(collection.find({"when": {"$gte": boundary}})) == {
+        "same-ms",
+        "next-ms",
+    }
+
+
+def test_legacy_binary_subtype_two_uses_its_encoded_length(contract_target):
+    collection = contract_target.collection
+    values = [
+        ("generic-one", Binary(b"a", subtype=0)),
+        ("uuid-one", Binary(b"a", subtype=4)),
+        ("generic-two", Binary(b"aa", subtype=0)),
+        ("legacy-one", Binary(b"a", subtype=2)),
+    ]
+    collection.insert_many(
+        {"_id": label, "value": value} for label, value in reversed(values)
+    )
+
+    # PyMongo cannot decode legacy subtype-2 Binary values from returned
+    # documents, so project only the comparison result identifier.
+    assert [row["_id"] for row in collection.find({}, {"_id": 1}).sort("value", 1)] == [
+        label for label, _value in values
+    ]
+    assert _ids(
+        collection.find(
+            {"value": {"$gt": Binary(b"a", subtype=4)}},
+            {"_id": 1},
+        )
+    ) == {
+        "generic-two",
+        "legacy-one",
+    }
+    assert _ids(
+        collection.find(
+            {"value": {"$gt": Binary(b"aa", subtype=0)}},
+            {"_id": 1},
+        )
+    ) == {"legacy-one"}
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [Regex("a", ""), Regex("[", ""), re.compile("a")],
+    ids=("bson-valid", "bson-malformed", "native"),
+)
+def test_regex_range_operands_are_rejected_with_code_2(
+    contract_target,
+    expression,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "first", "value": Regex("a", "")},
+            {"_id": "second", "value": Regex("b", "")},
+        ]
+    )
+
+    for operator in ("$gt", "$gte", "$lt", "$lte"):
+        with pytest.raises(_OPERATION_ERRORS) as caught:
+            list(collection.find({"value": {operator: expression}}))
+        assert caught.value.code == 2
+
+
+def test_nested_regex_range_values_are_compared_without_compilation(
+    contract_target,
+):
+    collection = contract_target.collection
+    invalid = Regex("[", "")
+    collection.insert_many(
+        [
+            {"_id": "object-equal", "value": {"regex": invalid}},
+            {"_id": "object-a", "value": {"regex": Regex("a", "")}},
+            {"_id": "object-b", "value": {"regex": Regex("b", "")}},
+            {"_id": "array-equal", "value": [invalid]},
+            {"_id": "array-a", "value": [Regex("a", "")]},
+            {"_id": "array-b", "value": [Regex("b", "")]},
+        ]
+    )
+
+    assert _ids(collection.find({"value": {"$eq": {"regex": invalid}}})) == {
+        "object-equal"
+    }
+    assert _ids(collection.find({"value": {"$gt": {"regex": invalid}}})) == {
+        "object-a",
+        "object-b",
+    }
+    assert _ids(collection.find({"value": {"$lte": {"regex": invalid}}})) == {
+        "object-equal"
+    }
+    assert _ids(collection.find({"value": {"$gt": [invalid]}})) == {
+        "array-a",
+        "array-b",
+    }
+
+
+def test_indexed_ranges_feed_every_filter_consumer(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "lower", "value": {"score": 0}, "marker": "lower"},
+            {"_id": "equal", "value": {"score": 1}, "marker": "equal"},
+            {"_id": "higher", "value": {"score": 2}, "marker": "higher"},
+            {
+                "_id": "array-higher",
+                "value": [{"score": 2}],
+                "marker": "array-higher",
+            },
+            {"_id": "other-type", "value": "z", "marker": "other-type"},
+        ]
+    )
+    query = {"value": {"$gt": {"score": 1}}}
+    expected = {"higher", "array-higher"}
+
+    assert _ids(collection.find(query)) == expected
+    collection.create_index("value")
+    assert _ids(collection.find(query)) == expected
+    assert collection.count_documents(query) == 2
+    assert set(collection.distinct("marker", query)) == expected
+    assert _ids(collection.aggregate([{"$match": query}])) == expected
+
+    result = collection.update_many(query, {"$set": {"matched": True}})
+    assert result.matched_count == 2
+    assert _ids(collection.find({"matched": True})) == expected
+
+
+def test_cursor_and_aggregation_sort_share_scalar_bson_order(contract_target):
+    collection = contract_target.collection
+    expected = [
+        ("number", 0),
+        ("string", "value"),
+        ("object", {"value": 1}),
+        ("binary", Binary(b"value", subtype=0)),
+        ("objectid", ObjectId("000000000000000000000001")),
+        ("boolean", False),
+        ("datetime", datetime(2026, 8, 2, tzinfo=timezone.utc)),
+        ("regex", Regex("value", "")),
+    ]
+    collection.insert_many(
+        {"_id": label, "value": value} for label, value in reversed(expected)
+    )
+
+    expected_ids = [label for label, _value in expected]
+    assert [row["_id"] for row in collection.find({}).sort("value", 1)] == expected_ids
+    assert [
+        row["_id"] for row in collection.aggregate([{"$sort": {"value": 1}}])
+    ] == expected_ids
+
+
+def test_pull_reuses_recursive_bson_range_comparison(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "arrays",
+                "values": [None, 0, [0, [2]], [[0], 0], [1], [1, 2], [2]],
+            },
+            {
+                "_id": "objects",
+                "values": [{}, {"a": 1}, {"a": 2}, {"b": 0}, {"a": "text"}],
+            },
+            {
+                "_id": "regex",
+                "values": [Regex("a", ""), Regex("b", "")],
+            },
+        ]
+    )
+
+    collection.update_one({"_id": "arrays"}, {"$pull": {"values": {"$gt": [1]}}})
+    collection.update_one({"_id": "objects"}, {"$pull": {"values": {"$gt": {"a": 1}}}})
+
+    assert collection.find_one({"_id": "arrays"})["values"] == [None, 0, [1]]
+    assert collection.find_one({"_id": "objects"})["values"] == [{}, {"a": 1}]
+
+    with pytest.raises(_WRITE_ERRORS) as caught:
+        collection.update_one(
+            {"_id": "regex"},
+            {"$pull": {"values": {"$gt": Regex("a", "")}}},
+        )
+    assert caught.value.code == 2
+    assert collection.find_one({"_id": "regex"})["values"] == [
+        Regex("a", ""),
+        Regex("b", ""),
+    ]
+
+
+def test_pull_document_ranges_share_missing_and_array_path_semantics(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "null-range",
+                "values": [
+                    {"label": "missing"},
+                    {"label": "null", "score": None},
+                    {"label": "number", "score": 1},
+                ],
+            },
+            {
+                "_id": "array-fanout",
+                "values": [
+                    {"label": "hit", "items": [{"score": 2}]},
+                    {"label": "miss", "items": [{"score": 0}]},
+                ],
+            },
+            {
+                "_id": "array-index",
+                "values": [
+                    {"label": "hit", "items": [2]},
+                    {"label": "miss", "items": [0, 2]},
+                ],
+            },
+            {
+                "_id": "embedded-id-range",
+                "values": [{"_id": [1, 2]}, {"_id": 2}, {"_id": 3}],
+            },
+            {
+                "_id": "embedded-id-equality",
+                "values": [{"_id": [1, 2]}, {"_id": 2}, {"_id": 3}],
+            },
+        ]
+    )
+
+    collection.update_one(
+        {"_id": "null-range"},
+        {"$pull": {"values": {"score": {"$gte": None}}}},
+    )
+    collection.update_one(
+        {"_id": "array-fanout"},
+        {"$pull": {"values": {"items.score": {"$gt": 1}}}},
+    )
+    collection.update_one(
+        {"_id": "array-index"},
+        {"$pull": {"values": {"items.0": {"$gt": 1}}}},
+    )
+    collection.update_one(
+        {"_id": "embedded-id-range"},
+        {"$pull": {"values": {"_id": {"$gt": 1}}}},
+    )
+    collection.update_one(
+        {"_id": "embedded-id-equality"},
+        {"$pull": {"values": {"_id": 2}}},
+    )
+
+    assert collection.find_one({"_id": "null-range"})["values"] == [
+        {"label": "number", "score": 1}
+    ]
+    assert collection.find_one({"_id": "array-fanout"})["values"] == [
+        {"label": "miss", "items": [{"score": 0}]}
+    ]
+    assert collection.find_one({"_id": "array-index"})["values"] == [
+        {"label": "miss", "items": [0, 2]}
+    ]
+    assert collection.find_one({"_id": "embedded-id-range"})["values"] == []
+    assert collection.find_one({"_id": "embedded-id-equality"})["values"] == [
+        {"_id": 3}
+    ]

--- a/tests/test_array_update_modifiers.py
+++ b/tests/test_array_update_modifiers.py
@@ -220,7 +220,7 @@ def test_pull_supports_query_operators_documents_logical_queries_and_exact_array
         ({"$not": {"$eq": 2}}, "does not support query operator"),
         ({"$options": "i"}, "does not support query operator"),
         ({"$regex": "["}, "does not support query operator"),
-        ({"$gte": {}}, "requires a supported scalar value"),
+        ({"$gte": {1}}, "requires a supported BSON value"),
         (
             {"$gte": 1, "$or": [{"score": 1}]},
             "document query operator",

--- a/tests/test_bson_codec.py
+++ b/tests/test_bson_codec.py
@@ -534,6 +534,10 @@ def test_bson_type_registry_uses_mongodb_scalar_order_and_subclass_precedence():
         5,
         (1, 128, b"x"),
     )
+    assert bson_types.bson_scalar_sort_key(Binary(b"x", subtype=2)) == (
+        5,
+        (5, 2, b"x"),
+    )
     assert bson_types.bson_scalar_sort_key(b"x") == (5, (1, 0, b"x"))
     assert bson_types.bson_scalar_sort_key(ObjectId("000000000000000000000001")) == (
         6,

--- a/tests/test_bson_registry_hardening.py
+++ b/tests/test_bson_registry_hardening.py
@@ -13,6 +13,7 @@ import pytest
 import tinymongo
 from tinymongo import bson_codec, bson_types
 from tinymongo.errors import BulkWriteError
+from tinymongo.sorting import sort_documents
 
 
 def test_core_datetime_and_binary_values_do_not_require_pymongo():
@@ -199,6 +200,36 @@ def test_numeric_sort_places_nan_below_all_other_numbers():
         "one",
         "infinity",
     ]
+
+
+def test_equal_bson_sort_keys_preserve_input_order_in_both_directions():
+    bson = pytest.importorskip("bson")
+    numeric = [
+        {"_id": "integer", "value": 1},
+        {"_id": "double", "value": 1.0},
+        {"_id": "decimal", "value": bson.Decimal128("1.00")},
+    ]
+    dates = [
+        {
+            "_id": "first",
+            "value": datetime(2026, 8, 2, 12, 0, 0, 123100),
+        },
+        {
+            "_id": "second",
+            "value": datetime(2026, 8, 2, 12, 0, 0, 123900),
+        },
+    ]
+
+    for documents in (numeric, dates):
+        expected = [document["_id"] for document in documents]
+        for direction in (1, -1):
+            assert [
+                document["_id"]
+                for document in sort_documents(
+                    documents,
+                    (("value", direction),),
+                )
+            ] == expected
 
 
 def test_recursive_bson_equality_preserves_nested_scalar_types():

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -730,7 +730,7 @@ def test_tinydb_native_search_errors_remain_empty_results(tmp_path, monkeypatch,
         lambda _condition: (_ for _ in ()).throw(error),
     )
 
-    assert list(collection.find({"name": {"$gt": "A"}})) == []
+    assert list(collection.find({"name": {"$exists": True}})) == []
     client.close()
 
 

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -275,13 +275,15 @@ def test_direct_id_and_cached_match_helpers_cover_operator_routes():
     assert core._cached_value_matches(1.0, 1, ("number", 1)) is True
 
 
-def test_tinydb_updates_and_replacements_parse_regular_queries(tmp_path):
+def test_tinydb_updates_and_replacements_use_native_query_routes(tmp_path):
     client = core.TinyMongoClient(str(tmp_path / "db"))
     collection = client.app.people
     collection.insert_one({"_id": 1, "name": "Ada", "score": 1})
 
-    updated = collection.update_one({"score": {"$gt": 0}}, {"$set": {"score": 2}})
-    replaced = collection.replace_one({"score": {"$gt": 0}}, {"name": "Grace"})
+    updated = collection.update_one(
+        {"score": {"$exists": True}}, {"$set": {"score": 2}}
+    )
+    replaced = collection.replace_one({"score": {"$exists": True}}, {"name": "Grace"})
 
     assert updated.matched_count == 1
     assert updated.modified_count == 1

--- a/tests/test_uuid_regex.py
+++ b/tests/test_uuid_regex.py
@@ -160,6 +160,59 @@ def test_regex_only_preflight_ignores_non_query_documents():
     assert validate_regex_filter(None) is None
 
 
+@pytest.mark.parametrize(
+    ("query", "expected_code"),
+    [
+        ({"value": bson.Regex("[")}, 51091),
+        ({"value": {"$gt": bson.Regex("[")}}, 2),
+        ({"value": {"$lte": re.compile("valid")}}, 2),
+        ({"value": {"$ne": bson.Regex("[")}}, 2),
+        ({"value": {"$ne": {"nested": bson.Regex("[")}}}, None),
+        ({"value": {"$eq": bson.Regex("[")}}, None),
+        ({"value": {"$gte": {"nested": bson.Regex("[")}}}, None),
+        ({"value": {"$in": [bson.Regex("[")]}}, 51091),
+        (
+            {"value": {"$nin": [{"nested": bson.Regex("[")}]}},
+            None,
+        ),
+        ({"value": {"$all": [bson.Regex("[")]}}, 51091),
+        ({"value": {"$all": [[bson.Regex("[")]]}}, None),
+        (
+            {"value": {"$all": [{"$elemMatch": {"name": bson.Regex("[")}}]}},
+            51091,
+        ),
+        ({"value": {"$not": bson.Regex("[")}}, 51091),
+        ({"value": {"$elemMatch": {"name": bson.Regex("[")}}}, 51091),
+        (
+            {"value": {"$elemMatch": {"$or": [{"name": bson.Regex("[")}]}}},
+            51091,
+        ),
+        (
+            {"value": {"$elemMatch": {"$gt": {"nested": bson.Regex("[")}}}},
+            None,
+        ),
+        ({"value": {"nested": bson.Regex("[")}}, None),
+        ({"value": {"$gt": {"nested": bson.Regex("nul\x00pattern")}}}, 2),
+    ],
+)
+def test_regex_only_preflight_matches_contextual_filter_validation(
+    query,
+    expected_code,
+):
+    for validator in (validate_filter_operators, validate_regex_filter):
+        if expected_code is None:
+            validator(query)
+            continue
+        with pytest.raises(OperationFailure) as caught:
+            validator(query)
+        assert caught.value.code == expected_code
+
+
+def test_regex_only_preflight_keeps_ignoring_non_regex_query_shape_errors():
+    validate_regex_filter({"value": {"$in": bson.Regex("[")}})
+    validate_regex_filter({"value": {"$elemMatch": "not-a-document"}})
+
+
 def test_full_filter_validation_rejects_operator_documents_inside_regex_arrays():
     with pytest.raises(OperationFailure, match="accepts regex values") as caught:
         validate_filter_operators({"value": {"$in": [{"$regex": "valid"}]}})

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -197,8 +197,10 @@ def binary_components(value):
 
 def _binary_sort_key(value):
     raw, subtype = binary_components(value)
-    # MongoDB compares BinData by length, then subtype, then byte content.
-    return len(raw), subtype, raw
+    # MongoDB compares BinData by encoded length, then subtype, then byte
+    # content. Legacy subtype 2 carries an additional four-byte inner length.
+    encoded_length = len(raw) + (4 if subtype == 2 else 0)
+    return encoded_length, subtype, raw
 
 
 def _binary_identity_key(value):
@@ -338,7 +340,7 @@ _BOOLEAN = BSONTypeSpec("boolean", 7, _identity, _identity)
 _DATETIME = BSONTypeSpec(
     "datetime",
     8,
-    normalize_datetime,
+    _datetime_identity_key,
     _datetime_identity_key,
     storage_tag="datetime",
     requires_python_comparison=True,
@@ -504,6 +506,47 @@ def bson_value_sort_key(value):
         return 4, tuple(parsed)
 
     return bson_scalar_sort_key(value)
+
+
+def bson_query_range_matches(actual, operand, comparison, exact=False):
+    """Return whether one query range comparison follows BSON semantics.
+
+    MongoDB brackets range predicates by the outer BSON type, with all numeric
+    representations sharing one family. A non-positional array field exposes
+    both its complete array value and each direct member to the predicate;
+    ``exact`` endpoints such as ``$elemMatch`` or a numeric path component do
+    not fan out again.
+    """
+
+    operand_identity = bson_value_identity_key(operand)
+    operand_order = bson_value_sort_key(operand)
+    if operand_identity is None or operand_order is None:
+        return False
+
+    values = [actual]
+    if isinstance(actual, (list, tuple)) and not exact:
+        values.extend(actual)
+
+    for value in values:
+        value_identity = bson_value_identity_key(value)
+        value_order = bson_value_sort_key(value)
+        if (
+            value_identity is None
+            or value_order is None
+            or value_identity[0] != operand_identity[0]
+        ):
+            continue
+        try:
+            if value_identity[0] == "number" and (
+                bson_number_decimal(value).is_nan()
+                != bson_number_decimal(operand).is_nan()
+            ):
+                continue
+            if comparison(value_order, operand_order):
+                return True
+        except (ArithmeticError, TypeError, ValueError):
+            continue
+    return False
 
 
 def bson_identity_key(value):

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -23,7 +23,7 @@ from .bson_codec import storage_values_equal
 from .bson_types import (
     bson_identity_key,
     bson_number_decimal,
-    bson_scalar_sort_key,
+    bson_query_range_matches,
     bson_values_equal,
     decimal128_type,
     is_bson_regex,
@@ -657,36 +657,8 @@ def _remote_unique_token(document, spec):
 
 
 def _comparison_matches(actual, operand, comparison, exact=False):
-    operand_identity = bson_identity_key(operand)
-    operand_order = bson_scalar_sort_key(operand)
-    if operand_identity is None or operand_order is None:
-        return False
-    values = actual if isinstance(actual, list) and not exact else [actual]
-    for value in values:
-        value_identity = bson_identity_key(value)
-        value_order = bson_scalar_sort_key(value)
-        try:
-            if (
-                value_identity is not None
-                and value_identity[0] == "number"
-                and is_bson_number(value)
-                and is_bson_number(operand)
-                and (
-                    bson_number_decimal(value).is_nan()
-                    != bson_number_decimal(operand).is_nan()
-                )
-            ):
-                continue
-            if (
-                value_identity is not None
-                and value_order is not None
-                and value_identity[0] == operand_identity[0]
-                and comparison(value_order[1], operand_order[1])
-            ):
-                return True
-        except (ArithmeticError, TypeError, ValueError):
-            continue
-    return False
+    value = None if actual is _MISSING else actual
+    return bson_query_range_matches(value, operand, comparison, exact=exact)
 
 
 def _validate_regex_options(options):
@@ -905,9 +877,14 @@ def _elem_match_matches(actual, operand):
         return any(_field_matches(item, operand, exact=True) for item in actual)
     return any(
         isinstance(item, Mapping)
-        and matches_filter(item, operand)
+        and matches_filter(item, operand, _exact_id=False)
         or isinstance(item, (list, tuple))
-        and matches_filter(item, operand, _array_document=True)
+        and matches_filter(
+            item,
+            operand,
+            _array_document=True,
+            _exact_id=False,
+        )
         for item in actual
     )
 
@@ -996,22 +973,22 @@ def _field_matches(actual, expected, exact=False):
             if bool(operand) != exists:
                 return False
         elif operator == "$gt":
-            if not exists or not _comparison_matches(
+            if not _comparison_matches(
                 actual, operand, lambda a, b: a > b, exact=exact
             ):
                 return False
         elif operator == "$gte":
-            if not exists or not _comparison_matches(
+            if not _comparison_matches(
                 actual, operand, lambda a, b: a >= b, exact=exact
             ):
                 return False
         elif operator == "$lt":
-            if not exists or not _comparison_matches(
+            if not _comparison_matches(
                 actual, operand, lambda a, b: a < b, exact=exact
             ):
                 return False
         elif operator == "$lte":
-            if not exists or not _comparison_matches(
+            if not _comparison_matches(
                 actual, operand, lambda a, b: a <= b, exact=exact
             ):
                 return False
@@ -1091,7 +1068,7 @@ def _field_matches(actual, expected, exact=False):
     return True
 
 
-def matches_filter(doc, filter_doc, _array_document=False):
+def matches_filter(doc, filter_doc, _array_document=False, _exact_id=True):
     if not filter_doc:
         return True
     if not isinstance(filter_doc, Mapping):
@@ -1099,13 +1076,22 @@ def matches_filter(doc, filter_doc, _array_document=False):
 
     for key, expected in filter_doc.items():
         if key == "$and":
-            if not all(matches_filter(doc, spec, _array_document) for spec in expected):
+            if not all(
+                matches_filter(doc, spec, _array_document, _exact_id)
+                for spec in expected
+            ):
                 return False
         elif key == "$or":
-            if not any(matches_filter(doc, spec, _array_document) for spec in expected):
+            if not any(
+                matches_filter(doc, spec, _array_document, _exact_id)
+                for spec in expected
+            ):
                 return False
         elif key == "$nor":
-            if any(matches_filter(doc, spec, _array_document) for spec in expected):
+            if any(
+                matches_filter(doc, spec, _array_document, _exact_id)
+                for spec in expected
+            ):
                 return False
         elif key in _IGNORED_FILTER_OPERATORS:
             continue
@@ -1123,14 +1109,14 @@ def matches_filter(doc, filter_doc, _array_document=False):
             if not _field_path_matches(
                 candidates,
                 expected,
-                exact=key == "_id",
+                exact=_exact_id and key == "_id",
                 indexed_endpoints=indexed_endpoints,
             ):
                 return False
     return True
 
 
-def _validate_regex_literal(value):
+def _validate_regex_transport_literal(value):
     """Reject regex values that cannot cross a BSON persistence boundary."""
 
     try:
@@ -1145,6 +1131,13 @@ def _validate_regex_literal(value):
             "Regular-expression patterns cannot contain NUL",
             code=2,
         )
+    return pattern, options
+
+
+def _validate_regex_literal(value):
+    """Reject regex values that cannot be executed by the query matcher."""
+
+    _pattern, options = _validate_regex_transport_literal(value)
     if is_native_regex(value) or "l" in options:
         return
     compile_pattern, flags = regex_compile_components(value)
@@ -1157,15 +1150,18 @@ def _validate_regex_literal(value):
         ) from error
 
 
-def _validate_regex_literals(value):
+def _validate_regex_literals(value, compile_patterns=True):
     if is_bson_regex(value):
-        _validate_regex_literal(value)
+        if compile_patterns:
+            _validate_regex_literal(value)
+        else:
+            _validate_regex_transport_literal(value)
     elif isinstance(value, Mapping):
         for item in value.values():
-            _validate_regex_literals(item)
+            _validate_regex_literals(item, compile_patterns=compile_patterns)
     elif isinstance(value, (list, tuple)):
         for item in value:
-            _validate_regex_literals(item)
+            _validate_regex_literals(item, compile_patterns=compile_patterns)
 
 
 def _regex_query_flags(options):
@@ -1227,7 +1223,29 @@ def _validate_field_filter_operators(expression):
                 "Field query documents cannot mix operators and literal fields",
                 code=2,
             )
-        _validate_regex_literals(operand)
+        if operator in ("$gt", "$gte", "$lt", "$lte"):
+            if is_bson_regex(operand):
+                raise OperationFailure(
+                    "Can't have RegEx as arg to non-equality predicate",
+                    code=2,
+                )
+            _validate_regex_literals(operand, compile_patterns=False)
+        elif operator == "$eq":
+            _validate_regex_literals(operand, compile_patterns=False)
+        elif operator == "$ne":
+            if is_bson_regex(operand):
+                raise OperationFailure("Can't have regex as arg to $ne", code=2)
+            _validate_regex_literals(operand, compile_patterns=False)
+        elif operator not in (
+            "$all",
+            "$elemMatch",
+            "$in",
+            "$nin",
+            "$not",
+            "$options",
+            "$regex",
+        ):
+            _validate_regex_literals(operand)
         if operator in ("$all", "$in", "$nin") and not isinstance(
             operand, (list, tuple)
         ):
@@ -1256,7 +1274,11 @@ def _validate_field_filter_operators(expression):
                     ),
                     code=2,
                 )
-            _validate_regex_literals(operand)
+            for item in operand:
+                _validate_regex_literals(
+                    item,
+                    compile_patterns=is_bson_regex(item),
+                )
         if operator == "$all":
             for item in operand:
                 nested_operators = (
@@ -1265,6 +1287,10 @@ def _validate_field_filter_operators(expression):
                     else []
                 )
                 if not nested_operators:
+                    _validate_regex_literals(
+                        item,
+                        compile_patterns=is_bson_regex(item),
+                    )
                     continue
                 if set(item) != {"$elemMatch"}:
                     if "$regex" in item:
@@ -1340,7 +1366,10 @@ def validate_filter_operators(filter_doc):
         ):
             _validate_field_filter_operators(expected)
         else:
-            _validate_regex_literals(expected)
+            _validate_regex_literals(
+                expected,
+                compile_patterns=is_bson_regex(expected),
+            )
 
 
 def query_operator_capabilities():
@@ -1356,29 +1385,66 @@ def query_operator_capabilities():
 def _validate_regex_field_expression(expression):
     """Validate only regex-specific shapes without widening query policy."""
 
-    if "$regex" in expression:
-        _validate_regex_query_operand(
-            expression["$regex"], expression.get("$options", "")
-        )
-    for operator in ("$all", "$in", "$nin"):
-        operand = expression.get(operator)
-        if not isinstance(operand, (list, tuple)):
-            continue
-        if any(isinstance(item, Mapping) and "$regex" in item for item in operand):
-            raise OperationFailure(
-                "{0} accepts regex values, not $regex operator documents".format(
-                    operator
-                ),
-                code=2,
-            )
-        _validate_regex_literals(operand)
-    not_operand = expression.get("$not")
-    if isinstance(not_operand, Mapping) and any(
-        str(key).startswith("$") for key in not_operand
-    ):
-        _validate_regex_field_expression(not_operand)
+    for operator, operand in expression.items():
+        if operator in ("$gt", "$gte", "$lt", "$lte"):
+            if is_bson_regex(operand):
+                raise OperationFailure(
+                    "Can't have RegEx as arg to non-equality predicate",
+                    code=2,
+                )
+            _validate_regex_literals(operand, compile_patterns=False)
+        elif operator == "$eq":
+            _validate_regex_literals(operand, compile_patterns=False)
+        elif operator == "$ne":
+            if is_bson_regex(operand):
+                raise OperationFailure("Can't have regex as arg to $ne", code=2)
+            _validate_regex_literals(operand, compile_patterns=False)
+        elif operator in ("$all", "$in", "$nin"):
+            if not isinstance(operand, (list, tuple)):
+                continue
+            if any(isinstance(item, Mapping) and "$regex" in item for item in operand):
+                raise OperationFailure(
+                    "{0} accepts regex values, not $regex operator documents".format(
+                        operator
+                    ),
+                    code=2,
+                )
+            for item in operand:
+                if (
+                    operator == "$all"
+                    and isinstance(item, Mapping)
+                    and set(item) == {"$elemMatch"}
+                ):
+                    _validate_regex_elem_match_operand(item["$elemMatch"])
+                else:
+                    _validate_regex_literals(
+                        item,
+                        compile_patterns=is_bson_regex(item),
+                    )
+        elif operator == "$regex":
+            _validate_regex_query_operand(operand, expression.get("$options", ""))
+        elif operator == "$not":
+            if isinstance(operand, Mapping) and any(
+                str(key).startswith("$") for key in operand
+            ):
+                _validate_regex_field_expression(operand)
+            else:
+                _validate_regex_literals(operand)
+        elif operator == "$elemMatch":
+            _validate_regex_elem_match_operand(operand)
+
+
+def _validate_regex_elem_match_operand(operand):
+    """Walk regex contexts inside ``$elemMatch`` without full validation."""
+
+    if not isinstance(operand, Mapping):
+        return
+    if any(key in _LOGICAL_FILTER_OPERATORS for key in operand):
+        validate_regex_filter(operand)
+    elif any(key in _FIELD_FILTER_OPERATORS for key in operand):
+        _validate_regex_field_expression(operand)
     else:
-        _validate_regex_literals(not_operand)
+        validate_regex_filter(operand)
 
 
 def validate_regex_filter(filter_doc):
@@ -1395,7 +1461,10 @@ def validate_regex_filter(filter_doc):
         ):
             _validate_regex_field_expression(expected)
         else:
-            _validate_regex_literals(expected)
+            _validate_regex_literals(
+                expected,
+                compile_patterns=is_bson_regex(expected),
+            )
 
 
 def _filter_references_id(filter_doc):
@@ -1521,12 +1590,13 @@ def requires_python_filter(filter_doc):
                 ):
                     return True
                 if any(
-                    operator in expected and is_bson_number(expected[operator])
-                    for operator in ("$gt", "$gte", "$lt", "$lte")
+                    operator in expected for operator in ("$gt", "$gte", "$lt", "$lte")
                 ):
-                    # Tagged Decimal128 values live in JSON objects, so native
-                    # numeric predicates cannot provide a complete candidate
-                    # set when the query operand is an int or double.
+                    # Native JSON/SQL predicates do not implement BSON type
+                    # bracketing, array-member matching, recursive object/array
+                    # comparison, or Decimal128's numeric family. Keep every
+                    # range predicate on the shared BSON matcher until a
+                    # backend can provide a complete candidate superset.
                     return True
     return False
 

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -21,7 +21,7 @@ from .bson_types import (
     add_bson_numbers,
     bson_identity_key,
     bson_number_decimal,
-    bson_scalar_sort_key,
+    bson_query_range_matches,
     bson_value_identity_key,
     bson_value_sort_key,
     bson_values_equal,
@@ -392,12 +392,10 @@ def _validate_pull_field_condition(condition):
     for key, operand in condition.items():
         if key not in _PULL_FIELD_OPERATORS:
             _raise_write_error("$pull does not support query operator {0}".format(key))
-        if key in _PULL_COMPARISON_OPERATORS and (
-            operand is None or bson_scalar_sort_key(operand) is None
-        ):
-            _raise_write_error(
-                "$pull {0} requires a supported scalar value".format(key)
-            )
+        if key in _PULL_COMPARISON_OPERATORS and is_bson_regex(operand):
+            _raise_write_error("Can't have RegEx as arg to non-equality predicate")
+        if key in _PULL_COMPARISON_OPERATORS and bson_value_sort_key(operand) is None:
+            _raise_write_error("$pull {0} requires a supported BSON value".format(key))
 
 
 def _validate_pull_document_condition(condition):
@@ -519,41 +517,10 @@ def _apply_add_to_set(current, value):
 
 
 def _pull_comparison_matches(actual, operand, comparison):
-    operand_identity = bson_identity_key(operand)
-    operand_order = bson_scalar_sort_key(operand)
-    values = actual if isinstance(actual, (list, tuple)) else [actual]
-    for value in values:
-        value_identity = bson_identity_key(value)
-        value_order = bson_scalar_sort_key(value)
-        if (
-            value_identity is not None
-            and value_identity[0] == "number"
-            and is_bson_number(value)
-            and is_bson_number(operand)
-            and (
-                bson_number_decimal(value).is_nan()
-                != bson_number_decimal(operand).is_nan()
-            )
-        ):
-            continue
-        if (
-            value_identity is not None
-            and value_order is not None
-            and value_identity[0] == operand_identity[0]
-            and comparison(value_order[1], operand_order[1])
-        ):
-            return True
-    return False
+    return bson_query_range_matches(actual, operand, comparison)
 
 
 def _pull_field_matches(actual, condition):
-    if actual is _MISSING:
-        return False
-    if not isinstance(condition, Mapping) or not any(
-        isinstance(key, str) and key.startswith("$") for key in condition
-    ):
-        return _value_matches(actual, condition)
-
     for query_operator, operand in condition.items():
         if query_operator == "$eq":
             if not _value_matches(actual, operand):
@@ -566,19 +533,9 @@ def _pull_field_matches(actual, condition):
 
 
 def _pull_document_matches(document, condition):
-    for key, expected in condition.items():
-        if key == "$and":
-            if not all(_pull_document_matches(document, item) for item in expected):
-                return False
-        elif key == "$or":
-            if not any(_pull_document_matches(document, item) for item in expected):
-                return False
-        elif key == "$nor":
-            if any(_pull_document_matches(document, item) for item in expected):
-                return False
-        elif not _pull_field_matches(_get_nested(document, key), expected):
-            return False
-    return True
+    # An ``_id`` field inside an array element is an ordinary embedded field,
+    # not the collection document's scalar-special primary key.
+    return matches_filter(document, condition, _exact_id=False)
 
 
 def _pull_matches(item, condition):


### PR DESCRIPTION
Closes #94.

## Summary

This PR completes the BSON comparison and sort-order work for TinyMongo's supported value families.

- Centralizes `$gt`, `$gte`, `$lt`, and `$lte` in one recursive BSON-aware comparison helper.
- Applies MongoDB type bracketing while keeping integers, doubles, and Decimal128 in one numeric family.
- Supports whole-array comparison, direct array-member matching, recursive document and array ordering, dotted array fanout, and numeric array path components.
- Routes range predicates through the shared Python matcher whenever a backend-native or indexed predicate cannot preserve the complete BSON candidate set.
- Reuses the same semantics for `$pull`, including missing/null fields and embedded `_id` values inside `$pull` and `$elemMatch`.
- Compares datetimes at MongoDB's signed UTC millisecond precision.
- Corrects legacy Binary subtype 2 ordering by including its four-byte inner-length prefix.
- Rejects direct regex range operands with MongoDB error code `2` while treating regex values nested in documents and arrays as comparison data.
- Preserves input order when BSON comparison keys are equal in both ascending and descending sorts.
- Updates the README, changelog, roadmap, and compatibility-report documentation.

## Root cause

The embedded backends previously allowed native TinyDB or SQL predicates to handle some range filters. Those predicates do not implement MongoDB's BSON type bracketing, recursive container ordering, Decimal128 numeric equivalence, or array-member rules. Query, sort, update, and regex-validation paths also had small independent implementations that could drift from one another.

This change gives supported comparison consumers a shared semantic source and deliberately uses the Python matcher when a native predicate cannot safely produce a complete candidate set.

## Compatibility scope

The generated contract suite runs every case through:

- synchronous and asynchronous APIs
- memory, JSON, SQLite, DuckDB, and Parquet
- live MongoDB as the same-API reference

The focused report is publishable with **204/204 cells observed**, **170/170 reference-qualified embedded cells compatible**, no missing or skipped cells, and a **100% compatibility score**.

Remaining unique-index token extensions stay tracked under #75 and #76. Update `$min` and `$max` remain tracked under #77 and are not claimed by this PR.

## Validation

- `.venv/bin/coverage run --branch -m pytest`
  - **3,002 passed, 431 deselected**
- `.venv/bin/coverage report --include='tinymongo/*' --fail-under=100`
  - **100% statement and branch coverage**
  - 7,227 statements and 2,968 branches, with no misses
- Focused sync/async live differential matrix:
  - **204 passed**
  - complete and publishable
  - no missing, skipped, duplicate, failed, or unqualified reference cells
- Black
- Ruff
- `git diff --check`
