### PR TITLE
Complete issue #77 update operators and prepare 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-02
+
 ### Added
 - A shared, backend-independent aggregation engine for `$match`, `$sort`,
   `$skip`, `$limit`, `$count`, `$project`, `$set`, `$addFields`, `$unset`, and
@@ -27,6 +29,14 @@
 - MongoDB-style `$size`, `$elemMatch`, `$type`, and `$mod` query operators,
   including array-member behavior, BSON type aliases and numeric codes, and
   operand validation across synchronous and asynchronous clients.
+- MongoDB-style `$rename`, `$min`, `$max`, and `$pop` update operators across
+  synchronous and asynchronous clients and every backend. They support dotted
+  paths, and the applicable operators traverse numeric array paths while
+  preserving MongoDB's missing-field, comparison-order, and array-end behavior.
+- Shared real-MongoDB update contracts cover upserts, multi-document and
+  find-and-modify writes, immutable `_id` handling, path conflicts, blocked
+  paths, invalid targets, and single-document atomic failure behavior for the
+  expanded update operator set.
 
 ### Changed
 - Datetimes now persist in MongoDB's canonical signed UTC millisecond form.
@@ -46,6 +56,14 @@
   a Boolean to a structured mapping of dependency-free `native` families and
   installed optional `pymongo` types; inspect its `pymongo` tuple when detecting
   optional BSON support.
+- Update capability reporting now exposes a structured `update_operators`
+  mapping containing the exact supported operator names plus the accepted
+  `$push` and `$addToSet` modifiers. Use `client.supports("update_operators")`
+  for a Boolean check.
+- Update validation now reports PyMongo-compatible `WriteError` codes for
+  malformed operator documents, empty or conflicting paths, non-viable
+  traversal, immutable `_id` changes, and invalid update targets before a
+  document is partially changed.
 - Remote SQL unique indexes now materialize versioned canonical BSON token
   digests protected by native constraints, preserving exact int/float identity
   across concurrent PostgreSQL and MariaDB/MySQL writers. Decimal128 and arrays

--- a/README.md
+++ b/README.md
@@ -17,21 +17,17 @@ supported at the beta level for the backends described below.
 
 # Installation
 
-The latest stable release is 1.2.1 and can be installed from PyPI:
+The latest stable release is 1.3.0 and can be installed from PyPI:
 
 ```bash
-pip install "tinymongo==1.2.1"
+pip install "tinymongo==1.3.0"
 ```
 
 For development, clone this repository and run `pip install -e .` from its
-root. Use the `v1.2.1` tag when you need source and documentation that match
-the current stable package exactly; `master` may contain unreleased changes.
-This README follows `master`: the aggregation core, advanced array-update
-modifiers, Decimal128, UUID, and regex support, and the additional query
-operators described below were added after `v1.2.1` and are not part of the
-1.2.1 package on PyPI. See
+root. Use the `v1.3.0` tag when you need source and documentation that match
+the current stable package exactly; `master` may contain later changes. See
 [`CHANGELOG.md`](https://github.com/schapman1974/tinymongo/blob/master/CHANGELOG.md)
-for the complete unreleased list.
+for the complete release history and any unreleased work.
 
 The default JSON backend has a small dependency set. Optional database backends
 may install native binary wheels supplied by DuckDB, PyArrow, or SQL drivers.
@@ -467,13 +463,27 @@ documents where `field` is missing, while `$ne` and `$nin` with only non-null
 values continue to include missing fields. The same rule applies to dotted
 paths and array members across TinyMongo backends.
 
-Update support includes `$set`, `$unset`, `$inc`, `$push`, `$pull`, and
-`$addToSet`, including `upsert=True`. As in PyMongo, `update_one()` and
-`update_many()` require update operators; use `replace_one()` for full-document
-replacement. `$push` accepts `$each`, `$position`, `$sort`, and `$slice`;
-`$addToSet` accepts `$each`; and `$pull` accepts literal, query, and document
-operands. Applying `$addToSet` to an existing null or non-array field raises a
-PyMongo-compatible `WriteError` with code `2`, and the update remains atomic.
+Update support includes `$set`, `$unset`, `$inc`, `$min`, `$max`, `$rename`,
+`$push`, `$pop`, `$pull`, and `$addToSet`, including `upsert=True`. As in
+PyMongo, `update_one()` and `update_many()` require update operators; use
+`replace_one()` for full-document replacement. `$push` accepts `$each`,
+`$position`, `$sort`, and `$slice`; `$addToSet` accepts `$each`; and `$pull`
+accepts literal, query, and document operands.
+
+`$min` and `$max` set a missing field or replace an existing value only when
+the candidate is lower or higher in TinyMongo's MongoDB-compatible BSON order.
+`$rename` moves an existing field without creating a value for a missing
+source. `$pop` removes the first array item for `-1` or the last for `1`, and is
+a no-op for a missing or empty array. Dotted paths are supported; the new
+operators also follow numeric array positions where MongoDB permits them, while
+`$rename` rejects array-element source and destination paths.
+
+Update documents are validated before any change is stored. Non-document
+operator operands, invalid or conflicting paths, traversal through a scalar,
+non-array `$pop` targets, and attempts to change `_id` raise
+PyMongo-compatible `WriteError` exceptions with the applicable MongoDB code,
+and the complete update remains atomic. Applying `$addToSet` to an existing
+null or non-array field similarly raises `WriteError` code `2`.
 
 `find()` and `find_one()` accept Mongo-style inclusion and exclusion
 projections. Dotted paths project nested fields, `_id` follows MongoDB's special
@@ -564,10 +574,9 @@ order for ascending and descending sorts. TinyMongo uses its shared Python
 matcher whenever a backend-native or indexed predicate cannot guarantee these
 rules. Extending unique-index identity to the remaining supported BSON values
 is still tracked separately in the roadmap and continues to fail closed where
-exact enforcement is unavailable. The update `$min` and `$max` modifiers remain
-tracked under
-[#77](https://github.com/schapman1974/tinymongo/issues/77); aggregation `$min`
-and `$max` are already part of the supported aggregation subset.
+exact enforcement is unavailable. Update and aggregation `$min` and `$max`
+share this BSON comparison order, including recursive document and array
+comparisons and numeric equivalence across supported numeric representations.
 
 ## Aggregation core subset
 
@@ -818,15 +827,19 @@ capabilities = client.capabilities()
 print(capabilities)
 print(capabilities["query_operators"]["field"])
 print(capabilities["query_operators"]["ignored"])
+print(capabilities["update_operators"]["operators"])
+print(capabilities["update_operators"]["modifiers"])
 print(capabilities["bson_types"]["pymongo"])
 print(client.supports("multiprocess_writes"))
 ```
 
 The capability map covers persistence, remote and object storage, table-native
 storage, multiprocess writes, native indexes, projections, bulk writes,
-aggregation, query operators, BSON types, sessions, transactions, and change
-streams. `query_operators` separates top-level logical operators from field
-operators and accepted-but-ignored metadata operators such as `$comment`.
+aggregation, query and update operators, BSON types, sessions, transactions,
+and change streams. `query_operators` separates top-level logical operators
+from field operators and accepted-but-ignored metadata operators such as
+`$comment`. `update_operators` lists every supported update operator and maps
+`$push` and `$addToSet` to their accepted modifiers.
 `bson_types` separates dependency-free `native` families from the richer
 `pymongo` types available when the optional BSON extra is installed. These
 values are structured mappings; use `client.supports()` for a Boolean feature

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -178,7 +178,7 @@ with the follow-up audit of his
   conflicting legacy values fail closed without advancing the catalog version.
   Decimal128 remains fail-closed until the same token can be derived safely
   from its BID representation.
-- [ ] Update Mike's agent guide against the `v1.2.1` tag and describe the
+- [ ] Update Mike's agent guide against the `v1.3.0` tag and describe the
   expanded API as available from PyPI.
   Correct its list-only `insert_many()` signature
   and defaults, `BulkWriteError` details, blanket session-rejection claim,
@@ -198,7 +198,9 @@ with the follow-up audit of his
 - [x] Under [#77](https://github.com/schapman1974/tinymongo/issues/77), reject
   unsupported query operators with `TinyMongoNotSupportedError` instead of
   silently returning no matches, and implement `$size`, `$elemMatch`, `$type`,
-  and `$mod`.
+  and `$mod`, plus the `$rename`, `$min`, `$max`, and `$pop` update operators
+  with MongoDB-shaped path validation, error codes, and structured capability
+  reporting.
 - [x] Under [#94](https://github.com/schapman1974/tinymongo/issues/94), complete
   the BSON-aware `$gt`, `$gte`, `$lt`, and `$lte` contracts across recursive
   documents and arrays, BSON type bracketing, query and `$pull` paths, and
@@ -234,14 +236,15 @@ Application-compatibility work:
   - [x] Milestone 1 ObjectId, datetime, and Binary storage/query support.
   - [x] **TM-014:** Add Decimal128 round trips and numeric behavior.
   - [x] Add UUID and regular-expression round trips.
-- [ ] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
+- [x] [#77: Additional query and update operators](https://github.com/schapman1974/tinymongo/issues/77)
   - [x] Talk Python query slice: scalar-to-array equality, combined `$nin`,
     `$not`, `$regex`, case-insensitive `$options`, and Mongo-correct
     null-versus-missing negation.
   - [x] Reject unsupported or misspelled query operators across CRUD filters and
     add `$size`, `$elemMatch`, `$type`, and `$mod`.
-  - [ ] Prioritize the remaining update candidates from measured application
-    failures, including the `$min` and `$max` update modifiers.
+  - [x] Complete the remaining update slice with `$rename`, `$min`, `$max`, and
+    `$pop`, including dotted and numeric-array paths, atomic validation,
+    MongoDB-compatible errors, and structured capability reporting.
 - [ ] [#102: Optional PyMongo-version adaptation](https://github.com/schapman1974/tinymongo/issues/102)
   - [x] TinyMongo errors conditionally inherit matching PyMongo errors.
   - [x] Derive accepted connection option names from the installed PyMongo
@@ -467,6 +470,8 @@ Exit criteria:
      real application aggregation call sites pass.
 6. [ ] Add advanced array, bulk, and remaining BSON operations according to measured
    compatibility gaps.
+   - [x] Complete the measured #77 update slice with `$rename`, `$min`, `$max`,
+     and `$pop` across synchronous and asynchronous clients.
 7. [ ] Implement GridFS on stable BSON, index, and cursor foundations.
 8. [ ] Build the wire-server foundation, followed by read-only Compass browsing and
    then editing support.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-This guide helps you migrate from earlier `tinymongo` versions to the 1.2.1
+This guide helps you migrate from earlier `tinymongo` versions to the 1.3.0
 release line.
 
 ## Key changes
@@ -9,7 +9,25 @@ release line.
 - Default storage remains TinyDB JSON storage.
 - Parquet v2, SQLite, and DuckDB are available as table-native backends.
 - A `tinymongo` CLI is available for inspecting, exporting, importing, and migrating data.
-- Common update operators and durable single-field indexes are supported.
+- The common update subset now includes `$rename`, `$min`, `$max`, and `$pop`
+  in addition to `$set`, `$unset`, `$inc`, `$push`, `$pull`, and `$addToSet`.
+  The new operators use MongoDB-compatible dotted-path, BSON comparison, array,
+  immutable `_id`, and atomic error behavior across synchronous and
+  asynchronous clients.
+- Aggregation now includes the application-driven `$match`, `$sort`, `$skip`,
+  `$limit`, `$count`, `$project`, `$set`, `$addFields`, `$unset`, and `$group`
+  stages, with the documented expression and accumulator subset.
+- Query support now includes `$size`, `$elemMatch`, `$type`, and `$mod`, and all
+  CRUD filters reject unknown query operators before touching storage.
+- Decimal128, UUID, and regex values join ObjectId, datetime, and Binary in the
+  BSON-aware storage and comparison layer when their optional types are
+  available.
+- PyMongo-shaped clients honor recursive `document_class`, `tz_aware`, and
+  `tzinfo` reads. Datetimes are stored at signed UTC millisecond precision.
+- Aggregation, query, update-operator, and BSON-type capabilities are structured
+  mappings. Use `client.supports()` for a Boolean check or inspect the mapping
+  to select an individual feature.
+- Durable single-field indexes remain supported across all backends.
 - Local JSON writes use advisory locks, atomic replacement, and file/directory
   `fsync`; local table backends use scoped locking plus database/file
   mechanisms, remote SQL relies on database transactions, and object-storage
@@ -50,6 +68,11 @@ pip install ".[all]"
 - Use `tinymongo migrate SOURCE TARGET --to-backend sqlite` to copy existing TinyDB JSON data into another backend.
 - Existing plain JSON and legacy stringified table-backend `_id` keys remain
   readable and mutable after upgrading.
+- Update specifications are validated before writes. Code that previously
+  relied on malformed operator operands, empty or conflicting paths, scalar
+  path traversal, or `_id` mutation now receives a PyMongo-compatible
+  `WriteError` without a partial update. `$pop` accepts only `1` or `-1`, and
+  `$rename` cannot address array elements.
 - Before a bulk rewrite or migration, check legacy data for `_id` pairs that
   are BSON-equivalent, such as `1` and `1.0` or native bytes and generic
   subtype-0 `Binary`. Version 1.2.1 rejects new equivalent duplicates while

--- a/docs/OBJECT_STORAGE.md
+++ b/docs/OBJECT_STORAGE.md
@@ -1,6 +1,6 @@
 # Parquet Object Storage
 
-This feature remains experimental in `1.2.1`.
+This feature remains experimental in `1.3.0`.
 
 TinyMongo's `parquet` and `parquetv2` backends can place collection Parquet
 files under an object-storage URI. DuckDB performs the remote file reads and

--- a/docs/TALKPYTHON_ACCEPTANCE.md
+++ b/docs/TALKPYTHON_ACCEPTANCE.md
@@ -154,11 +154,14 @@ reproductions and the real Talk Python write paths. The main application goal
 is complete with no known correctness defect in Talk Python's TinyMongo path.
 
 Mike's separate TinyMongo agent reference should now be updated against the
-`v1.2.1` tag, including the Binary codec, BSON-aware `_id` identity,
+`v1.3.0` tag, including the Binary codec, BSON-aware `_id` identity,
 `insert_many()` partial failures,
 bounded sort diagnostics, exact `$unset`, BSON-aware CLI, dotted child
 collections, native automatic `ObjectId` values, null-negation behavior, and
-contextual `InvalidDocument` errors. Also correct the stale list-only
+contextual `InvalidDocument` errors. It should also describe the structured
+query, update-operator, aggregation, and BSON-type capabilities plus the
+expanded `$rename`, `$min`, `$max`, and `$pop` update subset. Also correct the
+stale list-only
 `insert_many()` signature and defaults, `BulkWriteError` details, blanket
 session claim, conditional `AsyncMongoClient` patch/import caveat,
 numeric-versus-bool identity wording, explicit null `_id` handling, `_default`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinymongo"
-version = "1.2.1"
+version = "1.3.0"
 description = "Embedded MongoDB-compatible database with sync, async, and multi-backend storage"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/contracts/test_update_operator_contract.py
+++ b/tests/contracts/test_update_operator_contract.py
@@ -1,0 +1,410 @@
+"""Issue #77 update-operator contracts shared by every target."""
+
+import pytest
+
+from tinymongo.errors import WriteError as TinyMongoWriteError
+
+
+pytestmark = pytest.mark.contract
+
+_WRITE_ERRORS = (TinyMongoWriteError,)
+try:
+    from pymongo.errors import WriteError as PyMongoWriteError
+except ImportError:  # pragma: no cover - optional dependency guard
+    pass
+else:
+    _WRITE_ERRORS += (PyMongoWriteError,)
+
+
+def test_min_and_max_follow_bson_order_and_report_noops(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "changes",
+                "minimum": "text",
+                "maximum": 99,
+                "nested": {"score": 3},
+                "array": [2],
+            },
+            {
+                "_id": "numeric-equal",
+                "minimum": 1.0,
+                "maximum": 1.0,
+            },
+        ]
+    )
+
+    changed = collection.update_one(
+        {"_id": "changes"},
+        {
+            "$min": {
+                "minimum": 7,
+                "nested.score": 2,
+                "array": [1],
+                "created.low": 4,
+            },
+            "$max": {
+                "maximum": {"rank": 1},
+                "created.high": 9,
+            },
+        },
+    )
+    unchanged = collection.update_one(
+        {"_id": "numeric-equal"},
+        {
+            "$min": {"minimum": 1},
+            "$max": {"maximum": 1},
+        },
+    )
+
+    assert (changed.matched_count, changed.modified_count) == (1, 1)
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+    assert collection.find_one({"_id": "changes"}) == {
+        "_id": "changes",
+        "minimum": 7,
+        "maximum": {"rank": 1},
+        "nested": {"score": 2},
+        "array": [1],
+        "created": {"low": 4, "high": 9},
+    }
+    equal = collection.find_one({"_id": "numeric-equal"})
+    assert type(equal["minimum"]) is float
+    assert type(equal["maximum"]) is float
+
+
+def test_min_and_max_include_null_in_whole_bson_value_order(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "null-order",
+            "min-null": None,
+            "max-null": None,
+            "min-number": 1,
+            "max-number": 1,
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "null-order"},
+        {
+            "$min": {"min-null": 1, "min-number": None},
+            "$max": {"max-null": 1, "max-number": None},
+        },
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "null-order"}) == {
+        "_id": "null-order",
+        "min-null": None,
+        "max-null": 1,
+        "min-number": None,
+        "max-number": 1,
+    }
+
+
+def test_rename_moves_nested_values_overwrites_and_ignores_missing_source(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "move",
+                "source": {"value": 1},
+                "destination": {"stale": True},
+                "profile": {"old": "nested", "keep": True},
+            },
+            {
+                "_id": "missing",
+                "destination": "unchanged",
+            },
+        ]
+    )
+
+    moved = collection.update_one(
+        {"_id": "move"},
+        {
+            "$rename": {
+                "source": "destination",
+                "profile.old": "moved.value",
+            }
+        },
+    )
+    missing = collection.update_one(
+        {"_id": "missing"},
+        {"$rename": {"absent": "destination"}},
+    )
+
+    assert (moved.matched_count, moved.modified_count) == (1, 1)
+    assert (missing.matched_count, missing.modified_count) == (1, 0)
+    assert collection.find_one({"_id": "move"}) == {
+        "_id": "move",
+        "destination": {"value": 1},
+        "profile": {"keep": True},
+        "moved": {"value": "nested"},
+    }
+    assert collection.find_one({"_id": "missing"}) == {
+        "_id": "missing",
+        "destination": "unchanged",
+    }
+
+
+def test_pop_handles_front_back_nested_empty_and_missing_arrays(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {
+                "_id": "values",
+                "front": [1, 2, 3],
+                "back": [1, 2, 3],
+                "nested": {"values": [4, 5]},
+            },
+            {"_id": "empty", "values": []},
+            {"_id": "missing"},
+        ]
+    )
+
+    changed = collection.update_one(
+        {"_id": "values"},
+        {
+            "$pop": {
+                "front": -1,
+                "back": 1,
+                "nested.values": -1,
+            }
+        },
+    )
+    empty = collection.update_one({"_id": "empty"}, {"$pop": {"values": 1}})
+    missing = collection.update_one(
+        {"_id": "missing"}, {"$pop": {"values": 1, "nested.values": -1}}
+    )
+
+    assert (changed.matched_count, changed.modified_count) == (1, 1)
+    assert (empty.matched_count, empty.modified_count) == (1, 0)
+    assert (missing.matched_count, missing.modified_count) == (1, 0)
+    assert collection.find_one({"_id": "values"}) == {
+        "_id": "values",
+        "front": [2, 3],
+        "back": [1, 2],
+        "nested": {"values": [5]},
+    }
+
+
+def test_new_update_operators_follow_numeric_array_paths(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "array-paths",
+            "values": [5, 8],
+            "nested": [[1, 2], [3]],
+            "documents": [{"score": 9}],
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "array-paths"},
+        {
+            "$min": {
+                "values.0": 3,
+                "values.3": 7,
+                "documents.2.score": 4,
+            },
+            "$max": {"values.1": 10},
+            "$pop": {"nested.0": 1},
+        },
+    )
+
+    assert (result.matched_count, result.modified_count) == (1, 1)
+    assert collection.find_one({"_id": "array-paths"}) == {
+        "_id": "array-paths",
+        "values": [3, 10, None, 7],
+        "nested": [[1], [3]],
+        "documents": [{"score": 9}, None, {"score": 4}],
+    }
+
+
+def test_new_update_operators_cover_upsert_update_many_and_find_and_modify(
+    contract_target,
+):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "many-change", "group": "many", "low": 10, "high": 0},
+            {"_id": "many-noop", "group": "many", "low": 1, "high": 10},
+            {"_id": "find", "old": "value", "score": 1},
+        ]
+    )
+
+    many = collection.update_many(
+        {"group": "many"},
+        {"$min": {"low": 5}, "$max": {"high": 5}},
+    )
+    upserted = collection.update_one(
+        {"_id": "upserted"},
+        {
+            "$min": {"low": 3},
+            "$max": {"high": 7},
+            "$pop": {"missing_array": 1},
+        },
+        upsert=True,
+    )
+    after = collection.find_one_and_update(
+        {"_id": "find"},
+        {"$rename": {"old": "new"}, "$max": {"score": 2}},
+        return_document=True,
+    )
+
+    assert (many.matched_count, many.modified_count) == (2, 1)
+    assert collection.find_one({"_id": "many-change"})["low"] == 5
+    assert collection.find_one({"_id": "many-change"})["high"] == 5
+    assert collection.find_one({"_id": "many-noop"})["low"] == 1
+    assert collection.find_one({"_id": "many-noop"})["high"] == 10
+    assert upserted.upserted_id == "upserted"
+    assert collection.find_one({"_id": "upserted"}) == {
+        "_id": "upserted",
+        "low": 3,
+        "high": 7,
+    }
+    assert after == {"_id": "find", "new": "value", "score": 2}
+
+
+def test_new_update_operators_apply_to_upsert_equality_fields(contract_target):
+    collection = contract_target.collection
+
+    minimum = collection.update_one(
+        {"_id": "minimum", "score": 5},
+        {"$min": {"score": 3}},
+        upsert=True,
+    )
+    maximum = collection.update_one(
+        {"_id": "maximum", "score": 5},
+        {"$max": {"score": 7}},
+        upsert=True,
+    )
+    popped = collection.update_one(
+        {"_id": "popped", "values": [1, 2]},
+        {"$pop": {"values": 1}},
+        upsert=True,
+    )
+    renamed = collection.update_one(
+        {"_id": "renamed", "source": "value"},
+        {"$rename": {"source": "destination"}},
+        upsert=True,
+    )
+
+    assert minimum.upserted_id == "minimum"
+    assert maximum.upserted_id == "maximum"
+    assert popped.upserted_id == "popped"
+    assert renamed.upserted_id == "renamed"
+    assert collection.find_one({"_id": "minimum"})["score"] == 3
+    assert collection.find_one({"_id": "maximum"})["score"] == 7
+    assert collection.find_one({"_id": "popped"})["values"] == [1]
+    assert collection.find_one({"_id": "renamed"}) == {
+        "_id": "renamed",
+        "destination": "value",
+    }
+
+
+def test_malformed_new_update_operands_report_mongodb_codes(contract_target):
+    collection = contract_target.collection
+    original = {"_id": "original", "field": 1, "values": [1]}
+    collection.insert_one(original)
+    cases = (
+        ("rename-non-string", {"$rename": {"field": 1}}, 2),
+        ("rename-self", {"$rename": {"field": "field"}}, 2),
+        ("rename-prefix", {"$rename": {"field": "field.child"}}, 2),
+        ("pop-zero", {"$pop": {"values": 0}}, 9),
+        ("pop-two", {"$pop": {"values": 2}}, 9),
+        ("pop-fraction", {"$pop": {"values": 1.5}}, 9),
+        ("pop-boolean", {"$pop": {"values": True}}, 9),
+        ("pop-string", {"$pop": {"values": "1"}}, 9),
+        ("pop-body", {"$pop": []}, 9),
+    )
+
+    for label, update, code in cases:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": "original"}, update)
+        assert caught.value.code == code, label
+        assert collection.find_one({"_id": "original"}) == original, label
+
+
+def test_update_path_conflicts_report_code_40_before_writing(contract_target):
+    collection = contract_target.collection
+    original = {
+        "_id": "conflict",
+        "field": {"child": [1, 2]},
+        "other": 2,
+    }
+    collection.insert_one(original)
+    conflicts = (
+        {"$min": {"other": 1}, "$max": {"other": 3}},
+        {"$set": {"field": {}}, "$pop": {"field.child": 1}},
+        {"$rename": {"other": "moved"}, "$set": {"moved": 3}},
+    )
+
+    for update in conflicts:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": "conflict"}, update)
+        assert caught.value.code == 40
+        assert collection.find_one({"_id": "conflict"}) == original
+
+
+def test_new_update_operators_preserve_immutable_id_semantics(contract_target):
+    collection = contract_target.collection
+    collection.insert_one({"_id": 5, "value": 1})
+
+    unchanged = collection.update_one({"_id": 5}, {"$min": {"_id": 7}})
+    assert (unchanged.matched_count, unchanged.modified_count) == (1, 0)
+
+    for update in ({"$min": {"_id": 3}}, {"$rename": {"_id": "former_id"}}):
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": 5}, update)
+        assert caught.value.code == 66
+        assert collection.find_one({"_id": 5}) == {"_id": 5, "value": 1}
+
+
+def test_new_update_operators_report_target_and_path_errors_atomically(
+    contract_target,
+):
+    collection = contract_target.collection
+    cases = (
+        ("pop-null", {"values": None}, {"$pop": {"values": 1}}, 14),
+        (
+            "pop-scalar",
+            {"values": "scalar"},
+            {"$pop": {"values": -1}},
+            14,
+        ),
+        (
+            "pop-blocked-path",
+            {"path": "scalar"},
+            {"$pop": {"path.values": 1}},
+            28,
+        ),
+        (
+            "rename-out-of-array",
+            {"path": [1, 2]},
+            {"$rename": {"path.0": "moved"}},
+            2,
+        ),
+        (
+            "rename-into-array",
+            {"path": [1, 2], "moved": 3},
+            {"$rename": {"moved": "path.0"}},
+            2,
+        ),
+    )
+
+    for label, document, update, code in cases:
+        original = {"_id": label, "status": "unchanged"}
+        original.update(document)
+        collection.insert_one(original)
+        atomic_update = {"$set": {"status": "changed"}}
+        atomic_update.update(update)
+
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one({"_id": label}, atomic_update)
+
+        assert caught.value.code == code, label
+        assert collection.find_one({"_id": label}) == original, label

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -776,8 +776,9 @@ def test_update_operator_error_edges(tmp_path):
         c.update_one({"_id": 1}, {})
     with pytest.raises(ValueError, match="update only works with \\$ operators"):
         c.update_one({"_id": 1}, {"$set": {"x": 1}, "plain": 2})
-    with pytest.raises(ValueError, match="requires a dict"):
+    with pytest.raises(WriteError, match="requires a document") as malformed:
         c.update_one({"_id": 1}, {"$set": "not-a-dict"})
+    assert malformed.value.code == 9
     with pytest.raises(WriteError, match="\\$inc requires numeric values") as one:
         c.update_one({"_id": 1}, {"$inc": {"count": 1}})
     assert one.value.code == 14

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -178,6 +178,24 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
             "$type",
         ),
     }
+    assert capabilities["update_operators"] == {
+        "operators": (
+            "$addToSet",
+            "$inc",
+            "$max",
+            "$min",
+            "$pop",
+            "$pull",
+            "$push",
+            "$rename",
+            "$set",
+            "$unset",
+        ),
+        "modifiers": {
+            "$addToSet": ("$each",),
+            "$push": ("$each", "$position", "$slice", "$sort"),
+        },
+    }
     assert capabilities["bson_types"]["native"] == (
         "array",
         "binary",
@@ -196,6 +214,7 @@ def test_backend_capabilities_are_explicit(tmp_path, backend):
     assert client.supports("multiprocess_writes") is True
     assert client.supports("aggregation") is True
     assert client.supports("query_operators") is True
+    assert client.supports("update_operators") is True
     assert client.supports("bson_types") is True
 
 

--- a/tests/test_query_more.py
+++ b/tests/test_query_more.py
@@ -197,9 +197,9 @@ def test_update_operator_support():
             "$set": {"meta.active": True},
             "$unset": {"meta.old": ""},
             "$push": {"tags": "b"},
-            "$addToSet": {"tags": "b"},
         },
     )
+    c.update_one({"_id": 1}, {"$addToSet": {"tags": "b"}})
     c.update_one({"_id": 1}, {"$pull": {"tags": "a"}})
 
     doc = c.find_one({"_id": 1})

--- a/tests/test_update_operator_modifiers.py
+++ b/tests/test_update_operator_modifiers.py
@@ -1,0 +1,408 @@
+"""Focused unit coverage for the remaining issue #77 update modifiers."""
+
+import pytest
+
+from tinymongo import TinyMongoClient
+from tinymongo import tinymongo as core
+from tinymongo.errors import TinyMongoError, WriteError
+
+
+def test_min_max_use_bson_order_and_preserve_equal_numeric_representation():
+    original = {
+        "_id": 1,
+        "minimum": "text",
+        "maximum": 1,
+        "equal": 1.0,
+        "array": [2],
+    }
+
+    updated = core._apply_update_document(
+        original,
+        {
+            "$min": {"minimum": 5, "array": [1]},
+            "$max": {"maximum": {"value": 1}, "equal": 1},
+        },
+    )
+
+    assert updated == {
+        "_id": 1,
+        "minimum": 5,
+        "maximum": {"value": 1},
+        "equal": 1.0,
+        "array": [1],
+    }
+    assert type(updated["equal"]) is float
+    assert original["minimum"] == "text"
+
+
+def test_min_max_create_missing_nested_fields_and_empty_operands_are_noops():
+    original = {"_id": 1, "profile": {"keep": True}}
+
+    updated = core._apply_update_document(
+        original,
+        {
+            "$min": {"profile.low": 2, "created.low": 3},
+            "$max": {"profile.high": 8, "created.high": 9},
+        },
+    )
+    unchanged = core._apply_update_document(
+        original,
+        {"$min": {}, "$max": {}, "$rename": {}, "$pop": {}},
+    )
+
+    assert updated == {
+        "_id": 1,
+        "profile": {"keep": True, "low": 2, "high": 8},
+        "created": {"low": 3, "high": 9},
+    }
+    assert unchanged == original
+
+
+def test_min_max_and_pop_support_numeric_array_paths_and_sparse_growth():
+    original = {
+        "_id": 1,
+        "values": [5, 8],
+        "nested": [[1, 2], [3]],
+        "documents": [{"score": 9}],
+    }
+
+    updated = core._apply_update_document(
+        original,
+        {
+            "$min": {
+                "values.0": 3,
+                "values.3": 7,
+                "documents.0.score": 4,
+                "documents.2.score": 4,
+            },
+            "$max": {"values.1": 10},
+            "$pop": {"nested.0": 1},
+        },
+    )
+
+    assert updated == {
+        "_id": 1,
+        "values": [3, 10, None, 7],
+        "nested": [[1], [3]],
+        "documents": [{"score": 4}, None, {"score": 4}],
+    }
+
+
+def test_new_update_paths_reject_existing_scalar_and_null_ancestors():
+    cases = (
+        ({"_id": 1, "path": "scalar"}, {"$min": {"path.value": 1}}),
+        ({"_id": 1, "path": None}, {"$max": {"path.value": 1}}),
+        ({"_id": 1, "path": [None]}, {"$min": {"path.0.value": 1}}),
+        ({"_id": 1, "path": "scalar"}, {"$pop": {"path.values": 1}}),
+    )
+
+    for original, update in cases:
+        with pytest.raises(WriteError) as caught:
+            core._apply_update_document(original, update)
+        assert caught.value.code == 28
+
+
+def test_rename_moves_nested_values_overwrites_and_ignores_missing_source():
+    original = {
+        "_id": 1,
+        "source": {"value": 1},
+        "destination": "stale",
+        "nested": {"old": [1, 2], "keep": True},
+    }
+
+    updated = core._apply_update_document(
+        original,
+        {
+            "$rename": {
+                "source": "destination",
+                "nested.old": "created.deep.value",
+                "missing": "untouched",
+            }
+        },
+    )
+
+    assert updated == {
+        "_id": 1,
+        "destination": {"value": 1},
+        "nested": {"keep": True},
+        "created": {"deep": {"value": [1, 2]}},
+    }
+    assert original["source"] == {"value": 1}
+
+
+@pytest.mark.parametrize(
+    ("update", "code"),
+    [
+        ({"$rename": {"field": 1}}, 2),
+        ({"$rename": {"field": "field"}}, 2),
+        ({"$rename": {"field": "field.child"}}, 2),
+        ({"$rename": {"field.child": "field"}}, 2),
+        ({"$rename": {"field.$": "other"}}, 2),
+        ({"$rename": {"field": "other.$[item]"}}, 2),
+    ],
+    ids=(
+        "non-string-destination",
+        "same-path",
+        "destination-child",
+        "destination-parent",
+        "positional-source",
+        "filtered-destination",
+    ),
+)
+def test_rename_rejects_invalid_paths(update, code):
+    original = {"_id": 1, "field": {"child": 1}}
+
+    with pytest.raises(WriteError) as caught:
+        core._apply_update_document(original, update)
+
+    assert isinstance(caught.value, TinyMongoError)
+    assert caught.value.code == code
+    assert original == {"_id": 1, "field": {"child": 1}}
+
+
+def test_update_path_conflicts_and_empty_paths_report_mongodb_codes():
+    original = {"_id": 1, "field": {"child": 1}, "other": 2}
+    cases = (
+        ({"$min": {"other": 1}, "$max": {"other": 3}}, 40),
+        ({"$set": {"field": {}}, "$pop": {"field.child": 1}}, 40),
+        ({"$rename": {"other": "moved"}, "$set": {"moved": 3}}, 40),
+        ({"$rename": {"": "moved"}}, 56),
+        ({"$min": {"field.": 1}}, 56),
+        ({"$pop": []}, 9),
+    )
+
+    for update, code in cases:
+        with pytest.raises(WriteError) as caught:
+            core._apply_update_document(original, update)
+        assert caught.value.code == code
+        assert original == {"_id": 1, "field": {"child": 1}, "other": 2}
+
+
+def test_pop_removes_front_back_and_handles_missing_or_empty_arrays():
+    original = {
+        "_id": 1,
+        "front": [1, 2, 3],
+        "back": [1, 2, 3],
+        "empty": [],
+        "nested": {"values": [4, 5]},
+    }
+
+    updated = core._apply_update_document(
+        original,
+        {
+            "$pop": {
+                "front": -1,
+                "back": 1,
+                "empty": 1,
+                "missing": -1,
+                "nested.values": -1,
+            }
+        },
+    )
+
+    assert updated == {
+        "_id": 1,
+        "front": [2, 3],
+        "back": [1, 2],
+        "empty": [],
+        "nested": {"values": [5]},
+    }
+    assert original["front"] == [1, 2, 3]
+
+
+@pytest.mark.parametrize("operand", [0, 2, -2, 1.5, True, "1", {}, []])
+def test_pop_rejects_every_operand_except_integral_plus_or_minus_one(operand):
+    original = {"_id": 1, "values": [1, 2]}
+
+    with pytest.raises(WriteError) as caught:
+        core._apply_update_document(original, {"$pop": {"values": operand}})
+
+    assert caught.value.code == 9
+    assert original == {"_id": 1, "values": [1, 2]}
+
+
+@pytest.mark.parametrize(
+    ("operand", "expected"),
+    [(1.0, [1]), (-1.0, [2])],
+)
+def test_pop_accepts_integral_float_directions(operand, expected):
+    updated = core._apply_update_document(
+        {"_id": 1, "values": [1, 2]}, {"$pop": {"values": operand}}
+    )
+
+    assert updated["values"] == expected
+
+
+@pytest.mark.parametrize("value", [None, "scalar", 1, {}])
+def test_pop_rejects_non_array_targets_with_type_mismatch(value):
+    original = {"_id": 1, "values": value}
+
+    with pytest.raises(WriteError) as caught:
+        core._apply_update_document(original, {"$pop": {"values": 1}})
+
+    assert caught.value.code == 14
+    assert original == {"_id": 1, "values": value}
+
+
+def test_new_operator_failures_do_not_partially_apply_other_changes():
+    original = {"_id": 1, "status": "original", "values": "not-an-array"}
+
+    with pytest.raises(WriteError) as caught:
+        core._apply_update_document(
+            original,
+            {
+                "$set": {"status": "changed"},
+                "$pop": {"values": 1},
+            },
+        )
+
+    assert caught.value.code == 14
+    assert original == {"_id": 1, "status": "original", "values": "not-an-array"}
+
+
+def test_invalid_new_operators_are_preflighted_even_without_a_match(tmp_path):
+    client = TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.db.items
+
+    with pytest.raises(WriteError) as caught:
+        collection.update_one({"_id": "missing"}, {"$pop": {"values": 0}})
+
+    assert caught.value.code == 9
+    assert collection.count_documents({}) == 0
+    client.close()
+
+
+def test_upserts_apply_new_operators_to_equality_fields(tmp_path):
+    client = TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.db.items
+
+    minimum = collection.update_one(
+        {"_id": "minimum", "score": 5},
+        {"$min": {"score": 3}},
+        upsert=True,
+    )
+    maximum = collection.update_one(
+        {"_id": "maximum", "score": 5},
+        {"$max": {"score": 7}},
+        upsert=True,
+    )
+    popped = collection.update_one(
+        {"_id": "popped", "values": [1, 2]},
+        {"$pop": {"values": 1}},
+        upsert=True,
+    )
+    renamed = collection.update_one(
+        {"_id": "renamed", "source": "value"},
+        {"$rename": {"source": "destination"}},
+        upsert=True,
+    )
+
+    assert minimum.upserted_id == "minimum"
+    assert maximum.upserted_id == "maximum"
+    assert popped.upserted_id == "popped"
+    assert renamed.upserted_id == "renamed"
+    assert collection.find_one({"_id": "minimum"})["score"] == 3
+    assert collection.find_one({"_id": "maximum"})["score"] == 7
+    assert collection.find_one({"_id": "popped"})["values"] == [1]
+    assert collection.find_one({"_id": "renamed"}) == {
+        "_id": "renamed",
+        "destination": "value",
+    }
+    client.close()
+
+
+def test_update_path_and_comparison_internal_error_edges():
+    error_cases = (
+        (lambda: core._update_path_parts(1), 9),
+        (
+            lambda: core._read_update_path(
+                {"path": []}, "path.value", rename_role="source"
+            ),
+            28,
+        ),
+        (lambda: core._read_update_path({"path": []}, "path.value"), 28),
+        (
+            lambda: core._write_update_path(
+                {"path": "scalar"},
+                "path.value",
+                1,
+                rename_role="destination",
+            ),
+            28,
+        ),
+        (
+            lambda: core._write_update_path(
+                {"path": []},
+                "path.value",
+                1,
+                rename_role="destination",
+            ),
+            28,
+        ),
+        (lambda: core._write_update_path({"path": []}, "path.value", 1), 28),
+        (lambda: core._write_update_path({"path": [None]}, "path.0.value", 1), 28),
+        (lambda: core._write_update_path("scalar", "path", 1), 28),
+        (
+            lambda: core._remove_update_path(
+                {"path": [{"value": 1}]},
+                "path.0.value",
+                rename_role="source",
+            ),
+            2,
+        ),
+        (
+            lambda: core._remove_update_path(
+                {"path": []}, "path.value.child", rename_role="source"
+            ),
+            28,
+        ),
+        (
+            lambda: core._remove_update_path(
+                {"path": []}, "path.0", rename_role="source"
+            ),
+            2,
+        ),
+        (
+            lambda: core._remove_update_path(
+                {"path": []}, "path.value", rename_role="source"
+            ),
+            28,
+        ),
+        (
+            lambda: core._remove_update_path(
+                {"path": "scalar"},
+                "path.value.child",
+                rename_role="source",
+            ),
+            28,
+        ),
+        (
+            lambda: core._remove_update_path(
+                {"path": "scalar"}, "path.value", rename_role="source"
+            ),
+            28,
+        ),
+        (
+            lambda: core._apply_update_document(
+                {"_id": 1, "value": object()}, {"$min": {"value": 1}}
+            ),
+            2,
+        ),
+        (
+            lambda: core._apply_update_document({"_id": [1, 2]}, {"$pop": {"_id": 1}}),
+            66,
+        ),
+    )
+
+    for operation, code in error_cases:
+        with pytest.raises(WriteError) as caught:
+            operation()
+        assert caught.value.code == code
+
+    missing_parent = {}
+    core._remove_update_path(missing_parent, "missing.value", rename_role="source")
+    assert missing_parent == {}
+
+    existing_array_item = {"path": [{}]}
+    core._write_update_path(existing_array_item, "path.0.value", 1)
+    assert existing_array_item == {"path": [{"value": 1}]}

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -293,7 +293,19 @@ def _unset_nested(doc, path):
     current.pop(parts[-1], None)
 
 
-_UPDATE_OPERATORS = frozenset(("$set", "$unset", "$inc", "$push", "$pull", "$addToSet"))
+_UPDATE_OPERATOR_NAMES = (
+    "$addToSet",
+    "$inc",
+    "$max",
+    "$min",
+    "$pop",
+    "$pull",
+    "$push",
+    "$rename",
+    "$set",
+    "$unset",
+)
+_UPDATE_OPERATORS = frozenset(_UPDATE_OPERATOR_NAMES)
 _PUSH_MODIFIERS = frozenset(("$each", "$position", "$sort", "$slice"))
 _ADD_TO_SET_MODIFIERS = frozenset(("$each",))
 _PULL_COMPARISON_OPERATORS = {
@@ -310,6 +322,140 @@ def _raise_write_error(message, code=2):
     """Raise a Mongo-shaped write error that remains a TinyMongoError."""
 
     raise WriteError(message, code=code)
+
+
+def _update_path_parts(path):
+    """Validate and split one MongoDB update field path."""
+
+    if not isinstance(path, str):
+        _raise_write_error("Update field paths must be strings", code=9)
+    parts = path.split(".")
+    if any(not part for part in parts):
+        _raise_write_error("An empty update path is not valid", code=56)
+    return parts
+
+
+def _is_update_array_index(part):
+    return part == "0" or (
+        part
+        and part[0] in "123456789"
+        and all("0" <= character <= "9" for character in part)
+    )
+
+
+def _update_paths_overlap(left, right):
+    left_parts = _update_path_parts(left)
+    right_parts = _update_path_parts(right)
+    shared = min(len(left_parts), len(right_parts))
+    return left_parts[:shared] == right_parts[:shared]
+
+
+def _raise_path_not_viable(path):
+    _raise_write_error(
+        "Cannot create or traverse update path {0}".format(repr(path)),
+        code=28,
+    )
+
+
+def _raise_rename_array_path(path, role):
+    _raise_write_error(
+        "The {0} field cannot be an array element: {1}".format(role, repr(path)),
+        code=2,
+    )
+
+
+def _read_update_path(document, path, rename_role=None):
+    """Read a dotted update path while distinguishing missing and blocked paths."""
+
+    current = document
+    for part in _update_path_parts(path):
+        if isinstance(current, Mapping):
+            if part not in current:
+                return _MISSING
+            current = current[part]
+            continue
+        if isinstance(current, list):
+            if rename_role is not None:
+                if _is_update_array_index(part):
+                    _raise_rename_array_path(path, rename_role)
+                _raise_path_not_viable(path)
+            if not _is_update_array_index(part):
+                _raise_path_not_viable(path)
+            index = int(part)
+            if index >= len(current):
+                return _MISSING
+            current = current[index]
+            continue
+        _raise_path_not_viable(path)
+    return current
+
+
+def _write_update_path(document, path, value, rename_role=None):
+    """Write a dotted update path with MongoDB-style path viability checks."""
+
+    parts = _update_path_parts(path)
+    current = document
+    for offset, part in enumerate(parts):  # pragma: no branch - paths are nonempty
+        last = offset == len(parts) - 1
+        if isinstance(current, MutableMapping):
+            if last:
+                current[part] = copy.deepcopy(value)
+                return
+            if part not in current:
+                current[part] = {}
+            child = current[part]
+            if not isinstance(child, (MutableMapping, list)):
+                _raise_path_not_viable(path)
+            current = child
+            continue
+        if isinstance(current, list):
+            if rename_role is not None:
+                if _is_update_array_index(part):
+                    _raise_rename_array_path(path, rename_role)
+                _raise_path_not_viable(path)
+            if not _is_update_array_index(part):
+                _raise_path_not_viable(path)
+            index = int(part)
+            if last:
+                if index >= len(current):
+                    current.extend([None] * (index + 1 - len(current)))
+                current[index] = copy.deepcopy(value)
+                return
+            if index >= len(current):
+                current.extend([None] * (index + 1 - len(current)))
+                current[index] = {}
+            child = current[index]
+            if not isinstance(child, (MutableMapping, list)):
+                _raise_path_not_viable(path)
+            current = child
+            continue
+        _raise_path_not_viable(path)
+
+
+def _remove_update_path(document, path, rename_role=None):
+    """Remove an existing dotted update path without collapsing empty parents."""
+
+    parts = _update_path_parts(path)
+    current = document
+    for part in parts[:-1]:
+        if isinstance(current, MutableMapping):
+            if part not in current:
+                return
+            current = current[part]
+            continue
+        if isinstance(current, list):
+            if rename_role is not None and _is_update_array_index(part):
+                _raise_rename_array_path(path, rename_role)
+            _raise_path_not_viable(path)
+        _raise_path_not_viable(path)
+    if isinstance(current, MutableMapping):
+        current.pop(parts[-1], None)
+        return
+    if isinstance(current, list):
+        if rename_role is not None and _is_update_array_index(parts[-1]):
+            _raise_rename_array_path(path, rename_role)
+        _raise_path_not_viable(path)
+    _raise_path_not_viable(path)
 
 
 def _is_modifier_document(value):
@@ -376,6 +522,45 @@ def _validate_push_operand(value):
 
 def _validate_add_to_set_operand(value):
     return _validate_each_modifier(value, "$addToSet", _ADD_TO_SET_MODIFIERS)
+
+
+def _validate_pop_operand(value):
+    if not _is_modifier_integer(value) or bson_number_decimal(value) not in (-1, 1):
+        _raise_write_error("$pop expects 1 or -1", code=9)
+
+
+def _validate_rename_operand(source, target):
+    _update_path_parts(source)
+    if not isinstance(target, str):
+        _raise_write_error("The destination field for $rename must be a string")
+    _update_path_parts(target)
+    if any(part.startswith("$") for part in source.split(".") + target.split(".")):
+        _raise_write_error("$rename does not support positional array paths")
+    if _update_paths_overlap(source, target):
+        if source == target:
+            _raise_write_error("The source and target field for $rename must differ")
+        _raise_write_error(
+            "The source and target field for $rename must not be on the same path"
+        )
+
+
+def _validate_update_path_conflicts(update_doc):
+    paths = []
+    for operator, changes in update_doc.items():
+        for path, value in changes.items():
+            paths.append(path)
+            if operator == "$rename":
+                paths.append(value)
+
+    for index, path in enumerate(paths):
+        for other in paths[index + 1 :]:
+            if _update_paths_overlap(path, other):
+                _raise_write_error(
+                    "Updating path {0} would create a conflict at {1}".format(
+                        repr(other), repr(path)
+                    ),
+                    code=40,
+                )
 
 
 def _validate_pull_field_condition(condition):
@@ -447,8 +632,12 @@ def _validate_update_operators(update_doc):
             raise TinyMongoNotSupportedError(
                 "Unsupported update operator: {0}".format(operator)
             )
-        if not isinstance(changes, dict):
-            raise ValueError("{0} update requires a dict".format(operator))
+        if not isinstance(changes, Mapping):
+            _raise_write_error(
+                "{0} update requires a document".format(operator), code=9
+            )
+        for path in changes:
+            _update_path_parts(path)
         if operator == "$push":
             for value in changes.values():
                 _validate_push_operand(value)
@@ -462,6 +651,26 @@ def _validate_update_operators(update_doc):
             for value in changes.values():
                 if not is_bson_number(value):
                     _raise_write_error("$inc requires numeric values", code=14)
+        elif operator == "$pop":
+            for value in changes.values():
+                _validate_pop_operand(value)
+        elif operator == "$rename":
+            for source, target in changes.items():
+                _validate_rename_operand(source, target)
+
+    _validate_update_path_conflicts(update_doc)
+
+
+def update_operator_capabilities():
+    """Return the exact update operators and modifiers TinyMongo supports."""
+
+    return {
+        "operators": _UPDATE_OPERATOR_NAMES,
+        "modifiers": {
+            "$addToSet": tuple(sorted(_ADD_TO_SET_MODIFIERS)),
+            "$push": tuple(sorted(_PUSH_MODIFIERS)),
+        },
+    }
 
 
 def _sort_pushed_values(values, sort_spec):
@@ -517,6 +726,27 @@ def _apply_add_to_set(current, value):
         if not any(bson_values_equal(candidate, existing) for existing in current):
             current.append(copy.deepcopy(candidate))
     return current
+
+
+def _comparison_update_replaces(operator, current, candidate):
+    current_key = bson_value_sort_key(current)
+    candidate_key = bson_value_sort_key(candidate)
+    if current_key is None or candidate_key is None:
+        _raise_write_error(
+            "{0} requires supported BSON values".format(operator), code=2
+        )
+    if operator == "$min":
+        return candidate_key < current_key
+    return candidate_key > current_key
+
+
+def _raise_immutable_id_update(path):
+    _raise_write_error(
+        "Performing an update on path {0} would modify immutable field _id".format(
+            repr(path)
+        ),
+        code=66,
+    )
 
 
 def _pull_comparison_matches(actual, operand, comparison):
@@ -580,6 +810,37 @@ def _apply_update_document(item, update_doc):
                 if not is_bson_number(current) or not is_bson_number(value):
                     _raise_write_error("$inc requires numeric values", code=14)
                 _set_nested(updated, path, add_bson_numbers(current, value))
+        elif operator in ("$min", "$max"):
+            for path, value in changes.items():
+                current = _read_update_path(updated, path)
+                should_write = current is _MISSING or _comparison_update_replaces(
+                    operator, current, value
+                )
+                if should_write:
+                    if path == "_id" or path.startswith("_id."):
+                        _raise_immutable_id_update(path)
+                    _write_update_path(updated, path, value)
+        elif operator == "$pop":
+            for path, value in changes.items():
+                current = _read_update_path(updated, path)
+                if current is _MISSING or not current:
+                    if current is not _MISSING and not isinstance(current, list):
+                        _raise_write_error(
+                            "Cannot apply $pop to a non-array field", code=14
+                        )
+                    continue  # pragma: no cover - no trace event on Python 3.9
+                if not isinstance(current, list):
+                    _raise_write_error(
+                        "Cannot apply $pop to a non-array field", code=14
+                    )
+                popped = list(current)
+                if bson_number_decimal(value) < 0:
+                    popped.pop(0)
+                else:
+                    popped.pop()
+                if path == "_id" or path.startswith("_id."):
+                    _raise_immutable_id_update(path)
+                _write_update_path(updated, path, popped)
         elif operator == "$push":
             for path, value in changes.items():
                 current = _get_nested(updated, path, [])
@@ -606,6 +867,25 @@ def _apply_update_document(item, update_doc):
                 current = list(current)
                 current = _apply_add_to_set(current, value)
                 _set_nested(updated, path, current)
+        elif operator == "$rename":  # pragma: no branch - operators prevalidated
+            for source, destination in changes.items():
+                value = _read_update_path(updated, source, rename_role="source")
+                if value is _MISSING:
+                    continue
+                if (
+                    source == "_id"
+                    or source.startswith("_id.")
+                    or destination == "_id"
+                    or destination.startswith("_id.")
+                ):
+                    _raise_immutable_id_update(source)
+                _remove_update_path(updated, source, rename_role="source")
+                _write_update_path(
+                    updated,
+                    destination,
+                    value,
+                    rename_role="destination",
+                )
 
     updated["_id"] = item["_id"]
     return updated
@@ -1157,6 +1437,7 @@ class TinyMongoClient(object):
             "bulk_writes": False,
             "aggregation": aggregation_capabilities(),
             "query_operators": query_operator_capabilities(),
+            "update_operators": update_operator_capabilities(),
             "sessions": False,
             "transactions": False,
             "change_streams": False,


### PR DESCRIPTION
## Summary

Completes the remaining update-operator work tracked in #77 and prepares the package for the 1.3.0 release.

- adds `$rename`, `$min`, `$max`, and `$pop`
- supports the operators through the shared synchronous and asynchronous implementation on every backend
- bumps the package version to `1.3.0`
- updates the roadmap, changelog, README, migration guide, object-storage notes, and Talk Python acceptance guide

## MongoDB compatibility

The new implementation follows behavior verified directly against MongoDB 8:

- `$min` and `$max` use BSON value ordering, create missing paths, and preserve the stored numeric representation when values compare equal
- `$pop` removes the first or last array member for `-1` or `1`, treats missing and empty arrays as no-ops, and rejects invalid operands or non-array targets with MongoDB-compatible errors
- `$rename` moves nested values, overwrites an existing destination, ignores missing sources, and enforces MongoDB restrictions around overlapping paths, array traversal, and immutable `_id`
- numeric array paths and sparse array growth are supported where MongoDB permits them
- conflicting update paths are rejected before persistence, preventing partial document changes
- malformed documents, invalid targets, blocked paths, conflicts, and immutable `_id` changes report the corresponding MongoDB-style error codes
- upserts, `update_many()`, and find-and-modify paths share the same behavior

Capability reporting now exposes the exact supported update operators and the supported `$push`/`$addToSet` modifiers through `client.capabilities()`.

## Why

Issue #77 still listed four MongoDB update operators that TinyMongo did not implement. Supporting them required more than adding dispatcher branches: the existing update path helpers did not distinguish missing paths, blocked traversal, numeric array positions, rename restrictions, or cross-operator path conflicts closely enough for MongoDB-compatible behavior.

## Validation

- full suite: **3,266 passed**, 463 deselected
- coverage: **100% statements and branches** across all TinyMongo modules
- live MongoDB 8 update contract: **22 passed**
- dependency-free Python 3.9 job: **87 passed**, 8 skipped
- PyMongo 4.9 compatibility floor: **243 passed**, 28 deselected
- Black: passed
- Ruff: passed
- mypy with the CI configuration: passed
- source distribution and wheel build: passed
- strict Twine package checks: passed
- wheel metadata verified as version `1.3.0`

Closes #77
