### PR TITLE
Add Beanie ODM compatibility for issue #162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- Beanie 2.1 can initialize through the async client without application
+  shims. TinyMongo now answers the discovery-safe `ping` and `buildInfo`
+  database commands, accepts Beanie's `authorizedCollections` and `nameOnly`
+  collection-listing hints, and runs a pinned real-Beanie CRUD smoke contract.
+
 ### Fixed
+- Update and delete operations now expose PyMongo-shaped reply mappings through
+  `raw_result`, including `n`, `nModified`, `updatedExisting`, `upserted`, and
+  `ok` where applicable. Counts and upsert IDs are derived from that shared
+  reply, allowing Beanie `replace()` calls to complete normally.
 - **TM-036:** `MinKey` and `MaxKey` range operands now cross BSON type
   brackets, so whole-range queries return every supported value through
   `find()`, aggregation `$match`, and `$pull` instead of silently returning an

--- a/README.md
+++ b/README.md
@@ -899,19 +899,21 @@ writes remain serialized.
 Operations whose semantics TinyMongo cannot honor raise
 `TinyMongoNotSupportedError`. This includes sessions, transactions, change
 streams, aggregation features outside the documented core subset, bulk writes,
-database commands, non-default read/write concerns, and unsupported index
-specifications. Connection options that only describe an ignored network target
-remain harmless for drop-in use.
+database commands other than the discovery-safe `ping` and `buildInfo` subset,
+non-default read/write concerns, and unsupported index specifications.
+`list_collection_names()` accepts PyMongo's `authorizedCollections` and
+`nameOnly` server hints for ODM startup. Connection options that only describe
+an ignored network target remain harmless for drop-in use.
 `bypass_document_validation` is accepted as a compatibility no-op and never
 disables `_id` or unique-index enforcement. Where a compatibility method
 accepts a `session` keyword, `session=None` is allowed; non-`None` sessions and
 `start_session()` remain unsupported.
 
-## MongoEngine
+## MongoEngine and Beanie
 
 Basic MongoEngine CRUD is supported by passing TinyMongo as the client class.
-The example keeps a string primary key for maximum portability. Native
-`ObjectId` values also round-trip when `tinymongo[bson]` is installed:
+MongoEngine's native `ObjectId` primary key is supported when `tinymongo[bson]`
+is installed, so most models do not need a custom ID field:
 
 ```python
 import mongoengine as me
@@ -926,9 +928,37 @@ me.connect(
 )
 
 class Person(me.Document):
-    id = me.StringField(primary_key=True, default=tinymongo.generate_id)
     name = me.StringField(required=True)
 ```
+
+Use `id = me.StringField(primary_key=True, default=tinymongo.generate_id)` only
+when the application deliberately wants string IDs.
+
+Beanie 2.1 can initialize against TinyMongo's async client and use its ordinary
+CRUD surface without application-side shims:
+
+```python
+import beanie
+import tinymongo
+
+class PersonDocument(beanie.Document):
+    name: str
+
+client = tinymongo.AsyncMongoClient(
+    tinymongo_folder="./tinydb",
+    backend="sqlite",
+)
+await beanie.init_beanie(
+    database=client.app,
+    document_models=[PersonDocument],
+)
+```
+
+The compatibility layer supplies Beanie's `buildInfo` discovery command,
+collection-listing hints, and PyMongo-shaped update and delete reply documents.
+Single-field indexes continue to work. Compound, sparse, and partial unique
+indexes remain a tracked integrity feature and fail loudly instead of being
+silently weakened.
 
 The tested subset covers document creation, repeated saves, queries, updates,
 deletes, counts, and collection drops. Aggregation beyond the documented core

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -366,6 +366,16 @@ Exit criteria:
 
 - [ ] [#79: Backend benchmarks and compatibility reports](https://github.com/schapman1974/tinymongo/issues/79)
 - [ ] [#55: ODM integration](https://github.com/schapman1974/tinymongo/issues/55)
+  - [x] Run the [#162 Beanie 2.1 compatibility
+    spike](https://github.com/schapman1974/tinymongo/issues/162) through the real
+    async ODM and close its three driver-contract blockers: `buildInfo`,
+    collection-listing hints, and reply-document-shaped `raw_result` values.
+  - [x] Retain MongoEngine's and Beanie's native ObjectId primary-key behavior;
+    document `generate_id()` as an explicit string-ID choice rather than a
+    required workaround.
+  - [ ] Implement integrity-preserving compound, sparse, and partial unique
+    indexes across durable catalogs and supported backends. Keep unsupported
+    combinations fail-closed until their full semantics can be enforced.
 - [ ] [#81: MongoDB document and key validation](https://github.com/schapman1974/tinymongo/issues/81)
 - [ ] [#83: Remaining common BSON types](https://github.com/schapman1974/tinymongo/issues/83)
 - [ ] [#93: Backend concurrency and compatibility stress tests](https://github.com/schapman1974/tinymongo/issues/93)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pyarrow
 portalocker
 pymongo>=4.9
 mongoengine>=0.29,<1
+beanie==2.1.0; python_version >= "3.10" and python_version < "3.14"
 duckdb
 black>=25,<26
 ruff>=0.15,<0.16

--- a/tests/contracts/test_beanie_odm_contract.py
+++ b/tests/contracts/test_beanie_odm_contract.py
@@ -1,0 +1,69 @@
+from collections.abc import Mapping
+
+import pytest
+
+
+pytestmark = pytest.mark.contract
+
+
+def _assert_update_reply(result, *, matched, modified, existing, upserted=None):
+    assert isinstance(result.raw_result, Mapping)
+    assert result.raw_result["n"] == (1 if upserted is not None else matched)
+    assert result.raw_result["nModified"] == modified
+    assert result.raw_result["updatedExisting"] is existing
+    assert result.raw_result["ok"] == 1.0
+    if upserted is None:
+        assert "upserted" not in result.raw_result
+    else:
+        assert result.raw_result["upserted"] == upserted
+    assert result.matched_count == matched
+    assert result.modified_count == modified
+    assert result.upserted_id == upserted
+    assert result.did_upsert is (upserted is not None)
+
+
+def _assert_delete_reply(result, deleted):
+    assert isinstance(result.raw_result, Mapping)
+    assert result.raw_result["n"] == deleted
+    assert result.raw_result["ok"] == 1.0
+    assert result.deleted_count == deleted
+
+
+def test_beanie_write_result_contract(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": 1, "value": 0},
+            {"_id": 2, "value": 0},
+        ]
+    )
+
+    changed = collection.update_one({"_id": 1}, {"$set": {"value": 1}})
+    _assert_update_reply(changed, matched=1, modified=1, existing=True)
+
+    unchanged = collection.replace_one({"_id": 1}, {"value": 1})
+    _assert_update_reply(unchanged, matched=1, modified=0, existing=True)
+
+    missing = collection.update_one({"_id": 99}, {"$set": {"value": 1}})
+    _assert_update_reply(missing, matched=0, modified=0, existing=False)
+
+    collection.update_one({"_id": 1}, {"$set": {"seen": True}})
+    many = collection.update_many({}, {"$set": {"seen": True}})
+    _assert_update_reply(many, matched=2, modified=1, existing=True)
+
+    upserted = collection.replace_one(
+        {"_id": 3},
+        {"_id": 3, "value": 3},
+        upsert=True,
+    )
+    _assert_update_reply(
+        upserted,
+        matched=0,
+        modified=0,
+        existing=False,
+        upserted=3,
+    )
+
+    _assert_delete_reply(collection.delete_one({"_id": 2}), 1)
+    _assert_delete_reply(collection.delete_many({"_id": 99}), 0)
+    _assert_delete_reply(collection.delete_many({"seen": True}), 1)

--- a/tests/contracts/test_beanie_odm_contract.py
+++ b/tests/contracts/test_beanie_odm_contract.py
@@ -41,8 +41,13 @@ def test_beanie_write_result_contract(contract_target):
     changed = collection.update_one({"_id": 1}, {"$set": {"value": 1}})
     _assert_update_reply(changed, matched=1, modified=1, existing=True)
 
-    unchanged = collection.replace_one({"_id": 1}, {"value": 1})
+    unchanged = collection.update_one({"_id": 1}, {"$set": {"value": 1}})
     _assert_update_reply(unchanged, matched=1, modified=0, existing=True)
+
+    # An omitted _id can make an otherwise equal replacement count as modified
+    # on MongoDB, so exercise replacement with an intentional value change.
+    replaced = collection.replace_one({"_id": 1}, {"value": 2})
+    _assert_update_reply(replaced, matched=1, modified=1, existing=True)
 
     missing = collection.update_one({"_id": 99}, {"$set": {"value": 1}})
     _assert_update_reply(missing, matched=0, modified=0, existing=False)

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -218,8 +218,9 @@ def test_database_helpers_and_unsupported_calls():
             assert await database.list_collection_names() == ["events"]
             assert await database.drop_collection(collection) is True
 
+            assert await database.command("ping") == {"ok": 1.0}
             with pytest.raises(TinyMongoNotSupportedError):
-                await database.command("ping")
+                await database.command("serverStatus")
             cursor = await collection.aggregate([])
             assert isinstance(cursor, AsyncTinyMongoCursor)
             assert await cursor.to_list() == []

--- a/tests/test_beanie_compat.py
+++ b/tests/test_beanie_compat.py
@@ -1,0 +1,83 @@
+import asyncio
+
+import pytest
+
+import tinymongo
+from tinymongo import tinymongo as core
+from tinymongo.asyncio import AsyncTinyMongoClient
+from tinymongo.errors import InvalidOperation, TinyMongoNotSupportedError
+
+
+EXPECTED_BUILD_INFO = {
+    "version": "8.0.0",
+    "versionArray": [8, 0, 0, 0],
+    "ok": 1.0,
+    "tinymongo": True,
+}
+
+
+def test_database_supports_discovery_commands_used_by_odms():
+    client = tinymongo.TinyMongoClient(backend="memory")
+    database = client.app
+    database.items.insert_one({"_id": 1})
+
+    assert database.command({"buildInfo": 1}) == EXPECTED_BUILD_INFO
+    assert database.command("buildinfo") == EXPECTED_BUILD_INFO
+    assert database.command("ping") == {"ok": 1.0}
+    assert database.command({"ping": 1}) == {"ok": 1.0}
+    assert database.list_collection_names(
+        authorizedCollections=True,
+        nameOnly=True,
+    ) == ["items"]
+    assert database.list_collection_names(None) == ["items"]
+
+    detached = object.__new__(core.TinyMongoDatabase)
+    detached._client = None
+    assert detached.command("ping") == {"ok": 1.0}
+
+    with pytest.raises(TinyMongoNotSupportedError, match="serverStatus"):
+        database.command("serverStatus")
+    with pytest.raises(TinyMongoNotSupportedError, match="Sessions"):
+        database.command("ping", session=object())
+    with pytest.raises(TypeError, match="must not be empty"):
+        database.command({})
+    with pytest.raises(TypeError, match="string or mapping"):
+        database.command([])
+    with pytest.raises(TypeError, match="name must be a string"):
+        database.command({1: 1})
+    with pytest.raises(TypeError):
+        database.list_collection_names(None, None, None, None)
+    with pytest.raises(TypeError, match="multiple values"):
+        database.list_collection_names(None, session=None)
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        database.list_collection_names(unknown=True)
+    with pytest.raises(TinyMongoNotSupportedError, match="Filtered"):
+        database.list_collection_names(filter={"name": "items"})
+    with pytest.raises(TinyMongoNotSupportedError, match="Sessions"):
+        database.list_collection_names(session=object())
+
+    client.close()
+    with pytest.raises(InvalidOperation):
+        database.command("ping")
+
+
+def test_async_database_supports_discovery_commands_used_by_odms():
+    async def scenario():
+        client = AsyncTinyMongoClient(backend="memory")
+        try:
+            database = client.app
+            await database.items.insert_one({"_id": 1})
+
+            assert await database.command({"buildInfo": 1}) == EXPECTED_BUILD_INFO
+            assert await database.command("ping") == {"ok": 1.0}
+            assert await database.list_collection_names(
+                authorizedCollections=True,
+                nameOnly=True,
+            ) == ["items"]
+
+            with pytest.raises(TinyMongoNotSupportedError, match="serverStatus"):
+                await database.command("serverStatus")
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())

--- a/tests/test_beanie_odm_integration.py
+++ b/tests/test_beanie_odm_integration.py
@@ -1,0 +1,71 @@
+import asyncio
+import datetime
+
+import pytest
+import tinymongo
+
+
+beanie = pytest.importorskip("beanie")
+pydantic = pytest.importorskip("pydantic")
+pymongo = pytest.importorskip("pymongo")
+
+
+class InterviewQuestion(pydantic.BaseModel):
+    text: str
+    asked: bool = False
+
+
+class Interview(beanie.Document):
+    title: str
+    guest_name: str
+    created_date: datetime.datetime
+    questions: list[InterviewQuestion] = pydantic.Field(default_factory=list)
+
+    class Settings:
+        name = "beanie_interviews"
+        indexes = [
+            pymongo.IndexModel(
+                [("guest_name", pymongo.ASCENDING)],
+                name="guest_name_asc",
+            )
+        ]
+
+
+def test_beanie_initializes_and_runs_crud_without_application_shims(tmp_path):
+    async def scenario():
+        client = tinymongo.AsyncMongoClient(
+            tinymongo_folder=str(tmp_path),
+            backend="sqlite",
+        )
+        try:
+            await beanie.init_beanie(
+                database=client.interviewcue,
+                document_models=[Interview],
+            )
+
+            interview = Interview(
+                title="Python's origin",
+                guest_name="Guido",
+                created_date=datetime.datetime(2026, 8, 3, 12, 0),
+                questions=[InterviewQuestion(text="How did Python begin?")],
+            )
+            await interview.insert()
+
+            loaded = await Interview.get(interview.id)
+            assert loaded is not None
+            assert loaded.guest_name == "Guido"
+            assert loaded.questions == [InterviewQuestion(text="How did Python begin?")]
+
+            loaded.title = "The origins of Python"
+            await loaded.replace()
+            replaced = await Interview.get(interview.id)
+            assert replaced is not None
+            assert replaced.title == "The origins of Python"
+
+            assert await Interview.find(Interview.guest_name == "Guido").count() == 1
+            await replaced.delete()
+            assert await Interview.find_all().count() == 0
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())

--- a/tests/test_coverage_edges.py
+++ b/tests/test_coverage_edges.py
@@ -63,6 +63,18 @@ def test_result_properties_and_error_classes():
     assert list_result.matched_count == 1
     assert list_result.modified_count == 1
 
+    mapped_result = UpdateResult(
+        raw_result={"n": 9, "nModified": 8},
+        matched_count=2,
+        modified_count=1,
+        upserted_id="explicit",
+    )
+    assert mapped_result.matched_count == 2
+    assert mapped_result.modified_count == 1
+    assert mapped_result.upserted_id == "explicit"
+    assert mapped_result.did_upsert is False
+    assert DeleteResult(raw_result=[]).deleted_count == 0
+
 
 def test_cli_json_helpers_and_errors(tmp_path, capsys):
     payload_file = tmp_path / "payload.json"

--- a/tests/test_mongoengine_contract.py
+++ b/tests/test_mongoengine_contract.py
@@ -1,4 +1,5 @@
 import mongoengine as me
+from bson import ObjectId
 
 import tinymongo
 
@@ -21,6 +22,11 @@ def test_mongoengine_crud_contract(tmp_path):
 
         meta = {"db_alias": alias}
 
+    class NativePerson(me.Document):
+        name = me.StringField(required=True)
+
+        meta = {"db_alias": alias, "collection": "native_people"}
+
     try:
         Person.drop_collection()
         person = Person(name="Ada").save()
@@ -32,5 +38,9 @@ def test_mongoengine_crud_contract(tmp_path):
         assert Person.objects.get(name="Ada").score == 5
         assert Person.objects(name="Ada").delete() == 1
         assert Person.objects.count() == 0
+
+        native = NativePerson(name="Grace").save()
+        assert isinstance(native.id, ObjectId)
+        assert NativePerson.objects.get(id=native.id).name == "Grace"
     finally:
         me.disconnect(alias=alias)

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -240,7 +240,6 @@ def test_unsupported_features_fail_loudly(tmp_path):
     unsupported_calls = [
         client.start_session,
         client.watch,
-        database.command,
         database.watch,
         collection.bulk_write,
         collection.watch,
@@ -248,6 +247,9 @@ def test_unsupported_features_fail_loudly(tmp_path):
     for call in unsupported_calls:
         with pytest.raises(TinyMongoNotSupportedError):
             call([])
+
+    with pytest.raises(TinyMongoNotSupportedError, match="serverStatus"):
+        database.command("serverStatus")
 
     with pytest.raises(TinyMongoNotSupportedError, match=r"\$lookup"):
         collection.aggregate([{"$lookup": {}}])

--- a/tests/test_tinymongo.py
+++ b/tests/test_tinymongo.py
@@ -433,8 +433,12 @@ def test_update_one_set(collection):
     :return:
     """
     cu = collection["tiny"].update_one({"count": 3}, {"$set": {"countStr": "three"}})
-    # cu.raw_result contains the updated ids
-    assert len(cu.raw_result) == 1  # only one is updated
+    assert cu.raw_result == {
+        "n": 1,
+        "nModified": 1,
+        "ok": 1.0,
+        "updatedExisting": True,
+    }
 
     c = collection["tiny"].find_one({"count": 3})
     assert c["countStr"] == "three"

--- a/tinymongo/results.py
+++ b/tinymongo/results.py
@@ -1,5 +1,7 @@
 """Result class definitions."""
 
+from collections.abc import Mapping
+
 
 class _WriteResult(object):
     """Base class for write result classes."""
@@ -88,6 +90,10 @@ class UpdateResult(_WriteResult):
         """The number of documents matched for this update."""
         if self.__matched_count is not None:
             return self.__matched_count
+        if isinstance(self.raw_result, Mapping):
+            if self.upserted_id is not None:
+                return 0
+            return self.raw_result.get("n", 0)
         if isinstance(self.raw_result, list):
             return len(self.raw_result)
         return 0
@@ -97,6 +103,8 @@ class UpdateResult(_WriteResult):
         """The number of documents modified."""
         if self.__modified_count is not None:
             return self.__modified_count
+        if isinstance(self.raw_result, Mapping):
+            return self.raw_result.get("nModified", 0)
         if isinstance(self.raw_result, list):
             return len(self.raw_result)
         return 0
@@ -106,7 +114,14 @@ class UpdateResult(_WriteResult):
         """The _id of the inserted document if an upsert took place. Otherwise
         ``None``.
         """
+        if self.__upserted_id is None and isinstance(self.raw_result, Mapping):
+            return self.raw_result.get("upserted")
         return self.__upserted_id
+
+    @property
+    def did_upsert(self):
+        """Whether this update inserted a document through ``upsert=True``."""
+        return isinstance(self.raw_result, Mapping) and "upserted" in self.raw_result
 
 
 class DeleteResult(_WriteResult):
@@ -127,6 +142,8 @@ class DeleteResult(_WriteResult):
     @property
     def deleted_count(self):
         """The number of documents deleted."""
+        if isinstance(self.raw_result, Mapping):
+            return self.raw_result.get("n", 0)
         if isinstance(self.raw_result, list):
             return len(self.raw_result)
         else:

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -143,6 +143,27 @@ def _bulk_write_details(n_inserted, write_errors):
     }
 
 
+def _update_result(matched_count=0, modified_count=0, upserted_id=_MISSING):
+    """Build the normalized reply document exposed by PyMongo UpdateResult."""
+
+    upserted = upserted_id is not _MISSING
+    raw_result = {
+        "n": 1 if upserted else matched_count,
+        "nModified": modified_count,
+        "ok": 1.0,
+        "updatedExisting": bool(matched_count) and not upserted,
+    }
+    if upserted:
+        raw_result["upserted"] = upserted_id
+    return UpdateResult(raw_result=raw_result)
+
+
+def _delete_result(deleted_count):
+    """Build the normalized reply document exposed by PyMongo DeleteResult."""
+
+    return DeleteResult(raw_result={"n": deleted_count, "ok": 1.0})
+
+
 def _duplicate_write_error(collection, index, document, spec=None, error=None):
     """Describe one duplicate insert using PyMongo's bulk error shape."""
     field = "_id" if spec is None else spec.field
@@ -1734,9 +1755,35 @@ class TinyMongoDatabase(object):
             name = name.tablename
         return self[name].drop()
 
-    def command(self, *args, **kwargs):
+    def command(self, command, value=1, *args, **kwargs):
+        """Handle the discovery commands used by PyMongo-compatible tooling."""
+
+        if self._client is not None:
+            self._client._ensure_open()
+        _reject_session(kwargs)
+        if isinstance(command, Mapping):
+            if not command:
+                raise TypeError("command document must not be empty")
+            command_name = next(iter(command))
+        elif isinstance(command, str):
+            command_name = command
+        else:
+            raise TypeError("command must be a string or mapping")
+        if not isinstance(command_name, str):
+            raise TypeError("command name must be a string")
+
+        normalized = command_name.lower()
+        if normalized == "ping":
+            return {"ok": 1.0}
+        if normalized == "buildinfo":
+            return {
+                "version": "8.0.0",
+                "versionArray": [8, 0, 0, 0],
+                "ok": 1.0,
+                "tinymongo": True,
+            }
         raise TinyMongoNotSupportedError(
-            "Database commands are not supported by TinyMongo"
+            "Database command '{0}' is not supported by TinyMongo".format(command_name)
         )
 
     def watch(self, *args, **kwargs):
@@ -1756,8 +1803,24 @@ class TinyMongoDatabase(object):
             if name != "_default" and not name.startswith("__tinymongo_")
         ]
 
-    def list_collection_names(self):
-        """Compatibility alias for modern PyMongo."""
+    def list_collection_names(self, session=None, filter=None, comment=None, **kwargs):
+        """Return names while accepting PyMongo's server-side listing hints."""
+
+        _reject_session({"session": session})
+        supported = {
+            "authorizedCollections",
+            "nameOnly",
+        }
+        unknown = sorted(set(kwargs) - supported)
+        if unknown:
+            raise TypeError(
+                "list_collection_names() got an unexpected keyword argument "
+                "'{0}'".format(unknown[0])
+            )
+        if filter not in (None, {}):
+            raise TinyMongoNotSupportedError(
+                "Filtered collection listing is not supported by TinyMongo"
+            )
         return self.collection_names()
 
     def close(self):
@@ -2739,13 +2802,8 @@ class TinyMongoCollection(object):
                         self.parent.engine.find(self.tablename, {}) + [inserted],
                     )
                     self.parent.engine.insert_many(self.tablename, [inserted])
-                    return UpdateResult(
-                        raw_result=[],
-                        matched_count=0,
-                        modified_count=0,
-                        upserted_id=inserted["_id"],
-                    )
-                return UpdateResult(raw_result=[], matched_count=0, modified_count=0)
+                    return _update_result(upserted_id=inserted["_id"])
+                return _update_result()
             updated = self.parent.engine.apply_update(matches[0], doc)
             self._validate_storage_document(updated)
             modified = _update_document_modified(matches[0], updated, doc)
@@ -2761,15 +2819,7 @@ class TinyMongoCollection(object):
                 ],
             )
             self.parent.engine.update_many(self.tablename, query, doc, multi=False)
-            return UpdateResult(
-                raw_result={
-                    "n": 1,
-                    "nModified": int(modified),
-                    "updatedExisting": True,
-                },
-                matched_count=1,
-                modified_count=int(modified),
-            )
+            return _update_result(1, int(modified))
 
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
@@ -2806,13 +2856,8 @@ class TinyMongoCollection(object):
                     self._validate_unique_post_image(self.table.all() + [inserted])
                     self.table.insert(inserted)
                     self._invalidate_indexes()
-                    return UpdateResult(
-                        raw_result=[],
-                        matched_count=0,
-                        modified_count=0,
-                        upserted_id=inserted["_id"],
-                    )
-                return UpdateResult(raw_result=[])
+                    return _update_result(upserted_id=inserted["_id"])
+                return _update_result()
 
             updated = _apply_update_document(item, doc)
             self._validate_storage_document(updated)
@@ -2833,15 +2878,7 @@ class TinyMongoCollection(object):
                 )
                 self._invalidate_indexes()
 
-            return UpdateResult(
-                raw_result={
-                    "n": 1,
-                    "nModified": int(modified),
-                    "updatedExisting": True,
-                },
-                matched_count=1,
-                modified_count=int(modified),
-            )
+            return _update_result(1, int(modified))
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
@@ -2870,12 +2907,7 @@ class TinyMongoCollection(object):
                     self.parent.engine.find(self.tablename, {}) + [inserted],
                 )
                 self.parent.engine.insert_many(self.tablename, [inserted])
-                return UpdateResult(
-                    raw_result=[],
-                    matched_count=0,
-                    modified_count=0,
-                    upserted_id=inserted["_id"],
-                )
+                return _update_result(upserted_id=inserted["_id"])
             updates = [
                 (item, self.parent.engine.apply_update(item, doc)) for item in matches
             ]
@@ -2902,14 +2934,8 @@ class TinyMongoCollection(object):
                     for item in self.parent.engine.find(self.tablename, {})
                 ],
             )
-            result = self.parent.engine.update_many(
-                self.tablename, query, doc, multi=True
-            )
-            return UpdateResult(
-                raw_result=result,
-                matched_count=len(matches),
-                modified_count=modified_count,
-            )
+            self.parent.engine.update_many(self.tablename, query, doc, multi=True)
+            return _update_result(len(matches), modified_count)
 
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
@@ -2938,12 +2964,7 @@ class TinyMongoCollection(object):
                 self._validate_unique_post_image(self.table.all() + [inserted])
                 self.table.insert(inserted)
                 self._invalidate_indexes()
-                return UpdateResult(
-                    raw_result=[],
-                    matched_count=0,
-                    modified_count=0,
-                    upserted_id=inserted["_id"],
-                )
+                return _update_result(upserted_id=inserted["_id"])
             updates = [(item, _apply_update_document(item, doc)) for item in items]
             for _original, updated in updates:
                 self._validate_storage_document(updated)
@@ -2963,25 +2984,18 @@ class TinyMongoCollection(object):
                     for item in self.table.all()
                 ]
             )
-            result = []
             modified_count = 0
             for item, updated in updates:
                 if _update_document_modified(item, updated, doc):
                     modified_count += 1
-                    result.extend(
-                        self.table.update(
-                            _tinydb_replace_document(updated),
-                            _tinydb_id_condition(item["_id"]),
-                        )
+                    self.table.update(
+                        _tinydb_replace_document(updated),
+                        _tinydb_id_condition(item["_id"]),
                     )
             if modified_count:
                 self._invalidate_indexes()
 
-            return UpdateResult(
-                raw_result=result,
-                matched_count=len(items),
-                modified_count=modified_count,
-            )
+            return _update_result(len(items), modified_count)
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
@@ -3008,13 +3022,8 @@ class TinyMongoCollection(object):
                         self.parent.engine.find(self.tablename, {}) + [inserted],
                     )
                     self.parent.engine.insert_many(self.tablename, [inserted])
-                    return UpdateResult(
-                        raw_result=[],
-                        matched_count=0,
-                        modified_count=0,
-                        upserted_id=inserted["_id"],
-                    )
-                return UpdateResult(raw_result=[])
+                    return _update_result(upserted_id=inserted["_id"])
+                return _update_result()
             # MongoDB stores ``_id`` first even when the replacement omitted it.
             # Keep that canonical order so a later equivalent replacement is
             # not misreported as a field-order-only modification.
@@ -3036,11 +3045,7 @@ class TinyMongoCollection(object):
                     ],
                 )
                 self.parent.engine.replace_one(self.tablename, item["_id"], updated)
-            return UpdateResult(
-                raw_result=[item["_id"]] if modified else [],
-                matched_count=1,
-                modified_count=int(modified),
-            )
+            return _update_result(1, int(modified))
 
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
@@ -3078,13 +3083,8 @@ class TinyMongoCollection(object):
                     self._validate_unique_post_image(self.table.all() + [inserted])
                     self.table.insert(inserted)
                     self._invalidate_indexes()
-                    return UpdateResult(
-                        raw_result=[],
-                        matched_count=0,
-                        modified_count=0,
-                        upserted_id=inserted["_id"],
-                    )
-                return UpdateResult(raw_result=[])
+                    return _update_result(upserted_id=inserted["_id"])
+                return _update_result()
 
             updated = {"_id": item["_id"]}
             updated.update(copy.deepcopy(replacement))
@@ -3104,13 +3104,7 @@ class TinyMongoCollection(object):
                 self.table.remove(_tinydb_id_condition(item["_id"]))
                 self.table.insert(updated)
                 self._invalidate_indexes()
-                result = [item["_id"]]
-            else:
-                result = []
-
-            return UpdateResult(
-                raw_result=result, matched_count=1, modified_count=int(modified)
-            )
+            return _update_result(1, int(modified))
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
@@ -3449,13 +3443,13 @@ class TinyMongoCollection(object):
         validate_filter_operators(query)
         if self.parent.engine is not None:
             result = self.parent.engine.delete_many(self.tablename, query, multi=False)
-            return DeleteResult(raw_result=result)
+            return _delete_result(len(result))
 
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
             item = self.find_one(query)
             if item is None:
-                return DeleteResult(raw_result=[])
+                return _delete_result(0)
             self._set_storage_merge_writes(False)
             try:
                 result = self.table.remove(_tinydb_id_condition(item["_id"]))
@@ -3463,7 +3457,7 @@ class TinyMongoCollection(object):
             finally:
                 self._set_storage_merge_writes(True)
 
-            return DeleteResult(raw_result=result)
+            return _delete_result(len(result))
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 
@@ -3479,17 +3473,15 @@ class TinyMongoCollection(object):
         validate_filter_operators(query)
         if self.parent.engine is not None:
             result = self.parent.engine.delete_many(self.tablename, query, multi=True)
-            return DeleteResult(raw_result=result)
+            return _delete_result(len(result))
 
         rlock, portalocker_lock = self._acquire_collection_lock()
         try:
-            items = self.find(query)
+            items = list(self.find(query))
             self._set_storage_merge_writes(False)
             try:
-                result = [
+                for item in items:
                     self.table.remove(_tinydb_id_condition(item["_id"]))
-                    for item in items
-                ]
                 self._invalidate_indexes()
 
                 if query == {}:
@@ -3498,7 +3490,7 @@ class TinyMongoCollection(object):
             finally:
                 self._set_storage_merge_writes(True)
 
-            return DeleteResult(raw_result=result)
+            return _delete_result(len(items))
         finally:
             self._release_collection_lock(rlock, portalocker_lock)
 


### PR DESCRIPTION
## Summary

- Support the discovery-safe `ping` and `buildInfo` database commands used during Beanie initialization.
- Accept Beanie's `authorizedCollections` and `nameOnly` collection-listing hints.
- Normalize update and delete `raw_result` values to PyMongo-shaped reply mappings across every backend.
- Add sync, async, cross-backend, MongoEngine ObjectId, and real Beanie 2.1 integration coverage.
- Update the README, changelog, development requirements, and roadmap.

## Why

Beanie 2.1 stopped during initialization because TinyMongo rejected `buildInfo` and then rejected the collection-listing hints it uses for discovery. Once those calls were supported, document replacement still failed because TinyMongo exposed updated ID lists instead of the reply-document shape expected by PyMongo-compatible ODMs.

The underlying write operations already had the correct counts. This change normalizes the compatibility boundary so ODMs receive `n`, `nModified`, `updatedExisting`, `upserted`, and `ok` where appropriate.

## Impact

Beanie 2.1 can now initialize and perform ordinary async CRUD, including `replace()`, against TinyMongo without application-side shims. MongoEngine's native ObjectId behavior is also covered and documented; `generate_id()` remains an optional choice for applications that deliberately want string IDs.

Compound, sparse, and partial unique indexes remain a separate integrity feature. Unsupported combinations continue to fail loudly rather than silently weakening constraints.

## Validation

- 3,530 passed, 1 skipped, 509 deselected
- 100% branch coverage: 7,708 statements and 3,246 branches with no misses
- Real Beanie 2.1 smoke test on Python 3.13: 3 passed
- Black, Ruff, mypy, and `git diff --check` clean

Refs #162
Refs #55
