### PR TITLE
Honor PyMongo document and datetime read fidelity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: >-
           pytest -o addopts='' -q
           tests/test_bson_registry_hardening.py tests/test_cli.py
+          tests/test_client_configuration.py
 
   test:
     runs-on: ubuntu-latest
@@ -410,4 +411,5 @@ jobs:
           pytest -o addopts='' -q
           tests/test_patching.py tests/test_bson_codec.py
           tests/test_insert_many_semantics.py tests/test_talkpython_regressions.py
+          tests/test_client_configuration.py tests/test_client_read_fidelity.py
           -k 'not duckdb and not parquet'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@
   operand validation across synchronous and asynchronous clients.
 
 ### Changed
+- Datetimes now persist in MongoDB's canonical signed UTC millisecond form.
+  Naive inputs are interpreted as UTC, aware inputs are converted to UTC, and
+  PyMongo-shaped clients return naive UTC by default or timezone-aware values
+  when configured with `tz_aware` and optional `tzinfo`.
+- When PyMongo is installed, recognized connection option names are derived
+  from that version's validator catalog; dependency-free use retains the
+  bundled fallback set.
 - Aggregation capability reporting now describes the exact supported stages,
   accumulators, and expressions instead of reporting a blanket unsupported
   value. The value therefore changed from falsey `False` to a truthy structured
@@ -49,6 +56,13 @@
   constraint.
 
 ### Fixed
+- **TM-019 / TM-030:** `MongoClient` and `AsyncMongoClient` now honor
+  `document_class` recursively across finds, projections, aggregation,
+  document-valued `distinct()` results, and find-and-modify returns. The same
+  paths also honor `tz_aware` and `tzinfo`, with eager option validation.
+- Unknown or misplaced `$` operators in document-form `$elemMatch` now raise
+  `OperationFailure` code `2`, while valid but unsupported MongoDB predicates
+  continue to raise `TinyMongoNotSupportedError`.
 - **#94:** `$gt`, `$gte`, `$lt`, and `$lte` now share recursive BSON
   type-bracketed comparison semantics across queries, aggregation `$match`,
   and `$pull`, including direct array-member matching. Datetimes compare at

--- a/README.md
+++ b/README.md
@@ -71,12 +71,23 @@ rows = list(users.find({}).sort("score", pymongo.DESCENDING))
 
 This is intended for the supported TinyMongo subset of PyMongo operations, not
 for server features such as authentication, replica sets, sessions, or network
-connections. MongoDB URIs, host names, ports, and recognized PyMongo connection
-kwargs are accepted and ignored so existing code can be tried locally. Unknown
-or misspelled kwargs fail eagerly with `ConfigurationError`, matching PyMongo's
-configuration behavior instead of silently selecting the wrong local storage.
-Set `TINYMONGO_HOME` or pass `tinymongo_folder=` to choose where TinyMongo stores
-files. See `examples/pymongo_dropin.py` for a runnable example.
+connections. MongoDB URIs, host names, ports, and recognized network connection
+kwargs are accepted and ignored so existing code can be tried locally. When
+PyMongo is installed, TinyMongo derives those accepted option names from that
+installed version; dependency-free installs use a bundled fallback list.
+Unknown or misspelled kwargs fail eagerly with `ConfigurationError`, matching
+PyMongo's configuration behavior instead of silently selecting the wrong local
+storage. Set `TINYMONGO_HOME` or pass `tinymongo_folder=` to choose where
+TinyMongo stores files. See `examples/pymongo_dropin.py` for a runnable example.
+
+The behavior-bearing read options are not ignored. `document_class` constructs
+top-level and nested result documents—including documents inside arrays—with a
+mutable mapping class such as `OrderedDict` or `bson.SON`. Datetimes are stored
+as signed UTC milliseconds, just like BSON. Results are naive UTC by default;
+set `tz_aware=True` for aware UTC values, and optionally pass `tzinfo=` to
+convert the same instant to another timezone. These rules apply equally to the
+synchronous and asynchronous PyMongo-shaped clients. Raw BSON views via
+`RawBSONDocument` are not part of the embedded-storage document-class subset.
 
 ## Async API
 
@@ -198,9 +209,11 @@ keywords raise `TypeError` instead of being silently ignored. The other
 supported backend configuration keywords are `threads`, `storage_uri`,
 `duckdb_config`, and `dsn`.
 
-The PyMongo-shaped `MongoClient` and `AsyncMongoClient` accept recognized
-PyMongo connection kwargs for drop-in use and ignore their network effects.
-Unknown or misspelled kwargs raise `ConfigurationError` before storage opens.
+The PyMongo-shaped `MongoClient` and `AsyncMongoClient` accept the installed
+PyMongo version's recognized connection kwargs for drop-in use and ignore their
+network effects. Unknown or misspelled kwargs raise `ConfigurationError` before
+storage opens. `document_class`, `tz_aware`, and `tzinfo` are validated before
+storage opens and control returned values recursively.
 
 Parquet can also store collection files in object storage by passing
 `storage_uri` or setting `TINYMONGO_STORAGE_URI`. Object-storage Parquet is
@@ -366,7 +379,8 @@ tinymongo migrate ./tinydb ./unused --to-backend postgres --target-dsn "$TINYMON
 ```
 
 Export and import use the same tagged JSON codec as storage, so supported
-datetime, ObjectId, bytes, and Binary values round-trip. `bytearray` is accepted
+datetime, ObjectId, bytes, and Binary values remain portable. Datetimes use
+BSON's canonical naive-UTC millisecond representation. `bytearray` is accepted
 and imports back as `bytes`. Inspection, collection listing, and migration omit
 TinyDB's internal `_default` table. Export preserves embedded-document field
 order, including document-valued `_id` values. Replace-mode imports and
@@ -628,9 +642,11 @@ MongoDB's broader expression language are not part of this slice yet.
 
 ## ObjectId, datetime, binary, Decimal128, UUID, and regex values
 
-`datetime`, `bytes`, native `uuid.UUID`, and compiled `re.Pattern` values
-round-trip through every backend. `bytearray` is accepted and reads back as
-`bytes`. Install the optional BSON extra to use `bson.ObjectId`,
+`datetime`, `bytes`, native `uuid.UUID`, and compiled `re.Pattern` values are
+supported by every backend. Datetimes are converted to BSON's signed UTC
+millisecond representation; naive inputs are treated as UTC and aware inputs
+are converted to UTC. `bytearray` is accepted and reads back as `bytes`. Install
+the optional BSON extra to use `bson.ObjectId`,
 `bson.Decimal128`, `bson.Regex`, or non-generic `bson.Binary` subtypes without
 making PyMongo a core dependency:
 
@@ -712,9 +728,9 @@ BinData—including UUID—sorts by length, subtype, and then unsigned bytes,
 matching MongoDB; legacy subtype 2 includes its four-byte inner-length prefix
 when its comparison length is calculated. Regex values sort by pattern and
 canonical options after the other supported scalar families. Numeric `NaN`
-sorts below every other numeric value, matching MongoDB. TinyMongo can retain
-Python microseconds on round-trip, but BSON equality, range comparisons, and
-sorting use MongoDB's signed UTC millisecond precision.
+sorts below every other numeric value, matching MongoDB. Persistence, returned
+values, equality, range comparisons, and sorting all use MongoDB's signed UTC
+millisecond precision.
 
 Decimal128 values retain their exact BSON representation and participate in
 numeric equality and range queries, sorting, embedded-backend unique indexes,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,6 +157,19 @@ with the follow-up audit of his
 - [x] **TM-029:** Accept and ignore `$comment` in document-form `$elemMatch`
   filters, and reject it as a field operator with `OperationFailure` code `2`.
 
+#### Mike's [TM-019 / TM-030 final fidelity follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5159617517)
+
+- [x] **TM-019:** Store and return datetimes with BSON's signed UTC
+  millisecond precision, including correct pre-epoch flooring and no-op write
+  results for changes within one millisecond.
+- [x] **TM-030:** Honor `document_class` recursively and apply `tz_aware` plus
+  optional `tzinfo` across synchronous and asynchronous result paths.
+- [x] Derive accepted connection option names from the installed PyMongo
+  validator catalog, with a dependency-free fallback pinned in TinyMongo.
+- [x] Match MongoDB error code `2` for unknown or misplaced operators inside
+  `$elemMatch`, while preserving explicit unsupported errors for valid MongoDB
+  predicates outside TinyMongo's subset.
+
 - [x] **Remote SQL numeric uniqueness:** Persist versioned, fixed-width digests
   of canonical BSON scalar tokens for PostgreSQL and MariaDB/MySQL unique
   indexes. Native constraints now enforce exact cross-process equality for
@@ -214,6 +227,8 @@ Application-compatibility work:
     MongoDB and TinyMongo SQLite each passed 597 tests.
   - [x] Complete the write-heavy admin and multi-worker SQLite follow-up: all
     21 admin checks passed with no errors, lost writes, or torn reads.
+  - [x] Close the TM-019/TM-030 returned-value gaps for recursive document
+    classes and MongoDB-compatible datetime decoding.
 - [x] [#73: Common client, collection, and cursor API](https://github.com/schapman1974/tinymongo/issues/73)
 - [x] [#75: Optional BSON serialization](https://github.com/schapman1974/tinymongo/issues/75)
   - [x] Milestone 1 ObjectId, datetime, and Binary storage/query support.
@@ -229,6 +244,8 @@ Application-compatibility work:
     failures, including the `$min` and `$max` update modifiers.
 - [ ] [#102: Optional PyMongo-version adaptation](https://github.com/schapman1974/tinymongo/issues/102)
   - [x] TinyMongo errors conditionally inherit matching PyMongo errors.
+  - [x] Derive accepted connection option names from the installed PyMongo
+    validator catalog while retaining a dependency-free fallback.
   - [ ] Add version-matrix CI plus broader signature and result adaptation.
 - [ ] [#72: Real MongoDB and application contract suite](https://github.com/schapman1974/tinymongo/issues/72)
   - [x] Generate deterministic, dimensioned compatibility reports from the

--- a/docs/TALKPYTHON_ACCEPTANCE.md
+++ b/docs/TALKPYTHON_ACCEPTANCE.md
@@ -172,6 +172,14 @@ backend-specific locking and durability, the full object-storage environment
 table, portable capability and duplicate-error examples, and the fact that CLI
 migration does not copy source index metadata.
 
+Mike's final TM-019/TM-030 fidelity pass is also captured as shared contracts.
+PyMongo-shaped synchronous and asynchronous clients recursively honor
+`document_class`, `tz_aware`, and `tzinfo`; persisted datetimes now use BSON's
+signed UTC millisecond representation. The option-name allowlist follows the
+installed PyMongo validator catalog when available, and malformed operators
+inside `$elemMatch` report MongoDB error code `2` without disguising valid but
+unsupported predicates as malformed input.
+
 ## Handling failures
 
 For each difference found in the real application:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ minversion = "6.0"
 addopts = "-q -m 'not integration and not mongodb and not legacy_mongodb'"
 markers = [
   "contract: shared application-facing compatibility contracts",
+  "client_options: configure PyMongo-shaped clients for a shared contract",
   "integration: opt-in integration and stress tests that may be slower or resource intensive",
   "legacy_mongodb: quarantined MongoDB comparisons retained only during contract migration",
   "mongodb: requires a real MongoDB server selected through TINYMONGO_MONGODB_URI",

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 import pytest
 import tinymongo
-from tinymongo.asyncio import AsyncTinyMongoClient
+from tinymongo.asyncio import AsyncMongoClient, AsyncTinyMongoClient
 
 from .support import ContractTarget
 
@@ -99,13 +99,17 @@ class _AsyncCollectionAdapter:
         return call
 
 
-def _mongo_client(uri):
+def _mongo_client(uri, client_options=None):
     try:
         from pymongo import MongoClient
     except ImportError:  # pragma: no cover - guarded by dev requirements
         pytest.fail("Real MongoDB contracts require PyMongo; run `pip install pymongo`")
 
-    client = MongoClient(uri, serverSelectionTimeoutMS=1000)
+    client = MongoClient(
+        uri,
+        serverSelectionTimeoutMS=1000,
+        **dict(client_options or {}),
+    )
     deadline = time.monotonic() + 15
     last_error = None
     while time.monotonic() < deadline:
@@ -119,13 +123,17 @@ def _mongo_client(uri):
     raise RuntimeError("MongoDB did not become ready: {0}".format(last_error))
 
 
-def _async_mongo_client(uri, runner):
+def _async_mongo_client(uri, runner, client_options=None):
     try:
         from pymongo import AsyncMongoClient
     except ImportError:  # pragma: no cover - guarded by dev requirements
         pytest.fail("Real MongoDB contracts require PyMongo; run `pip install pymongo`")
 
-    client = AsyncMongoClient(uri, serverSelectionTimeoutMS=1000)
+    client = AsyncMongoClient(
+        uri,
+        serverSelectionTimeoutMS=1000,
+        **dict(client_options or {}),
+    )
     deadline = time.monotonic() + 15
     last_error = None
     while time.monotonic() < deadline:
@@ -144,6 +152,8 @@ def _contract_suite(request):
         return "talkpython"
     if "test_bson_comparison_contract.py" in request.node.nodeid:
         return "bson-comparison"
+    if "test_client_read_fidelity_contract.py" in request.node.nodeid:
+        return "client-read-fidelity"
     return "core"
 
 
@@ -152,6 +162,8 @@ def contract_target(request, tmp_path, monkeypatch):
     """Yield an isolated collection for a TinyMongo backend or real MongoDB."""
 
     api, target_name = request.param
+    options_marker = request.node.get_closest_marker("client_options")
+    client_options = dict(options_marker.kwargs) if options_marker else {}
     database_name = "tinymongo_contract_{0}".format(uuid4().hex)
     request.node.user_properties.extend(
         [
@@ -173,9 +185,9 @@ def contract_target(request, tmp_path, monkeypatch):
         try:
             if api == "async":
                 runner = _AsyncRunner()
-                client = _async_mongo_client(uri, runner)
+                client = _async_mongo_client(uri, runner, client_options)
             else:
-                client = _mongo_client(uri)
+                client = _mongo_client(uri, client_options)
         except RuntimeError as error:
             if runner is not None:
                 runner.close()
@@ -223,9 +235,13 @@ def contract_target(request, tmp_path, monkeypatch):
     runner = None
     if api == "async":
         runner = _AsyncRunner()
-        client = AsyncTinyMongoClient(*arguments, **options)
+        client_class = AsyncMongoClient if client_options else AsyncTinyMongoClient
+        client = client_class(*arguments, **options, **client_options)
     else:
-        client = tinymongo.TinyMongoClient(*arguments, **options)
+        client_class = (
+            tinymongo.MongoClient if client_options else tinymongo.TinyMongoClient
+        )
+        client = client_class(*arguments, **options, **client_options)
     database = client[database_name]
     collection = database["items"]
     if runner is not None:

--- a/tests/contracts/test_client_read_fidelity_contract.py
+++ b/tests/contracts/test_client_read_fidelity_contract.py
@@ -1,0 +1,112 @@
+"""Configured-client read contracts shared with a real MongoDB server."""
+
+from collections import OrderedDict
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+pytestmark = [
+    pytest.mark.contract,
+    pytest.mark.client_options(document_class=OrderedDict, tz_aware=True),
+]
+
+
+_STORED = datetime(
+    2026,
+    1,
+    2,
+    3,
+    4,
+    5,
+    123456,
+    tzinfo=timezone(timedelta(hours=-5)),
+)
+_UTC_MILLIS = datetime(
+    2026,
+    1,
+    2,
+    8,
+    4,
+    5,
+    123000,
+    tzinfo=timezone.utc,
+)
+
+
+def _assert_recursive_class(document):
+    assert type(document) is OrderedDict
+    assert type(document["inner"]) is OrderedDict
+    assert type(document["items"][0]) is OrderedDict
+    assert type(document["items"][0]["deep"]) is OrderedDict
+
+
+def test_configured_document_and_datetime_results_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "main",
+            "when": _STORED,
+            "inner": {"when": _STORED},
+            "items": [{"deep": {"when": _STORED}}],
+        }
+    )
+
+    found = collection.find_one({"_id": "main"})
+    _assert_recursive_class(found)
+    assert found["when"] == _UTC_MILLIS
+    assert found["when"].utcoffset() == timedelta(0)
+    assert found["inner"]["when"] == _UTC_MILLIS
+    assert found["items"][0]["deep"]["when"] == _UTC_MILLIS
+
+    projected = list(
+        collection.find(
+            {"_id": "main"},
+            {"inner": 1, "items": 1, "when": 1},
+        )
+    )[0]
+    _assert_recursive_class(projected)
+
+    aggregated = list(
+        collection.aggregate(
+            [
+                {"$match": {"_id": "main"}},
+                {"$project": {"inner": 1, "items": 1, "when": 1}},
+            ]
+        )
+    )[0]
+    _assert_recursive_class(aggregated)
+
+    distinct = collection.distinct("inner")
+    assert len(distinct) == 1
+    assert type(distinct[0]) is OrderedDict
+    assert distinct[0]["when"] == _UTC_MILLIS
+
+    collection.insert_one({"_id": "modify", "inner": {"value": 1}})
+    modified = collection.find_one_and_update(
+        {"_id": "modify"},
+        {"$set": {"inner.value": 2}},
+        projection={"_id": 0, "inner": 1},
+        return_document=True,
+    )
+    assert type(modified) is OrderedDict
+    assert type(modified["inner"]) is OrderedDict
+
+
+def test_same_millisecond_write_identity_matches_mongodb(contract_target):
+    collection = contract_target.collection
+    first = datetime(2026, 1, 2, 3, 4, 5, 123001, tzinfo=timezone.utc)
+    same_millisecond = first.replace(microsecond=123999)
+    collection.insert_one({"_id": "same-millisecond", "when": first})
+
+    updated = collection.update_one(
+        {"_id": "same-millisecond"},
+        {"$set": {"when": same_millisecond}},
+    )
+    replaced = collection.replace_one(
+        {"_id": "same-millisecond"},
+        {"_id": "same-millisecond", "when": same_millisecond},
+    )
+
+    assert updated.modified_count == 0
+    assert replaced.modified_count == 0

--- a/tests/contracts/test_query_operator_contract.py
+++ b/tests/contracts/test_query_operator_contract.py
@@ -461,6 +461,28 @@ def test_recognized_query_operators_reject_malformed_operands(contract_target):
             list(collection.find(query))
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"numbers": {"$elemMatch": {"$nonsense": 1}}},
+        {"numbers": {"$elemMatch": {"$gt": 4, "$nonsense": 1}}},
+        {"numbers": {"$elemMatch": {"$and": [{"$gt": 4}]}}},
+    ],
+    ids=("unknown", "unknown-beside-field-operator", "misplaced-logical-clause"),
+)
+def test_elem_match_unknown_or_misplaced_operators_report_code_2(
+    contract_target,
+    query,
+):
+    collection = contract_target.collection
+    collection.insert_one({"_id": "original", "numbers": [1, 5, 10]})
+
+    with pytest.raises(_OPERATION_ERRORS) as caught:
+        list(collection.find(query))
+
+    assert caught.value.code == 2
+
+
 def test_comment_is_accepted_and_ignored_while_matching(contract_target):
     collection = contract_target.collection
     collection.insert_many(

--- a/tests/test_bson_codec.py
+++ b/tests/test_bson_codec.py
@@ -90,15 +90,33 @@ def _extended_document():
     }
 
 
-def test_codec_round_trips_nested_object_ids_and_aware_datetimes():
+def _canonical_extended_document(document):
+    return {
+        "_id": document["_id"],
+        "created": bson_types.canonicalize_datetime(document["created"]),
+        "nested": {
+            "owner_id": document["nested"]["owner_id"],
+            "history": [
+                {
+                    "at": bson_types.canonicalize_datetime(
+                        document["nested"]["history"][0]["at"]
+                    )
+                },
+                document["nested"]["history"][1],
+            ],
+        },
+    }
+
+
+def test_codec_round_trips_nested_object_ids_and_canonical_datetimes():
     document = _extended_document()
 
     restored = bson_codec.loads(bson_codec.dumps(document))
 
-    assert restored == document
+    assert restored == _canonical_extended_document(document)
     assert isinstance(restored["_id"], ObjectId)
-    assert restored["created"].tzinfo is not None
-    assert restored["created"].utcoffset() == timedelta(hours=-4)
+    assert restored["created"].tzinfo is None
+    assert restored["created"].microsecond == 123000
     assert isinstance(restored["nested"]["owner_id"], ObjectId)
     assert isinstance(restored["nested"]["history"][0]["at"], datetime)
     assert isinstance(restored["nested"]["history"][1], ObjectId)
@@ -117,8 +135,52 @@ def test_codec_tags_are_valid_readable_json():
     }
     assert encoded["created"] == {
         "__tinymongo_type_v1__": "datetime",
-        "value": document["created"].isoformat(),
+        "value": "2026-07-19T13:30:45.123",
     }
+
+
+def test_codec_canonicalizes_legacy_aware_datetime_tags():
+    tagged = {
+        "__tinymongo_type_v1__": "datetime",
+        "value": "2026-07-19T09:30:45.123999-04:00",
+    }
+
+    assert bson_codec.decode_value(tagged) == datetime(2026, 7, 19, 13, 30, 45, 123000)
+
+
+def test_codec_canonicalizes_pre_epoch_datetimes_without_float_rounding():
+    value = datetime(1969, 12, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+    assert bson_types.datetime_milliseconds(value) == -1
+    assert bson_types.canonicalize_datetime(value) == datetime(
+        1969, 12, 31, 23, 59, 59, 999000
+    )
+    assert bson_codec.loads(bson_codec.dumps(value)) == datetime(
+        1969, 12, 31, 23, 59, 59, 999000
+    )
+
+
+def test_canonical_datetime_supports_aware_and_requested_timezone_results():
+    value = datetime(2026, 7, 19, 13, 30, 45, 123999)
+    eastern = timezone(timedelta(hours=-4))
+
+    assert bson_types.canonicalize_datetime(value, tz_aware=True) == datetime(
+        2026, 7, 19, 13, 30, 45, 123000, tzinfo=timezone.utc
+    )
+    assert bson_types.canonicalize_datetime(
+        value,
+        tz_aware=True,
+        tzinfo=eastern,
+    ) == datetime(2026, 7, 19, 9, 30, 45, 123000, tzinfo=eastern)
+
+
+def test_storage_equality_uses_canonical_bson_datetime_milliseconds():
+    first = datetime(2026, 7, 19, 9, 30, 45, 123001, tzinfo=timezone.utc)
+    same_millisecond = first.replace(microsecond=123999)
+    next_millisecond = first.replace(microsecond=124000)
+
+    assert bson_codec.storage_values_equal(first, same_millisecond)
+    assert not bson_codec.storage_values_equal(first, next_millisecond)
 
 
 @pytest.mark.parametrize(
@@ -582,8 +644,9 @@ def test_extended_values_round_trip_through_public_backends(tmp_path, backend):
     try:
         restored = reader.app.events.find_one({"_id": document["_id"]})
 
-        assert restored == document
-        assert reader.app.events.find_one({"created": document["created"]}) == document
+        expected = _canonical_extended_document(document)
+        assert restored == expected
+        assert reader.app.events.find_one({"created": document["created"]}) == expected
     finally:
         reader.close()
 
@@ -642,4 +705,4 @@ def test_json_backend_persists_readable_tags(tmp_path):
     assert '"__tinymongo_type_v1__": "objectid"' in raw
     assert '"__tinymongo_type_v1__": "datetime"' in raw
     assert str(document["_id"]) in raw
-    assert document["created"].isoformat() in raw
+    assert "2026-07-19T13:30:45.123" in raw

--- a/tests/test_bson_registry_hardening.py
+++ b/tests/test_bson_registry_hardening.py
@@ -322,12 +322,9 @@ def test_valid_datetime_and_object_id_tags_still_decode():
     )
     object_id = bson.ObjectId("000000000000000000000001")
 
-    assert (
-        bson_codec.decode_value(
-            {"__tinymongo_type_v1__": "datetime", "value": moment.isoformat()}
-        )
-        == moment
-    )
+    assert bson_codec.decode_value(
+        {"__tinymongo_type_v1__": "datetime", "value": moment.isoformat()}
+    ) == datetime(2026, 7, 29, 12, 30)
     assert (
         bson_codec.decode_value(
             {"__tinymongo_type_v1__": "objectid", "value": str(object_id)}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,14 +198,15 @@ def test_cli_export_import_and_migrate_preserve_supported_bson_values(tmp_path, 
     imported = tm.TinyMongoClient(str(imported_target)).app.events.find_one(
         {"_id": object_id}
     )
-    assert imported == {
+    canonical_document = {
         "_id": object_id,
-        "created": created,
+        "created": created.replace(tzinfo=None),
         "price": bson.Decimal128("19.950"),
         "raw": b"\x00\x01\xff",
         "buffer": b"mutable",
         "binary": bson.Binary(b"0123456789abcdef", subtype=4),
     }
+    assert imported == canonical_document
 
     assert (
         cli.main(
@@ -223,7 +224,7 @@ def test_cli_export_import_and_migrate_preserve_supported_bson_values(tmp_path, 
     migrated = tm.TinyMongoClient(
         str(migrated_target), backend="sqlite"
     ).app.events.find_one({"_id": object_id})
-    assert migrated == document
+    assert migrated == canonical_document
 
 
 def test_cli_import_from_stdin_and_replace_mode(tmp_path, monkeypatch, capsys):

--- a/tests/test_client_configuration.py
+++ b/tests/test_client_configuration.py
@@ -1,6 +1,9 @@
 import asyncio
+from datetime import timezone
+from types import SimpleNamespace
 
 import pytest
+import tinymongo.tinymongo as core
 
 from tinymongo import (
     AsyncMongoClient,
@@ -9,6 +12,53 @@ from tinymongo import (
     TinyMongoClient,
 )
 from tinymongo.errors import ConfigurationError
+
+
+def test_connection_option_catalog_tracks_installed_pymongo_or_fallback():
+    try:
+        from pymongo.common import VALIDATORS
+    except ImportError:
+        expected = core._PYMONGO_CONNECTION_OPTIONS_FALLBACK
+    else:
+        expected = frozenset(name.lower() for name in VALIDATORS)
+
+    assert core._PYMONGO_CONNECTION_OPTIONS == expected
+
+
+def test_connection_option_catalog_uses_dynamic_validator_names(monkeypatch):
+    module = SimpleNamespace(VALIDATORS={"FutureOption": object()})
+    monkeypatch.setattr(core.importlib, "import_module", lambda name: module)
+
+    assert core._load_pymongo_connection_options() == frozenset({"futureoption"})
+
+
+def test_connection_option_catalog_falls_back_when_pymongo_is_missing(monkeypatch):
+    def missing(_name):
+        raise ImportError("pymongo is optional")
+
+    monkeypatch.setattr(core.importlib, "import_module", missing)
+
+    assert (
+        core._load_pymongo_connection_options()
+        == core._PYMONGO_CONNECTION_OPTIONS_FALLBACK
+    )
+
+
+@pytest.mark.parametrize(
+    "validators",
+    [None, {}, [], {1: object()}],
+)
+def test_connection_option_catalog_rejects_malformed_validator_tables(
+    monkeypatch,
+    validators,
+):
+    module = SimpleNamespace(VALIDATORS=validators)
+    monkeypatch.setattr(core.importlib, "import_module", lambda name: module)
+
+    assert (
+        core._load_pymongo_connection_options()
+        == core._PYMONGO_CONNECTION_OPTIONS_FALLBACK
+    )
 
 
 def test_tiny_client_honors_tinymongo_folder_alias(tmp_path, monkeypatch):
@@ -56,6 +106,88 @@ def test_async_mongo_client_accepts_default_configuration():
     client = AsyncMongoClient()
 
     asyncio.run(client.close())
+
+
+@pytest.mark.parametrize("client_class", [MongoClient, AsyncMongoClient])
+def test_pymongo_shaped_clients_validate_document_class_immediately(
+    tmp_path,
+    client_class,
+):
+    configured = tmp_path / "invalid-document-class"
+
+    with pytest.raises(TypeError, match="document_class must be a subclass"):
+        client_class(tinymongo_folder=configured, document_class=list)
+
+    assert not configured.exists()
+
+
+@pytest.mark.parametrize("client_class", [MongoClient, AsyncMongoClient])
+@pytest.mark.parametrize("document_class", [None, False, 0, "", [], {}])
+def test_pymongo_shaped_clients_treat_falsey_document_classes_as_default(
+    tmp_path,
+    client_class,
+    document_class,
+):
+    client = client_class(
+        tinymongo_folder=tmp_path / "default-document-class",
+        document_class=document_class,
+    )
+
+    if client_class is AsyncMongoClient:
+        asyncio.run(client.close())
+    else:
+        client.close()
+
+
+@pytest.mark.parametrize("client_class", [MongoClient, AsyncMongoClient])
+@pytest.mark.parametrize(
+    ("options", "error", "message"),
+    [
+        ({"tz_aware": 1}, TypeError, "tz_aware must be True or False"),
+        ({"tz_aware": "yes"}, ValueError, "must be 'true' or 'false'"),
+        ({"tz_aware": "TRUE"}, ValueError, "must be 'true' or 'false'"),
+        ({"tzinfo": "UTC"}, TypeError, "datetime.tzinfo"),
+        (
+            {"tzinfo": timezone.utc},
+            ValueError,
+            "cannot specify tzinfo without also setting tz_aware=True",
+        ),
+    ],
+)
+def test_pymongo_shaped_clients_validate_datetime_options_immediately(
+    tmp_path,
+    client_class,
+    options,
+    error,
+    message,
+):
+    configured = tmp_path / "invalid-datetime-option"
+
+    with pytest.raises(error, match=message):
+        client_class(tinymongo_folder=configured, **options)
+
+    assert not configured.exists()
+
+
+@pytest.mark.parametrize("client_class", [MongoClient, AsyncMongoClient])
+@pytest.mark.parametrize("tz_aware", [None, False, True, "false", "true"])
+def test_pymongo_shaped_clients_accept_datetime_option_forms(
+    tmp_path,
+    client_class,
+    tz_aware,
+):
+    options = {"tz_aware": tz_aware}
+    if tz_aware in (True, "true"):
+        options["tzInfo"] = timezone.utc
+    client = client_class(
+        tinymongo_folder=tmp_path / "configured",
+        **options,
+    )
+
+    if client_class is AsyncMongoClient:
+        asyncio.run(client.close())
+    else:
+        client.close()
 
 
 @pytest.mark.parametrize("client_class", [TinyMongoClient, AsyncTinyMongoClient])

--- a/tests/test_client_read_fidelity.py
+++ b/tests/test_client_read_fidelity.py
@@ -1,0 +1,350 @@
+import asyncio
+import copy
+from collections import OrderedDict, UserDict
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from tinymongo import AsyncMongoClient, MongoClient
+from tinymongo.storage_backends import clear_memory_namespace
+
+
+_BACKENDS = ("memory", "tinydb", "sqlite", "duckdb", "parquet")
+_STORED = datetime(
+    2026,
+    1,
+    2,
+    3,
+    4,
+    5,
+    123456,
+    tzinfo=timezone(timedelta(hours=-5)),
+)
+_UTC_MILLIS = datetime(2026, 1, 2, 8, 4, 5, 123000)
+_BEFORE_EPOCH = datetime(1969, 12, 31, 23, 59, 59, 999999)
+
+
+def _client_location(tmp_path, backend):
+    if backend == "memory":
+        return "memory://read-fidelity-{0}".format(uuid4().hex)
+    return str(tmp_path / backend)
+
+
+def _require_backend_dependencies(backend):
+    if backend in ("duckdb", "parquet"):
+        pytest.importorskip("duckdb")
+    if backend == "parquet":
+        pytest.importorskip("pyarrow")
+
+
+def _assert_recursive_document_class(document, document_class):
+    assert type(document) is document_class
+    assert type(document["inner"]) is document_class
+    assert type(document["items"][0]) is document_class
+    assert type(document["items"][0]["deep"]) is document_class
+
+
+def _close_clients(location, *clients):
+    for client in clients:
+        client.close()
+    if str(location).startswith("memory://"):
+        clear_memory_namespace(location)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_sync_mongo_client_materializes_documents_and_datetimes_across_backends(
+    tmp_path,
+    backend,
+):
+    _require_backend_dependencies(backend)
+    location = _client_location(tmp_path, backend)
+    client = MongoClient(
+        location,
+        backend=backend,
+        document_class=OrderedDict,
+    )
+    collection = client.app.items
+    source = {
+        "_id": "main",
+        "when": _STORED,
+        "before_epoch": _BEFORE_EPOCH,
+        "inner": {"when": _STORED},
+        "items": [{"deep": {"when": _STORED}}],
+    }
+    original = copy.deepcopy(source)
+
+    collection.insert_one(source)
+
+    assert source == original
+    found = collection.find_one({"_id": "main"})
+    _assert_recursive_document_class(found, OrderedDict)
+    assert found["when"] == _UTC_MILLIS
+    assert found["when"].tzinfo is None
+    assert found["before_epoch"] == datetime(1969, 12, 31, 23, 59, 59, 999000)
+    assert found["inner"]["when"] == _UTC_MILLIS
+    assert found["items"][0]["deep"]["when"] == _UTC_MILLIS
+
+    projected = collection.find_one(
+        {"_id": "main"},
+        {"inner": 1, "items": 1, "when": 1},
+    )
+    _assert_recursive_document_class(projected, OrderedDict)
+
+    cursor = collection.find({"_id": "main"})
+    indexed = cursor[0]
+    listed = cursor.clone().to_list()
+    _assert_recursive_document_class(indexed, OrderedDict)
+    _assert_recursive_document_class(listed[0], OrderedDict)
+
+    aggregated = collection.aggregate(
+        [
+            {"$match": {"_id": "main"}},
+            {"$project": {"inner": 1, "items": 1, "when": 1}},
+        ]
+    ).next()
+    _assert_recursive_document_class(aggregated, OrderedDict)
+
+    distinct = collection.distinct("inner")
+    assert len(distinct) == 1
+    assert type(distinct[0]) is OrderedDict
+    assert distinct[0]["when"] == _UTC_MILLIS
+
+    collection.insert_many(
+        [
+            {"_id": "update", "inner": {"value": 1}},
+            {"_id": "replace", "inner": {"value": 1}},
+            {"_id": "delete", "inner": {"value": 1}},
+        ]
+    )
+    updated = collection.find_one_and_update(
+        {"_id": "update"},
+        {"$set": {"inner.value": 2}},
+        projection={"_id": 0, "inner": 1},
+        return_document=True,
+    )
+    replaced = collection.find_one_and_replace(
+        {"_id": "replace"},
+        {"inner": {"value": 2}},
+        projection={"_id": 0, "inner": 1},
+        return_document=True,
+    )
+    deleted = collection.find_one_and_delete(
+        {"_id": "delete"},
+        projection={"_id": 0, "inner": 1},
+    )
+    for returned in (updated, replaced, deleted):
+        assert type(returned) is OrderedDict
+        assert type(returned["inner"]) is OrderedDict
+
+    database_metadata = client.list_databases().to_list()
+    assert database_metadata
+    assert type(database_metadata[0]) is dict
+    assert type(collection.list_indexes()[0]) is dict
+    assert type(collection.index_information()) is dict
+
+    _close_clients(location, client)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_sync_mongo_client_honors_aware_and_custom_timezone_reads(
+    tmp_path,
+    backend,
+):
+    _require_backend_dependencies(backend)
+    location = _client_location(tmp_path, backend)
+    writer = MongoClient(location, backend=backend)
+    writer.app.items.insert_one({"_id": 1, "when": _STORED})
+    writer.close()
+
+    aware = MongoClient(location, backend=backend, tz_aware="true")
+    aware_value = aware.app.items.find_one({"_id": 1})["when"]
+    assert aware_value == _UTC_MILLIS.replace(tzinfo=timezone.utc)
+    assert aware_value.utcoffset() == timedelta(0)
+
+    eastern = timezone(timedelta(hours=-4))
+    converted = MongoClient(
+        location,
+        backend=backend,
+        tz_aware=True,
+        tzinfo=eastern,
+    )
+    converted_value = converted.app.items.find_one({"_id": 1})["when"]
+    assert converted_value == datetime(
+        2026,
+        1,
+        2,
+        4,
+        4,
+        5,
+        123000,
+        tzinfo=eastern,
+    )
+
+    _close_clients(location, aware, converted)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_same_millisecond_datetime_writes_are_noops_across_backends(
+    tmp_path,
+    backend,
+):
+    _require_backend_dependencies(backend)
+    location = _client_location(tmp_path, backend)
+    client = MongoClient(location, backend=backend)
+    collection = client.app.items
+    first = datetime(2026, 1, 2, 3, 4, 5, 123001, tzinfo=timezone.utc)
+    same_millisecond = first.replace(microsecond=123999)
+    collection.insert_one({"_id": 1, "when": first})
+
+    updated = collection.update_one(
+        {"_id": 1},
+        {"$set": {"when": same_millisecond}},
+    )
+    replaced = collection.replace_one(
+        {"_id": 1},
+        {"_id": 1, "when": same_millisecond},
+    )
+
+    assert updated.modified_count == 0
+    assert replaced.modified_count == 0
+    assert collection.find_one({"_id": 1})["when"] == datetime(
+        2026,
+        1,
+        2,
+        3,
+        4,
+        5,
+        123000,
+    )
+
+    _close_clients(location, client)
+
+
+def test_document_class_supports_mutable_mapping_classes_and_client_isolation(
+    tmp_path,
+):
+    location = str(tmp_path / "shared")
+    writer = MongoClient(location, backend="sqlite")
+    writer.app.items.insert_one(
+        {"_id": 1, "inner": {"value": 1}, "items": [{"deep": {"value": 2}}]}
+    )
+    writer.close()
+
+    user_dict_client = MongoClient(
+        location,
+        backend="sqlite",
+        document_class=UserDict,
+    )
+    ordered_client = MongoClient(
+        location,
+        backend="sqlite",
+        document_class=OrderedDict,
+    )
+    user_document = user_dict_client.app.items.find_one({"_id": 1})
+    ordered_document = ordered_client.app.items.find_one({"_id": 1})
+
+    _assert_recursive_document_class(user_document, UserDict)
+    _assert_recursive_document_class(ordered_document, OrderedDict)
+    user_document["inner"]["value"] = 99
+    assert ordered_client.app.items.find_one({"_id": 1})["inner"]["value"] == 1
+
+    _close_clients(location, user_dict_client, ordered_client)
+
+
+@pytest.mark.parametrize("document_class", [dict[str, object], UserDict[str, object]])
+def test_document_class_supports_parameterized_mutable_mapping_aliases(
+    tmp_path,
+    document_class,
+):
+    client = MongoClient(
+        str(tmp_path / "generic-alias"),
+        backend="sqlite",
+        document_class=document_class,
+    )
+    client.app.items.insert_one({"_id": 1, "inner": {"value": 1}})
+
+    document = client.app.items.find_one({"_id": 1})
+    assert type(document) is document_class.__origin__
+    assert type(document["inner"]) is document_class.__origin__
+
+    client.close()
+
+
+def test_document_class_supports_bson_son(tmp_path):
+    son = pytest.importorskip("bson.son").SON
+    client = MongoClient(
+        str(tmp_path / "son"),
+        backend="sqlite",
+        document_class=son,
+    )
+    client.app.items.insert_one({"_id": 1, "inner": {}, "items": [{"deep": {}}]})
+
+    _assert_recursive_document_class(
+        client.app.items.find_one({"_id": 1}),
+        son,
+    )
+
+    client.close()
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_async_mongo_client_matches_recursive_sync_read_fidelity(
+    tmp_path,
+    backend,
+):
+    _require_backend_dependencies(backend)
+    location = _client_location(tmp_path, backend)
+
+    async def scenario():
+        client = AsyncMongoClient(
+            location,
+            backend=backend,
+            document_class=OrderedDict,
+            tz_aware=True,
+        )
+        collection = client.app.items
+        try:
+            await collection.insert_one(
+                {
+                    "_id": "main",
+                    "when": _STORED,
+                    "inner": {"when": _STORED},
+                    "items": [{"deep": {"when": _STORED}}],
+                }
+            )
+            found = await collection.find_one({"_id": "main"})
+            _assert_recursive_document_class(found, OrderedDict)
+            assert found["when"] == _UTC_MILLIS.replace(tzinfo=timezone.utc)
+
+            cursor = collection.find({"_id": "main"})
+            cloned = cursor.clone()
+            listed = await cursor.to_list()
+            cloned_list = await cloned.to_list()
+            _assert_recursive_document_class(listed[0], OrderedDict)
+            _assert_recursive_document_class(cloned_list[0], OrderedDict)
+
+            aggregate = await collection.aggregate(
+                [{"$project": {"inner": 1, "items": 1, "when": 1}}]
+            )
+            aggregated = await aggregate.to_list()
+            _assert_recursive_document_class(aggregated[0], OrderedDict)
+
+            distinct = await collection.distinct("inner")
+            assert type(distinct[0]) is OrderedDict
+
+            await collection.insert_one({"_id": "update", "inner": {"value": 1}})
+            updated = await collection.find_one_and_update(
+                {"_id": "update"},
+                {"$set": {"inner.value": 2}},
+                projection={"_id": 0, "inner": 1},
+                return_document=True,
+            )
+            assert type(updated) is OrderedDict
+            assert type(updated["inner"]) is OrderedDict
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+    if str(location).startswith("memory://"):
+        clear_memory_namespace(location)

--- a/tests/test_query_operator_coverage_edges.py
+++ b/tests/test_query_operator_coverage_edges.py
@@ -5,7 +5,7 @@ import re
 import pytest
 
 from tinymongo import table_backends as backends
-from tinymongo.errors import OperationFailure
+from tinymongo.errors import OperationFailure, TinyMongoNotSupportedError
 
 
 @pytest.mark.parametrize(
@@ -103,6 +103,20 @@ def test_malformed_query_shapes_use_mongodb_parse_error_code(query, message):
         backends.validate_filter_operators(query)
 
     assert caught.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"$expr": {"$eq": ["$value", 1]}},
+        {"$jsonSchema": {"required": ["value"]}},
+        {"values": {"$elemMatch": {"$jsonSchema": {"required": ["score"]}}}},
+        {"values": {"$elemMatch": {"$bitsAllSet": 1}}},
+    ],
+)
+def test_known_mongodb_operators_remain_honestly_unsupported(query):
+    with pytest.raises(TinyMongoNotSupportedError):
+        backends.validate_filter_operators(query)
 
 
 def test_empty_elem_match_matches_only_container_array_members():

--- a/tinymongo/asyncio.py
+++ b/tinymongo/asyncio.py
@@ -21,6 +21,8 @@ from .tinymongo import (
     TinyMongoClient,
     TinyMongoCollection,
     TinyMongoCursor,
+    _normalize_read_options,
+    _pop_case_insensitive_option,
     _resolve_tiny_client_folder,
     _validate_mongo_client_kwargs,
 )
@@ -225,9 +227,34 @@ class AsyncMongoClient(_AsyncClientBase):
     _sync_client_class = MongoClient
     _backend_position = None
 
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(
+        self,
+        host: Any = None,
+        port: Any = None,
+        document_class: Any = None,
+        tz_aware: Any = None,
+        connect: Any = None,
+        type_registry: Any = None,
+        **kwargs: Any,
+    ):
         _validate_mongo_client_kwargs(kwargs)
-        super().__init__(*args, **kwargs)
+        tzinfo = _pop_case_insensitive_option(kwargs, "tzinfo")
+        document_class, tz_aware, tzinfo = _normalize_read_options(
+            document_class,
+            tz_aware,
+            tzinfo,
+        )
+        if tzinfo is not None:
+            kwargs["tzinfo"] = tzinfo
+        super().__init__(
+            host,
+            port,
+            document_class,
+            tz_aware,
+            connect,
+            type_registry,
+            **kwargs,
+        )
 
 
 class AsyncTinyMongoDatabase:

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -110,7 +110,11 @@ def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
     if storage_tag == "objectid":
         return {_TYPE_MARKER: "objectid", _VALUE_MARKER: str(value)}
     if storage_tag == "datetime":
-        return {_TYPE_MARKER: "datetime", _VALUE_MARKER: value.isoformat()}
+        canonical = bson_types.canonicalize_datetime(value)
+        return {
+            _TYPE_MARKER: "datetime",
+            _VALUE_MARKER: canonical.isoformat(timespec="milliseconds"),
+        }
     if storage_tag == _BINARY_VALUE:
         raw, subtype = bson_types.binary_components(value)
         return _encode_binary(raw, subtype)
@@ -301,8 +305,10 @@ def decode_value(value):
             if kind == "datetime":
                 if isinstance(payload, str):
                     try:
-                        return datetime.fromisoformat(payload)
-                    except ValueError:
+                        return bson_types.canonicalize_datetime(
+                            datetime.fromisoformat(payload)
+                        )
+                    except (OverflowError, ValueError):
                         # Preserve malformed or future-shaped tags below.
                         pass
             if kind == "objectid":

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, localcontext
 import math
 import re
@@ -297,13 +297,46 @@ def normalize_datetime(value):
     return value.astimezone(timezone.utc)
 
 
-def _datetime_identity_key(value):
-    """Return MongoDB's signed UTC millisecond identity for a datetime."""
+def datetime_milliseconds(value):
+    """Return MongoDB's signed UTC millisecond value for ``value``.
+
+    BSON dates are signed integers rather than floating-point timestamps.
+    Calculating from a :class:`~datetime.timedelta` preserves exact behavior
+    before the Unix epoch and avoids platform-dependent timestamp rounding.
+    """
 
     normalized = normalize_datetime(value)
     epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
     delta = normalized - epoch
     return delta.days * 86_400_000 + delta.seconds * 1_000 + delta.microseconds // 1_000
+
+
+def canonicalize_datetime(value, tz_aware=False, tzinfo=None):
+    """Return ``value`` with MongoDB's UTC millisecond decode semantics.
+
+    The default mirrors PyMongo's naive-UTC result. With ``tz_aware=True``,
+    the result is UTC-aware and is converted to ``tzinfo`` when supplied.
+    Client-option validation remains the caller's responsibility.
+    """
+
+    milliseconds = datetime_milliseconds(value)
+    days, day_milliseconds = divmod(milliseconds, 86_400_000)
+    seconds, milliseconds = divmod(day_milliseconds, 1_000)
+    canonical = datetime(1970, 1, 1) + timedelta(
+        days=days,
+        seconds=seconds,
+        milliseconds=milliseconds,
+    )
+    if not tz_aware:
+        return canonical
+    canonical = canonical.replace(tzinfo=timezone.utc)
+    return canonical if tzinfo is None else canonical.astimezone(tzinfo)
+
+
+def _datetime_identity_key(value):
+    """Return MongoDB's signed UTC millisecond identity for a datetime."""
+
+    return datetime_milliseconds(value)
 
 
 # The ranks reserve 3 and 4 for mappings and arrays, which cursors recursively

--- a/tinymongo/projection.py
+++ b/tinymongo/projection.py
@@ -1,7 +1,7 @@
 """Mongo-style inclusion and exclusion projections."""
 
 import copy
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Mapping, MutableMapping, Sequence, Set
 
 from .bson_types import bson_number_truth, is_bson_number
 from .errors import OperationFailure, TinyMongoNotSupportedError
@@ -128,7 +128,7 @@ def normalize_projection(projection):
 def _include_value(value, tree):
     if _LEAF in tree:
         return copy.deepcopy(value)
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         result = {}
         for key, child_value in value.items():
             if key not in tree:
@@ -140,7 +140,7 @@ def _include_value(value, tree):
     if isinstance(value, list):
         result = []
         for item in value:
-            if not isinstance(item, (dict, list)):
+            if not isinstance(item, (Mapping, list)):
                 continue
             result.append(_include_value(item, tree))
         return result
@@ -148,7 +148,7 @@ def _include_value(value, tree):
 
 
 def _exclude_value(value, tree):
-    if isinstance(value, dict):
+    if isinstance(value, MutableMapping):
         for key, child_tree in tree.items():
             if key not in value:
                 continue

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -84,6 +84,28 @@ _FIELD_FILTER_OPERATOR_NAMES = (
 _LOGICAL_FILTER_OPERATORS = frozenset(_LOGICAL_FILTER_OPERATOR_NAMES)
 _IGNORED_FILTER_OPERATORS = frozenset(_IGNORED_FILTER_OPERATOR_NAMES)
 _FIELD_FILTER_OPERATORS = frozenset(_FIELD_FILTER_OPERATOR_NAMES)
+_KNOWN_UNSUPPORTED_FILTER_OPERATORS = frozenset(
+    (
+        "$bitsAllClear",
+        "$bitsAllSet",
+        "$bitsAnyClear",
+        "$bitsAnySet",
+        "$expr",
+        "$geoIntersects",
+        "$geoWithin",
+        "$jsonSchema",
+        "$near",
+        "$nearSphere",
+        "$text",
+        "$where",
+    )
+)
+_KNOWN_MONGODB_FILTER_OPERATORS = (
+    _LOGICAL_FILTER_OPERATORS
+    | _IGNORED_FILTER_OPERATORS
+    | _FIELD_FILTER_OPERATORS
+    | _KNOWN_UNSUPPORTED_FILTER_OPERATORS
+)
 _BSON_QUERY_TYPE_CODES = {
     -1: "minKey",
     1: "double",
@@ -1208,7 +1230,7 @@ def _validate_regex_query_operand(operand, options=""):
         ) from error
 
 
-def _validate_field_filter_operators(expression):
+def _validate_field_filter_operators(expression, *, _inside_elem_match=False):
     """Validate one field's operator document, including nested ``$not``."""
 
     for operator, operand in expression.items():
@@ -1216,6 +1238,13 @@ def _validate_field_filter_operators(expression):
             raise OperationFailure("unknown operator: {0}".format(operator), code=2)
         if operator not in _FIELD_FILTER_OPERATORS:
             if isinstance(operator, str) and operator.startswith("$"):
+                if (
+                    _inside_elem_match
+                    and operator not in _KNOWN_MONGODB_FILTER_OPERATORS
+                ):
+                    raise OperationFailure(
+                        "unknown operator: {0}".format(operator), code=2
+                    )
                 raise TinyMongoNotSupportedError(
                     "Query operator {0} is not supported by TinyMongo".format(operator)
                 )
@@ -1314,7 +1343,10 @@ def _validate_field_filter_operators(expression):
             _validate_regex_query_operand(expression["$regex"], operand)
         if operator == "$not":
             nested = _normalize_not_operand(operand)
-            _validate_field_filter_operators(nested)
+            _validate_field_filter_operators(
+                nested,
+                _inside_elem_match=_inside_elem_match,
+            )
         if operator == "$elemMatch":
             _validate_elem_match_operand(operand)
         if operator == "$mod":
@@ -1329,14 +1361,14 @@ def _validate_elem_match_operand(operand):
     if not isinstance(operand, Mapping):
         raise OperationFailure("$elemMatch requires a query document", code=2)
     if any(key in _LOGICAL_FILTER_OPERATORS for key in operand):
-        validate_filter_operators(operand)
+        validate_filter_operators(operand, _inside_elem_match=True)
     elif any(key in _FIELD_FILTER_OPERATORS for key in operand):
-        _validate_field_filter_operators(operand)
+        _validate_field_filter_operators(operand, _inside_elem_match=True)
     else:
-        validate_filter_operators(operand)
+        validate_filter_operators(operand, _inside_elem_match=True)
 
 
-def validate_filter_operators(filter_doc):
+def validate_filter_operators(filter_doc, *, _inside_elem_match=False):
     """Reject operators the shared Python matcher cannot evaluate safely."""
 
     if not isinstance(filter_doc, Mapping):
@@ -1352,11 +1384,19 @@ def validate_filter_operators(filter_doc):
                     code=2,
                 )
             for specification in expected:
-                validate_filter_operators(specification)
+                validate_filter_operators(
+                    specification,
+                    _inside_elem_match=_inside_elem_match,
+                )
             continue
         if key in _IGNORED_FILTER_OPERATORS:
             continue
         if key.startswith("$"):
+            if _inside_elem_match and (
+                key in _FIELD_FILTER_OPERATORS
+                or key not in _KNOWN_MONGODB_FILTER_OPERATORS
+            ):
+                raise OperationFailure("unknown operator: {0}".format(key), code=2)
             raise TinyMongoNotSupportedError(
                 "Query operator {0} is not supported by TinyMongo".format(key)
             )
@@ -1364,7 +1404,10 @@ def validate_filter_operators(filter_doc):
         if isinstance(expected, Mapping) and any(
             str(operator).startswith("$") for operator in expected
         ):
-            _validate_field_filter_operators(expected)
+            _validate_field_filter_operators(
+                expected,
+                _inside_elem_match=_inside_elem_match,
+            )
         else:
             _validate_regex_literals(
                 expected,

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -7,7 +7,9 @@ from __future__ import absolute_import
 import copy
 from collections.abc import Iterable, Mapping, MutableMapping
 from dataclasses import replace
+import datetime as datetime_module
 from functools import reduce, wraps
+import importlib
 import logging
 import operator as comparison_operator
 import os
@@ -25,6 +27,7 @@ from .bson_types import (
     bson_value_identity_key,
     bson_value_sort_key,
     bson_values_equal,
+    canonicalize_datetime,
     decimal128_type,
     is_bson_regex,
     is_bson_number,
@@ -766,7 +769,7 @@ _PYMONGO_CLIENT_PARAMETERS = frozenset(
         "type_registry",
     )
 )
-_PYMONGO_CONNECTION_OPTIONS = frozenset(
+_PYMONGO_CONNECTION_OPTIONS_FALLBACK = frozenset(
     """
     appname authmechanism authmechanismproperties authoidcallowedhosts
     authsource auto_encryption_opts compressors connect connecttimeoutms
@@ -787,6 +790,28 @@ _PYMONGO_CONNECTION_OPTIONS = frozenset(
 )
 
 
+def _load_pymongo_connection_options():
+    """Use the installed PyMongo option catalog, with an offline fallback."""
+
+    try:
+        validators = getattr(
+            importlib.import_module("pymongo.common"),
+            "VALIDATORS",
+            None,
+        )
+    except ImportError:
+        return _PYMONGO_CONNECTION_OPTIONS_FALLBACK
+    if not isinstance(validators, Mapping) or not validators:
+        return _PYMONGO_CONNECTION_OPTIONS_FALLBACK
+    names = tuple(validators)
+    if not all(isinstance(name, str) for name in names):
+        return _PYMONGO_CONNECTION_OPTIONS_FALLBACK
+    return frozenset(name.lower() for name in names)
+
+
+_PYMONGO_CONNECTION_OPTIONS = _load_pymongo_connection_options()
+
+
 def _validate_mongo_client_kwargs(options):
     """Reject unknown PyMongo-shaped options before storage can be opened."""
 
@@ -802,6 +827,89 @@ def _validate_mongo_client_kwargs(options):
     )
     if unknown is not None:
         raise ConfigurationError("Unknown option: {0}".format(unknown))
+
+
+def _normalize_document_class(document_class):
+    """Validate the mutable mapping class used for returned documents."""
+
+    if not document_class:
+        return dict
+    resolved_class = getattr(document_class, "__origin__", document_class)
+    supported = isinstance(resolved_class, type) and issubclass(
+        resolved_class,
+        MutableMapping,
+    )
+    if not supported:
+        raise TypeError(
+            "document_class must be a subclass of " "collections.abc.MutableMapping"
+        )
+    return resolved_class
+
+
+def _normalize_tz_aware(tz_aware):
+    """Normalize PyMongo's Boolean-or-string ``tz_aware`` option."""
+
+    if tz_aware is None:
+        return False
+    if isinstance(tz_aware, bool):
+        return tz_aware
+    if isinstance(tz_aware, str):
+        if tz_aware == "true":
+            return True
+        if tz_aware == "false":
+            return False
+        raise ValueError("The value of tz_aware must be 'true' or 'false'")
+    raise TypeError(
+        "tz_aware must be True or False, was: tz_aware={0!r}".format(tz_aware)
+    )
+
+
+def _normalize_read_options(document_class, tz_aware, tzinfo):
+    """Return validated PyMongo-compatible document decoding options."""
+
+    document_class = _normalize_document_class(document_class)
+    tz_aware = _normalize_tz_aware(tz_aware)
+    if tzinfo is not None and not isinstance(tzinfo, datetime_module.tzinfo):
+        raise TypeError("tzinfo must be an instance of datetime.tzinfo")
+    if tzinfo is not None and not tz_aware:
+        raise ValueError("cannot specify tzinfo without also setting tz_aware=True")
+    return document_class, tz_aware, tzinfo
+
+
+def _pop_case_insensitive_option(options, name, default=None):
+    """Remove one case-insensitive PyMongo connection option."""
+
+    matched = next((key for key in options if key.lower() == name), None)
+    if matched is None:
+        return default
+    return options.pop(matched)
+
+
+def _materialize_result_value(value, document_class, tz_aware, tzinfo):
+    """Recursively build one public result using client codec options."""
+
+    if isinstance(value, datetime_module.datetime):
+        return canonicalize_datetime(
+            value,
+            tz_aware=tz_aware,
+            tzinfo=tzinfo,
+        )
+    if isinstance(value, Mapping):
+        document = document_class()
+        for key, item in value.items():
+            document[key] = _materialize_result_value(
+                item,
+                document_class,
+                tz_aware,
+                tzinfo,
+            )
+        return document
+    if isinstance(value, list):
+        return [
+            _materialize_result_value(item, document_class, tz_aware, tzinfo)
+            for item in value
+        ]
+    return copy.deepcopy(value)
 
 
 def _resolve_tiny_client_folder(foldername, tinymongo_folder):
@@ -897,6 +1005,10 @@ class TinyMongoClient(object):
         self._databases = {}
         self._databases_lock = threading.RLock()
         self._closed = False
+        self._canonical_read_values = False
+        self._document_class = dict
+        self._tz_aware = False
+        self._tzinfo = None
         storage_is_nonlocal = is_remote_sql_backend(backend_name) or bool(
             self._storage_uri and backend_name in ("parquet", "parquetv2")
         )
@@ -959,6 +1071,7 @@ class TinyMongoClient(object):
                     key,
                     path,
                     self._storage,
+                    client=self,
                     engine=engine_class(
                         path,
                         threads=self._threads,
@@ -968,9 +1081,26 @@ class TinyMongoClient(object):
                     ),
                 )
             else:
-                database = TinyMongoDatabase(key, path, self._storage)
+                database = TinyMongoDatabase(
+                    key,
+                    path,
+                    self._storage,
+                    client=self,
+                )
             self._databases[key] = database
             return database
+
+    def _materialize_read_value(self, value):
+        """Return an isolated public value using this client's read options."""
+
+        if not self._canonical_read_values:
+            return copy.deepcopy(value)
+        return _materialize_result_value(
+            value,
+            self._document_class,
+            self._tz_aware,
+            self._tzinfo,
+        )
 
     def _ensure_open(self):
         """Reject operations that would use a client after it was closed."""
@@ -1168,6 +1298,12 @@ class MongoClient(TinyMongoClient):
         **kwargs,
     ):
         _validate_mongo_client_kwargs(kwargs)
+        tzinfo = _pop_case_insensitive_option(kwargs, "tzinfo")
+        document_class, tz_aware, tzinfo = _normalize_read_options(
+            document_class,
+            tz_aware,
+            tzinfo,
+        )
         backend = kwargs.pop("backend", "tinydb")
         storage_uri = kwargs.pop("storage_uri", None)
         threads = kwargs.pop("threads", None)
@@ -1195,12 +1331,16 @@ class MongoClient(TinyMongoClient):
             duckdb_config=duckdb_config,
             dsn=dsn,
         )
+        self._canonical_read_values = True
+        self._document_class = document_class
+        self._tz_aware = tz_aware
+        self._tzinfo = tzinfo
 
 
 class TinyMongoDatabase(object):
     """Representation of a Pymongo database"""
 
-    def __init__(self, database, path, storage, engine=None):
+    def __init__(self, database, path, storage, engine=None, client=None):
         """Initialize a TinyDB file named as the db name in the given folder."""
         self.database = database
         self._path = path
@@ -1210,6 +1350,7 @@ class TinyMongoDatabase(object):
             else os.path.dirname(path) or "."
         )
         self._storage = storage
+        self._client = client
         self.engine = engine
         self.tinydb = None if engine is not None else TinyDB(path, storage=storage)
         self._memory_revision = self._current_memory_revision()
@@ -1317,6 +1458,14 @@ class TinyMongoCollection(object):
         self._index_cache = {}
         self._memory_revision = None
 
+    def _materialize_read_value(self, value):
+        """Apply the owning client's public document decoding options."""
+
+        client = getattr(self.parent, "_client", None)
+        if client is None:
+            return copy.deepcopy(value)
+        return client._materialize_read_value(value)
+
     def __repr__(self):
         """Return collection name"""
         return self.tablename
@@ -1389,7 +1538,10 @@ class TinyMongoCollection(object):
             prepared = prepared[1:]
         else:
             documents = self.find({})
-        return TinyMongoCursor(engine.run_prepared(documents, prepared))
+        return TinyMongoCursor(
+            engine.run_prepared(documents, prepared),
+            materializer=self._materialize_read_value,
+        )
 
     def bulk_write(self, *args, **kwargs):
         raise TinyMongoNotSupportedError("Bulk writes are not supported by TinyMongo")
@@ -2652,7 +2804,7 @@ class TinyMongoCollection(object):
             else:
                 self.update_one({"_id": item["_id"]}, update, *args, **write_kwargs)
                 returned = self.find_one({"_id": item["_id"]}) if return_after else item
-            return project_document(returned, projection)
+            return self._materialize_read_value(project_document(returned, projection))
         finally:
             if self.parent.engine is None:
                 self._release_collection_lock(rlock, portalocker_lock)
@@ -2690,7 +2842,7 @@ class TinyMongoCollection(object):
                     if return_after
                     else previous
                 )
-            return project_document(returned, projection)
+            return self._materialize_read_value(project_document(returned, projection))
         finally:
             if self.parent.engine is None:
                 self._release_collection_lock(rlock, portalocker_lock)
@@ -2709,7 +2861,9 @@ class TinyMongoCollection(object):
             if item is None:
                 return None
             self.delete_one({"_id": item["_id"]})
-            return project_document(item, normalize_projection(projection))
+            return self._materialize_read_value(
+                project_document(item, normalize_projection(projection))
+            )
         finally:
             if self.parent.engine is None:
                 self._release_collection_lock(rlock, portalocker_lock)
@@ -3018,6 +3172,7 @@ class TinyMongoCursor(object):
         query=None,
         source_projected=False,
         deferred_loader=None,
+        materializer=None,
     ):
         """Initialize the mongo iterable cursor with data"""
         self._deferred_loader = deferred_loader
@@ -3025,6 +3180,11 @@ class TinyMongoCursor(object):
         self._source_data = list(cursordat) if self._deferred_loaded else []
         self.cursordat = list(self._source_data)
         self.collection = collection
+        self._materializer = materializer or getattr(
+            collection,
+            "_materialize_read_value",
+            None,
+        )
         self.projection = projection
         self.query = copy.deepcopy(query)
         self._source_projected = source_projected
@@ -3051,9 +3211,14 @@ class TinyMongoCursor(object):
         return self._project(self.currentrec)[key]
 
     def _project(self, document):
-        if self.projection is None:
-            return copy.deepcopy(document)
-        return project_document(document, self.projection)
+        projected = (
+            document
+            if self.projection is None
+            else project_document(document, self.projection)
+        )
+        if self._materializer is not None:
+            return self._materializer(projected)
+        return copy.deepcopy(projected)
 
     def _invalidate_deferred_source(self):
         """Discard a loaded SQLite window after cursor options change."""
@@ -3269,12 +3434,14 @@ class TinyMongoCursor(object):
                 query=copy.deepcopy(self.query),
                 source_projected=self._source_projected,
                 deferred_loader=self._deferred_loader,
+                materializer=self._materializer,
             )
         elif self.collection is None:
             clone = type(self)(
                 copy.deepcopy(self._source_data),
                 projection=copy.deepcopy(self.projection),
                 query=copy.deepcopy(self.query),
+                materializer=self._materializer,
             )
         else:
             clone = self.collection.find(copy.deepcopy(self.query))


### PR DESCRIPTION
## Summary

This completes Mike Kennedy's remaining TM-019/TM-030 returned-value findings and includes the related compatibility nice-to-haves from his final review.

- Honor `document_class` recursively for synchronous and asynchronous query results, including nested documents, documents inside arrays, projections, aggregation output, document-valued `distinct()` results, cursor clones, and find-and-modify returns.
- Store datetimes using MongoDB's signed UTC millisecond representation. Naive values are treated as UTC, aware values are converted to UTC, sub-millisecond precision is floored correctly before and after the Unix epoch, and same-millisecond writes report no modification.
- Honor and eagerly validate `tz_aware` and optional `tzinfo` on both PyMongo-shaped clients.
- Derive accepted connection option names from the installed `pymongo.common.VALIDATORS` table, with the bundled static set retained for dependency-free installs.
- Return `OperationFailure` code `2` for the three unknown or misplaced operator shapes inside `$elemMatch` from Mike's matrix, while preserving `TinyMongoNotSupportedError` for valid MongoDB predicates outside TinyMongo's supported subset.
- Update the roadmap, README, changelog, Talk Python acceptance notes, and CI's dependency-free and minimum-PyMongo slices.

## Why

TinyMongo previously accepted `document_class` and `tz_aware` but silently ignored them. Datetimes also retained the original Python timezone and microseconds instead of passing through BSON's canonical representation. That made accepted client configuration observably different from PyMongo even though matching, sorting, and range behavior were already correct.

This PR makes the public read behavior and persisted datetime identity agree with MongoDB rather than applying a display-only conversion. It also removes maintenance drift from the hand-maintained PyMongo option list and closes the three remaining `$elemMatch` validation differences from the final matrix.

Related to #136 and #102.

## Compatibility notes

- Existing datetime tags remain readable and are canonicalized when decoded; no migration is required.
- Datetime round trips now intentionally use naive UTC milliseconds by default, matching PyMongo. Use `tz_aware=True` and optional `tzinfo` for aware results.
- Mutable mapping document classes such as `OrderedDict`, `UserDict`, parameterized mapping aliases, and `bson.SON` are supported. Raw BSON views through `RawBSONDocument` remain explicitly outside the embedded-storage subset.
- PyMongo metadata behavior was checked live: `list_databases()`, `server_info()`, and command documents remain plain dictionaries regardless of `document_class`.

## Validation

- `3,125 passed, 441 deselected`
- 100% coverage: 7,329 statements and 3,012 branches, zero misses
- Focused MongoDB 8 live comparison: 10/10 passed across sync and async
- Dependency-free Python 3.9 slice: 87 passed, 8 skipped
- PyMongo 4.9.2 floor slice: 243 passed, 28 deselected
- Black, Ruff, mypy, and `git diff --check` all pass
