### PR TITLE
Fix MinKey and MaxKey range semantics (TM-036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- **TM-036:** `MinKey` and `MaxKey` range operands now cross BSON type
+  brackets, so whole-range queries return every supported value through
+  `find()`, aggregation `$match`, and `$pull` instead of silently returning an
+  empty result.
+
 ## [1.3.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -578,11 +578,13 @@ booleans, datetimes, `Timestamp`, regex, unscoped `Code`, scoped `Code`, and
 `$gt`, `$gte`, `$lt`, and `$lte` query operators, including range predicates
 inside `$pull`. Range queries apply MongoDB's BSON type bracketing: numeric
 representations share one family, while values from other type families do not
-compare with one another. Array fields expose both the whole array and its
-direct members where MongoDB does, and documents and arrays are compared
-recursively. Values with equal comparison keys retain their input order for
-ascending and descending sorts. TinyMongo uses its shared Python matcher
-whenever a backend-native or indexed predicate cannot guarantee these rules.
+compare with one another. `MinKey` and `MaxKey` operands are the two exceptions:
+they compare across every supported BSON type and can express an inclusive
+whole-value range. Array fields expose both the whole array and its direct
+members where MongoDB does, and documents and arrays are compared recursively.
+Values with equal comparison keys retain their input order for ascending and
+descending sorts. TinyMongo uses its shared Python matcher whenever a
+backend-native or indexed predicate cannot guarantee these rules.
 Extending unique-index identity to the remaining supported BSON values is
 still tracked separately in the roadmap and continues to fail closed where
 exact enforcement is unavailable. Update and aggregation `$min` and `$max`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,6 +188,18 @@ with the follow-up audit of his
   and preserve TinyMongo's more diagnostic `InvalidDocument` messages with
   collection, `_id`, and full nested-path context.
 
+#### Mike's [TM-036 through TM-038 BSON follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5169028297)
+
+- [x] **TM-036:** Exempt `MinKey` and `MaxKey` range operands from BSON type
+  bracketing so inclusive whole-range scans work through `find()`, aggregation
+  `$match`, and `$pull`, including missing fields and stored boundary values.
+- [ ] **TM-037:** Decide whether top-level `Timestamp(0, 0)` inserts should
+  receive MongoDB's server timestamp or remain a documented embedded-database
+  difference.
+- [ ] **TM-038:** Extend `$pull` through the shared matcher for the remaining
+  measured predicate set: `$exists`, `$type`, `$ne`, `$mod`, `$all`, `$size`,
+  and document-field `$not`.
+
 - [x] **Remote SQL numeric uniqueness:** Persist versioned, fixed-width digests
   of canonical BSON scalar tokens for PostgreSQL and MariaDB/MySQL unique
   indexes. Native constraints now enforce exact cross-process equality for

--- a/tests/contracts/test_bson_comparison_contract.py
+++ b/tests/contracts/test_bson_comparison_contract.py
@@ -12,6 +12,8 @@ from tinymongo.errors import WriteError as TinyMongoWriteError
 pytestmark = pytest.mark.contract
 bson = pytest.importorskip("bson")
 Binary = bson.Binary
+MaxKey = bson.MaxKey
+MinKey = bson.MinKey
 ObjectId = bson.ObjectId
 Regex = bson.Regex
 
@@ -115,6 +117,107 @@ def test_generated_scalar_range_matrix(
         operator: _ids(collection.find({"value": {operator: operand}}))
         for operator in ("$gt", "$gte", "$lt", "$lte")
     } == expected
+
+
+def test_tm036_min_max_key_range_operands_cross_type_brackets(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "minimum", "value": MinKey()},
+            {"_id": "null", "value": None},
+            {"_id": "nan", "value": float("nan")},
+            {"_id": "decimal-nan", "value": bson.Decimal128("NaN")},
+            {"_id": "number", "value": 1},
+            {"_id": "string", "value": "value"},
+            {"_id": "object", "value": {"answer": 42}},
+            {"_id": "empty-array", "value": []},
+            {"_id": "array", "value": [1, 2]},
+            {"_id": "maximum", "value": MaxKey()},
+            {"_id": "missing"},
+        ]
+    )
+
+    all_ids = {
+        "minimum",
+        "null",
+        "nan",
+        "decimal-nan",
+        "number",
+        "string",
+        "object",
+        "empty-array",
+        "array",
+        "maximum",
+        "missing",
+    }
+    assert _ids(collection.find({"value": {"$gt": MinKey()}})) == all_ids - {"minimum"}
+    assert _ids(collection.find({"value": {"$gte": MinKey()}})) == all_ids
+    assert _ids(collection.find({"value": {"$lt": MinKey()}})) == set()
+    assert _ids(collection.find({"value": {"$lte": MinKey()}})) == {"minimum"}
+
+    assert _ids(collection.find({"value": {"$lt": MaxKey()}})) == all_ids - {"maximum"}
+    assert _ids(collection.find({"value": {"$lte": MaxKey()}})) == all_ids
+    assert _ids(collection.find({"value": {"$gt": MaxKey()}})) == set()
+    assert _ids(collection.find({"value": {"$gte": MaxKey()}})) == {"maximum"}
+
+    whole_range = {"value": {"$gte": MinKey(), "$lte": MaxKey()}}
+    assert _ids(collection.find(whole_range)) == all_ids
+    assert _ids(collection.aggregate([{"$match": whole_range}])) == all_ids
+
+    # Only MinKey and MaxKey operands span BSON type brackets. Ordinary
+    # numeric predicates still exclude stored values from every other family.
+    assert _ids(collection.find({"value": {"$gt": 0}})) == {"number", "array"}
+    assert _ids(collection.find({"value": {"$in": [MinKey()]}})) == {"minimum"}
+
+
+def test_tm036_extreme_array_members_preserve_exact_semantics(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "minimum-array", "value": [MinKey()]},
+            {"_id": "maximum-array", "value": [MaxKey()]},
+        ]
+    )
+
+    array_ids = {"minimum-array", "maximum-array"}
+    assert _ids(collection.find({"value": {"$gt": MinKey()}})) == array_ids
+    assert _ids(collection.find({"value": {"$lte": MinKey()}})) == {"minimum-array"}
+    assert _ids(collection.find({"value": {"$lt": MaxKey()}})) == array_ids
+    assert _ids(collection.find({"value": {"$gte": MaxKey()}})) == {"maximum-array"}
+
+    assert _ids(collection.find({"value": {"$elemMatch": {"$gt": MinKey()}}})) == {
+        "maximum-array"
+    }
+    assert _ids(collection.find({"value": {"$elemMatch": {"$lte": MinKey()}}})) == {
+        "minimum-array"
+    }
+
+
+def test_tm036_pull_reuses_unbounded_min_max_key_ranges(contract_target):
+    collection = contract_target.collection
+    collection.insert_one(
+        {
+            "_id": "values",
+            "items": [
+                MinKey(),
+                None,
+                1,
+                "value",
+                {"answer": 42},
+                [1, 2],
+                MaxKey(),
+            ],
+        }
+    )
+
+    result = collection.update_one(
+        {"_id": "values"},
+        {"$pull": {"items": {"$gte": MinKey(), "$lte": MaxKey()}}},
+    )
+
+    assert result.matched_count == 1
+    assert result.modified_count == 1
+    assert collection.find_one({"_id": "values"})["items"] == []
 
 
 def test_null_range_queries_include_missing_and_array_members(contract_target):

--- a/tests/integration/test_remote_sql.py
+++ b/tests/integration/test_remote_sql.py
@@ -181,6 +181,98 @@ def test_remote_sql_async_query_operators(backend, env_name):
 
 
 @pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_tm036_min_max_key_ranges(backend, env_name):
+    bson = pytest.importorskip("bson")
+    dsn, database, prefix = _remote_target(backend, env_name)
+    client = tm.TinyMongoClient(backend=backend, dsn=dsn)
+    docs = client[database][prefix + "_tm036_ranges"]
+    whole_range = {"value": {"$gte": bson.MinKey(), "$lte": bson.MaxKey()}}
+    expected = {"minimum", "number", "string", "maximum", "missing", "holder"}
+    try:
+        docs.insert_many(
+            [
+                {"_id": "minimum", "value": bson.MinKey()},
+                {"_id": "number", "value": 1},
+                {"_id": "string", "value": "value"},
+                {"_id": "maximum", "value": bson.MaxKey()},
+                {"_id": "missing"},
+                {
+                    "_id": "holder",
+                    "value": 0,
+                    "items": [bson.MinKey(), 1, "value", bson.MaxKey()],
+                },
+            ]
+        )
+
+        assert {row["_id"] for row in docs.find(whole_range)} == expected
+        assert {
+            row["_id"] for row in docs.aggregate([{"$match": whole_range}])
+        } == expected
+
+        result = docs.update_one(
+            {"_id": "holder"},
+            {"$pull": {"items": {"$gte": bson.MinKey(), "$lte": bson.MaxKey()}}},
+        )
+        assert result.modified_count == 1
+        assert docs.find_one({"_id": "holder"})["items"] == []
+    finally:
+        docs.drop()
+        client.close()
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
+def test_remote_sql_async_tm036_min_max_key_ranges(backend, env_name):
+    bson = pytest.importorskip("bson")
+    dsn, database, prefix = _remote_target(backend, env_name)
+    whole_range = {"value": {"$gte": bson.MinKey(), "$lte": bson.MaxKey()}}
+    expected = {"minimum", "number", "string", "maximum", "missing", "holder"}
+
+    async def scenario():
+        client = AsyncTinyMongoClient(backend=backend, dsn=dsn)
+        docs = client[database][prefix + "_async_tm036_ranges"]
+        try:
+            await docs.insert_many(
+                [
+                    {"_id": "minimum", "value": bson.MinKey()},
+                    {"_id": "number", "value": 1},
+                    {"_id": "string", "value": "value"},
+                    {"_id": "maximum", "value": bson.MaxKey()},
+                    {"_id": "missing"},
+                    {
+                        "_id": "holder",
+                        "value": 0,
+                        "items": [bson.MinKey(), 1, "value", bson.MaxKey()],
+                    },
+                ]
+            )
+
+            assert {
+                row["_id"] for row in await docs.find(whole_range).to_list()
+            } == expected
+            aggregate = await docs.aggregate([{"$match": whole_range}])
+            assert {row["_id"] for row in await aggregate.to_list()} == expected
+
+            result = await docs.update_one(
+                {"_id": "holder"},
+                {
+                    "$pull": {
+                        "items": {
+                            "$gte": bson.MinKey(),
+                            "$lte": bson.MaxKey(),
+                        }
+                    }
+                },
+            )
+            assert result.modified_count == 1
+            assert (await docs.find_one({"_id": "holder"}))["items"] == []
+        finally:
+            await docs.drop()
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(("backend", "env_name"), REMOTE_BACKENDS)
 def test_remote_sql_uuid_regex_roundtrip_query_and_unique_fail_closed(
     backend, env_name
 ):

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -684,16 +684,18 @@ def bson_query_range_matches(actual, operand, comparison, exact=False):
     """Return whether one query range comparison follows BSON semantics.
 
     MongoDB brackets range predicates by the outer BSON type, with all numeric
-    representations sharing one family. A non-positional array field exposes
-    both its complete array value and each direct member to the predicate;
-    ``exact`` endpoints such as ``$elemMatch`` or a numeric path component do
-    not fan out again.
+    representations sharing one family. MinKey and MaxKey operands are the two
+    exceptions: their comparisons span every supported BSON type. A
+    non-positional array field exposes both its complete array value and each
+    direct member to the predicate; ``exact`` endpoints such as ``$elemMatch``
+    or a numeric path component do not fan out again.
     """
 
     operand_identity = bson_value_identity_key(operand)
     operand_order = bson_value_sort_key(operand)
     if operand_identity is None or operand_order is None:
         return False
+    crosses_type_brackets = operand_identity[0] in ("minKey", "maxKey")
 
     values = [actual]
     if isinstance(actual, (list, tuple)) and not exact:
@@ -705,11 +707,11 @@ def bson_query_range_matches(actual, operand, comparison, exact=False):
         if (
             value_identity is None
             or value_order is None
-            or value_identity[0] != operand_identity[0]
+            or (not crosses_type_brackets and value_identity[0] != operand_identity[0])
         ):
             continue
         try:
-            if value_identity[0] == "number" and (
+            if value_identity[0] == operand_identity[0] == "number" and (
                 bson_number_decimal(value).is_nan()
                 != bson_number_decimal(operand).is_nan()
             ):


### PR DESCRIPTION
## Summary

- Allow `MinKey` and `MaxKey` range operands to cross BSON type brackets in the shared matcher.
- Apply the corrected behavior consistently to `find()`, aggregation `$match`, and `$pull`, including sync and async APIs.
- Preserve ordinary BSON type bracketing, numeric/NaN behavior, equality semantics, and array/`$elemMatch` behavior.
- Add the full TM-036 contract matrix across local backends plus PostgreSQL and MariaDB integration coverage.
- Document the behavior and record TM-036 through TM-038 in the changelog and roadmap.

## Root cause

The shared range matcher rejected candidates whose outer BSON family differed from the operand before comparing their BSON sort positions. That is correct for normal range operands, but MongoDB treats `MinKey` and `MaxKey` as sentinel exceptions that bound all supported BSON values. The numeric NaN guard also needed to run only when both sides are numeric so numeric candidates can be compared safely with either sentinel.

## User impact

Inclusive `MinKey` to `MaxKey` ranges now return the complete supported value set instead of incomplete or empty results. The same semantics are available through queries, aggregation matching, and update-time `$pull` predicates without weakening normal type-bracket behavior.

## Validation

- Full local suite: **3,518 passed, 507 deselected**
- Branch coverage: **100%**
- Focused TM-036 contract matrix: **30 passed**
- Black, Ruff, and `git diff --check`: clean
- PostgreSQL and MariaDB cases are included for CI; they skip locally when their DSNs are unavailable

Refs #136
