### PR TITLE
Accelerate SQLite bulk writes and indexed reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
   shims. TinyMongo now answers the discovery-safe `ping` and `buildInfo`
   database commands, accepts Beanie's `authorizedCollections` and `nameOnly`
   collection-listing hints, and runs a pinned real-Beanie CRUD smoke contract.
+- A reproducible comparison benchmark now runs the same JSON-document workload
+  against TinyMongo SQLite, raw `sqlite3`, and an optional real MongoDB server.
+
+### Changed
+- SQLite bulk inserts now use BSON-aware identity sets and one-pass unique-index
+  token maps instead of quadratic duplicate planning and repeated backend
+  preflights.
+- SQLite multi-document updates now select, validate, and write their complete
+  batch in one transaction with one `executemany()` call and commit.
+- Exact SQLite `_id` queries now use the primary-key path directly, while
+  declared scalar indexes use bounded reads plus a companion candidate index
+  for array and object values. One-time migration, WAL, and collection setup is
+  cached without losing recovery from external collection drops.
 
 ### Fixed
 - Update and delete operations now expose PyMongo-shaped reply mappings through

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -4,7 +4,65 @@ These numbers are local benchmark results from the TinyMongo storage load
 benchmark. They are useful for comparing relative behavior on this machine, not
 for making universal performance claims.
 
-## Methodology
+## SQLite performance work: 2026-08-04
+
+The focused comparison uses the same 10,000 JSON-shaped documents and performs:
+
+- One `insert_many()` batch.
+- 200 warmed, deterministic `_id` point lookups.
+- 200 warmed equality queries through an index on `group`. Each query returns
+  1,000 documents, for 200,000 decoded result rows in total.
+- One indexed update affecting 1,000 documents.
+
+TinyMongo and raw SQLite both store `_id` plus a JSON document payload. Raw
+SQLite is a lower-bound comparison: it does not provide TinyMongo's BSON,
+MongoDB query, validation, or update semantics, and its update is native SQL.
+MongoDB 8.0 ran locally through PyMongo 4.17.0 in a disposable Docker container
+with a persistent Docker volume. Its collection explicitly used
+`WriteConcern(w=1, j=True)`, and the benchmark verifies that both measured
+writes were acknowledged. The two SQLite connections reported WAL mode with
+`synchronous=NORMAL`.
+
+Command:
+
+```bash
+TINYMONGO_MONGODB_URI='mongodb://127.0.0.1:27017/?directConnection=true' \
+  .venv/bin/python tests/benchmarks/bench_sqlite_comparison.py \
+    --docs 10000 \
+    --queries 200 \
+    --json-output /tmp/tinymongo-sqlite-comparison.json
+```
+
+| Engine | Insert docs/s | Point avg ms | Point p95 ms | Indexed queries/s | Indexed rows/s | Update docs/s | Update s |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| tinymongo-sqlite | 18,985 | 0.414 | 0.470 | 116.7 | 116,688 | 5,054 | 0.198 |
+| raw-sqlite | 302,158 | 0.006 | 0.007 | 596.6 | 596,596 | 84,231 | 0.012 |
+| mongodb | 127,198 | 1.541 | 4.172 | 176.0 | 176,008 | 110,101 | 0.009 |
+
+The MongoDB durability setting is stricter than SQLite's `NORMAL` setting, so
+MongoDB is not receiving an unacknowledged-write advantage in this run. MongoDB
+uses Docker's storage stack while SQLite uses the host filesystem, which means
+the absolute write-throughput comparison remains directional rather than a
+claim that the storage media are identical.
+
+The same 1,000-document storage benchmark was captured immediately before and
+after the SQLite work on this machine:
+
+| SQLite measurement | Insert docs/s | Point avg ms | Update 100 docs s |
+| --- | ---: | ---: | ---: |
+| Before | 566 | 1.821 | 2.984 |
+| After | 15,046 | 0.431 | 0.023 |
+
+That run measured approximately 27x higher batch-insert throughput, 4.2x lower
+point-lookup latency, and 130x faster multi-document updates. The gains come
+from linear duplicate planning, one validated update transaction, direct
+primary-key reads, cached one-time SQLite setup, bounded indexed reads, and
+selective array candidates. Absolute values will vary with hardware, document
+size, result selectivity, durability settings, and process layout.
+
+## Cross-backend snapshot: 2026-07-09
+
+### Methodology
 
 Command:
 
@@ -36,7 +94,7 @@ SQLite, DuckDB, and Parquet now use table-native storage: one collection table
 or Parquet file per TinyMongo collection. Supported filters are compiled into SQL
 over `_id` and JSON document payloads.
 
-## Results
+### Results
 
 | Backend | Insert docs/s | Read docs/s | Avg point lookup ms | p95 point lookup ms | Update s | Delete s | Size KiB |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -45,7 +103,7 @@ over `_id` and JSON document payloads.
 | sqlite | 44,104 | 283,618 | 1.165 | 1.428 | 0.458 | 0.007 | 136.0 |
 | duckdb | 2,490 | 41,844 | 22.593 | 24.983 | 2.529 | 0.086 | 1,036.0 |
 
-## Notes
+### Notes
 
 - TinyDB JSON remains very fast for this small local workload.
 - SQLite has the fastest point lookups in this run because `_id` maps directly

--- a/tests/benchmarks/bench_sqlite_comparison.py
+++ b/tests/benchmarks/bench_sqlite_comparison.py
@@ -1,0 +1,510 @@
+"""Compare TinyMongo SQLite with raw SQLite and a real MongoDB server.
+
+This is a local benchmark, not a pytest test.  It intentionally uses the same
+JSON document shape for TinyMongo and raw SQLite so the raw result is a useful
+lower bound for TinyMongo's compatibility-layer overhead rather than a test of
+a different relational schema.  Raw SQLite uses native SQL for its update, so
+it does not provide MongoDB's full update semantics.  MongoDB runs in a uniquely
+named temporary database that is dropped at the end of the run.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import os
+import random
+import sqlite3
+import statistics
+import tempfile
+import time
+import uuid
+
+import tinymongo as tm
+
+
+ENGINES = ("tinymongo-sqlite", "raw-sqlite", "mongodb")
+_SQLITE_SYNCHRONOUS_NAMES = {0: "OFF", 1: "NORMAL", 2: "FULL", 3: "EXTRA"}
+
+
+def _docs(count):
+    return [
+        {
+            "_id": "doc-{0}".format(index),
+            "i": index,
+            "group": "g{0}".format(index % 10),
+            "payload": "value-{0}".format(index),
+        }
+        for index in range(count)
+    ]
+
+
+def _time_call(operation):
+    started = time.perf_counter()
+    result = operation()
+    return time.perf_counter() - started, result
+
+
+def _percentile(values, percentile):
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    index = int(round((percentile / 100.0) * (len(ordered) - 1)))
+    return ordered[index]
+
+
+def _group_count(documents, group_number):
+    """Return how many generated documents belong to one benchmark group."""
+
+    if documents <= group_number:
+        return 0
+    return ((documents - 1 - group_number) // 10) + 1
+
+
+def _expected_indexed_rows(documents, queries):
+    return sum(_group_count(documents, index % 10) for index in range(queries))
+
+
+def _point_targets(documents, queries):
+    """Return the same deterministic, non-sequential lookup set for each engine."""
+
+    generator = random.Random(1974)
+    return ["doc-{0}".format(generator.randrange(documents)) for _ in range(queries)]
+
+
+def _result(
+    engine,
+    documents,
+    queries,
+    insert_seconds,
+    point_latencies,
+    indexed_seconds,
+    indexed_rows,
+    update_seconds,
+    updated_docs,
+):
+    return {
+        "engine": engine,
+        "available": True,
+        "documents": documents,
+        "queries": queries,
+        "insert_seconds": insert_seconds,
+        "insert_docs_per_second": (
+            documents / insert_seconds if insert_seconds else 0.0
+        ),
+        "point_avg_ms": statistics.mean(point_latencies) * 1000,
+        "point_p95_ms": _percentile(point_latencies, 95) * 1000,
+        "indexed_seconds": indexed_seconds,
+        "indexed_queries_per_second": (
+            queries / indexed_seconds if indexed_seconds else 0.0
+        ),
+        "indexed_rows_per_second": (
+            indexed_rows / indexed_seconds if indexed_seconds else 0.0
+        ),
+        "indexed_rows": indexed_rows,
+        "update_seconds": update_seconds,
+        "update_docs_per_second": (
+            updated_docs / update_seconds if update_seconds else 0.0
+        ),
+        "updated_docs": updated_docs,
+    }
+
+
+def _sqlite_settings(conn):
+    """Capture the durability settings used by one SQLite benchmark run."""
+
+    journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    synchronous = conn.execute("PRAGMA synchronous").fetchone()[0]
+    return {
+        "journal_mode": str(journal_mode).upper(),
+        "synchronous": _SQLITE_SYNCHRONOUS_NAMES.get(synchronous, str(synchronous)),
+    }
+
+
+def _run_tinymongo_sqlite(documents, queries, work_root):
+    # Never remove a fixed path supplied by the caller. A unique child also
+    # makes concurrent benchmark runs safe.
+    db_dir = tempfile.mkdtemp(prefix="tinymongo-sqlite-", dir=work_root)
+    client = tm.TinyMongoClient(db_dir, backend="sqlite")
+    try:
+        return _run_tinymongo_sqlite_client(client, documents, queries)
+    finally:
+        client.close()
+
+
+def _run_tinymongo_sqlite_client(client, documents, queries):
+    collection = client.comparison.records
+    settings_conn = collection.parent.engine._connect()
+    try:
+        sqlite_settings = _sqlite_settings(settings_conn)
+    finally:
+        settings_conn.close()
+    docs = _docs(documents)
+
+    insert_seconds, result = _time_call(lambda: collection.insert_many(docs))
+    if len(result.inserted_ids) != documents:
+        raise AssertionError("TinyMongo inserted the wrong number of documents")
+    collection.create_index("group")
+
+    # Warm SQLite's page cache before measuring lookup latency.
+    targets = _point_targets(documents, queries)
+    if collection.find_one({"_id": targets[0]}) is None:
+        raise AssertionError("TinyMongo point lookup warm-up missed a document")
+    point_latencies = []
+    for target in targets:
+        elapsed, found = _time_call(
+            lambda target=target: collection.find_one({"_id": target})
+        )
+        if found is None or found["_id"] != target:
+            raise AssertionError("TinyMongo point lookup missed {0}".format(target))
+        point_latencies.append(elapsed)
+
+    def indexed_queries():
+        rows = 0
+        for index in range(queries):
+            group = "g{0}".format(index % 10)
+            rows += len(list(collection.find({"group": group})))
+        return rows
+
+    if len(list(collection.find({"group": "g0"}))) != _group_count(documents, 0):
+        raise AssertionError("TinyMongo indexed lookup warm-up returned wrong rows")
+    indexed_seconds, indexed_rows = _time_call(indexed_queries)
+    expected_rows = _expected_indexed_rows(documents, queries)
+    if indexed_rows != expected_rows:
+        raise AssertionError(
+            "TinyMongo indexed queries returned {0} rows, expected {1}".format(
+                indexed_rows, expected_rows
+            )
+        )
+
+    update_seconds, update_result = _time_call(
+        lambda: collection.update_many({"group": "g1"}, {"$inc": {"i": 1}})
+    )
+    expected_updates = _group_count(documents, 1)
+    if update_result.modified_count != expected_updates:
+        raise AssertionError(
+            "TinyMongo updated {0} rows, expected {1}".format(
+                update_result.modified_count, expected_updates
+            )
+        )
+    if documents > 1:
+        updated = collection.find_one({"_id": "doc-1"})
+        if updated is None or updated["i"] != 2:
+            raise AssertionError("TinyMongo update produced the wrong value")
+    benchmark_result = _result(
+        "tinymongo-sqlite",
+        documents,
+        queries,
+        insert_seconds,
+        point_latencies,
+        indexed_seconds,
+        indexed_rows,
+        update_seconds,
+        update_result.modified_count,
+    )
+    benchmark_result["sqlite_settings"] = sqlite_settings
+    return benchmark_result
+
+
+def _run_raw_sqlite(documents, queries, work_root):
+    descriptor, path = tempfile.mkstemp(
+        prefix="raw-sqlite-", suffix=".sqlite", dir=work_root
+    )
+    os.close(descriptor)
+    conn = sqlite3.connect(path, timeout=30)
+    try:
+        return _run_raw_sqlite_connection(conn, documents, queries)
+    finally:
+        conn.close()
+
+
+def _run_raw_sqlite_connection(conn, documents, queries):
+    conn.execute("PRAGMA journal_mode=WAL")
+    sqlite_settings = _sqlite_settings(conn)
+    conn.execute("CREATE TABLE records (_id TEXT PRIMARY KEY, data TEXT NOT NULL)")
+    docs = _docs(documents)
+
+    def insert_all():
+        rows = [
+            (
+                document["_id"],
+                json.dumps(document, ensure_ascii=False, separators=(",", ":")),
+            )
+            for document in docs
+        ]
+        conn.executemany("INSERT INTO records (_id, data) VALUES (?, ?)", rows)
+        conn.commit()
+
+    insert_seconds, _ = _time_call(insert_all)
+    conn.execute(
+        "CREATE INDEX records_group ON records (json_extract(data, '$.group'))"
+    )
+    conn.commit()
+
+    targets = _point_targets(documents, queries)
+    if (
+        conn.execute("SELECT data FROM records WHERE _id = ?", (targets[0],)).fetchone()
+        is None
+    ):
+        raise AssertionError("raw SQLite point lookup warm-up missed a document")
+    point_latencies = []
+    for target in targets:
+
+        def point_lookup(target=target):
+            row = conn.execute(
+                "SELECT data FROM records WHERE _id = ?", (target,)
+            ).fetchone()
+            return None if row is None else json.loads(row[0])
+
+        elapsed, found = _time_call(point_lookup)
+        if found is None or found["_id"] != target:
+            raise AssertionError("raw SQLite point lookup missed {0}".format(target))
+        point_latencies.append(elapsed)
+
+    def indexed_queries():
+        rows_found = 0
+        for index in range(queries):
+            group = "g{0}".format(index % 10)
+            rows = conn.execute(
+                "SELECT data FROM records WHERE json_extract(data, '$.group') = ?",
+                (group,),
+            ).fetchall()
+            rows_found += len([json.loads(row[0]) for row in rows])
+        return rows_found
+
+    query_plan = conn.execute(
+        "EXPLAIN QUERY PLAN SELECT data FROM records "
+        "WHERE json_extract(data, '$.group') = ?",
+        ("g0",),
+    ).fetchall()
+    if not any("records_group" in str(row[-1]) for row in query_plan):
+        raise AssertionError("raw SQLite did not use the requested group index")
+    warm_rows = conn.execute(
+        "SELECT data FROM records WHERE json_extract(data, '$.group') = ?",
+        ("g0",),
+    ).fetchall()
+    if len(warm_rows) != _group_count(documents, 0):
+        raise AssertionError("raw SQLite indexed lookup warm-up returned wrong rows")
+    for row in warm_rows:
+        json.loads(row[0])
+    indexed_seconds, indexed_rows = _time_call(indexed_queries)
+    expected_rows = _expected_indexed_rows(documents, queries)
+    if indexed_rows != expected_rows:
+        raise AssertionError(
+            "raw SQLite indexed queries returned {0} rows, expected {1}".format(
+                indexed_rows, expected_rows
+            )
+        )
+
+    def update_group():
+        cursor = conn.execute(
+            "UPDATE records SET data = json_set("
+            "data, '$.i', json_extract(data, '$.i') + 1) "
+            "WHERE json_extract(data, '$.group') = ?",
+            ("g1",),
+        )
+        conn.commit()
+        return cursor.rowcount
+
+    update_seconds, updated_docs = _time_call(update_group)
+    expected_updates = _group_count(documents, 1)
+    if updated_docs != expected_updates:
+        raise AssertionError(
+            "raw SQLite updated {0} rows, expected {1}".format(
+                updated_docs, expected_updates
+            )
+        )
+    if documents > 1:
+        updated = conn.execute(
+            "SELECT data FROM records WHERE _id = ?", ("doc-1",)
+        ).fetchone()
+        if updated is None or json.loads(updated[0])["i"] != 2:
+            raise AssertionError("raw SQLite update produced the wrong value")
+    benchmark_result = _result(
+        "raw-sqlite",
+        documents,
+        queries,
+        insert_seconds,
+        point_latencies,
+        indexed_seconds,
+        indexed_rows,
+        update_seconds,
+        updated_docs,
+    )
+    benchmark_result["sqlite_settings"] = sqlite_settings
+    return benchmark_result
+
+
+def _run_mongodb(documents, queries, mongo_uri):
+    if not mongo_uri:
+        return {
+            "engine": "mongodb",
+            "available": False,
+            "reason": "set TINYMONGO_MONGODB_URI or pass --mongo-uri",
+        }
+    try:
+        import pymongo
+        from pymongo.write_concern import WriteConcern
+    except ImportError:
+        return {
+            "engine": "mongodb",
+            "available": False,
+            "reason": "install the pymongo benchmark dependency",
+        }
+
+    client = pymongo.MongoClient(mongo_uri, serverSelectionTimeoutMS=3000)
+    try:
+        client.admin.command("ping")
+    except Exception as exc:
+        client.close()
+        return {
+            "engine": "mongodb",
+            "available": False,
+            "reason": "MongoDB is unavailable: {0}".format(exc),
+        }
+
+    database_name = "tinymongo_perf_{0}_{1}".format(os.getpid(), uuid.uuid4().hex[:10])
+    write_concern = WriteConcern(w=1, j=True)
+    database = client.get_database(database_name, write_concern=write_concern)
+    collection = database.records
+    docs = _docs(documents)
+    try:
+        insert_seconds, result = _time_call(lambda: collection.insert_many(docs))
+        if not result.acknowledged:
+            raise AssertionError("MongoDB did not acknowledge the insert batch")
+        if len(result.inserted_ids) != documents:
+            raise AssertionError("MongoDB inserted the wrong number of documents")
+        collection.create_index("group")
+
+        targets = _point_targets(documents, queries)
+        if collection.find_one({"_id": targets[0]}) is None:
+            raise AssertionError("MongoDB point lookup warm-up missed a document")
+        point_latencies = []
+        for target in targets:
+            elapsed, found = _time_call(
+                lambda target=target: collection.find_one({"_id": target})
+            )
+            if found is None or found["_id"] != target:
+                raise AssertionError("MongoDB point lookup missed {0}".format(target))
+            point_latencies.append(elapsed)
+
+        def indexed_queries():
+            rows = 0
+            for index in range(queries):
+                group = "g{0}".format(index % 10)
+                rows += len(list(collection.find({"group": group})))
+            return rows
+
+        if len(list(collection.find({"group": "g0"}))) != _group_count(documents, 0):
+            raise AssertionError("MongoDB indexed lookup warm-up returned wrong rows")
+        indexed_seconds, indexed_rows = _time_call(indexed_queries)
+        expected_rows = _expected_indexed_rows(documents, queries)
+        if indexed_rows != expected_rows:
+            raise AssertionError(
+                "MongoDB indexed queries returned {0} rows, expected {1}".format(
+                    indexed_rows, expected_rows
+                )
+            )
+
+        update_seconds, update_result = _time_call(
+            lambda: collection.update_many({"group": "g1"}, {"$inc": {"i": 1}})
+        )
+        if not update_result.acknowledged:
+            raise AssertionError("MongoDB did not acknowledge the update batch")
+        expected_updates = _group_count(documents, 1)
+        if update_result.modified_count != expected_updates:
+            raise AssertionError(
+                "MongoDB updated {0} rows, expected {1}".format(
+                    update_result.modified_count, expected_updates
+                )
+            )
+        if documents > 1:
+            updated = collection.find_one({"_id": "doc-1"})
+            if updated is None or updated["i"] != 2:
+                raise AssertionError("MongoDB update produced the wrong value")
+        benchmark_result = _result(
+            "mongodb",
+            documents,
+            queries,
+            insert_seconds,
+            point_latencies,
+            indexed_seconds,
+            indexed_rows,
+            update_seconds,
+            update_result.modified_count,
+        )
+        benchmark_result["write_concern"] = write_concern.document
+        return benchmark_result
+    finally:
+        try:
+            client.drop_database(database_name)
+        finally:
+            client.close()
+
+
+def format_markdown(results):
+    rows = [
+        "| Engine | Insert docs/s | Point avg ms | Point p95 ms | "
+        "Indexed queries/s | Indexed rows/s | Update docs/s | Update s |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        if not result.get("available"):
+            rows.append(
+                "| {0} | unavailable | unavailable | unavailable | "
+                "unavailable | unavailable | unavailable | unavailable |".format(
+                    result["engine"]
+                )
+            )
+            continue
+        rows.append(
+            "| {engine} | {insert_docs_per_second:,.0f} | {point_avg_ms:.3f} | "
+            "{point_p95_ms:.3f} | {indexed_queries_per_second:,.1f} | "
+            "{indexed_rows_per_second:,.0f} | {update_docs_per_second:,.0f} | "
+            "{update_seconds:.3f} |".format(**result)
+        )
+    return "\n".join(rows)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--docs", type=int, default=10000)
+    parser.add_argument("--queries", type=int, default=200)
+    parser.add_argument("--engine", action="append", choices=ENGINES)
+    parser.add_argument("--work-root")
+    parser.add_argument("--mongo-uri", default=os.getenv("TINYMONGO_MONGODB_URI"))
+    parser.add_argument("--json-output")
+    args = parser.parse_args(argv)
+    if args.docs <= 0 or args.queries <= 0:
+        parser.error("--docs and --queries must both be positive")
+
+    work_root = args.work_root or tempfile.mkdtemp(prefix="tinymongo-compare-")
+    os.makedirs(work_root, exist_ok=True)
+    requested = args.engine or list(ENGINES)
+    runners = {
+        "tinymongo-sqlite": lambda: _run_tinymongo_sqlite(
+            args.docs, args.queries, work_root
+        ),
+        "raw-sqlite": lambda: _run_raw_sqlite(args.docs, args.queries, work_root),
+        "mongodb": lambda: _run_mongodb(args.docs, args.queries, args.mongo_uri),
+    }
+    results = [runners[engine]() for engine in requested]
+    payload = {
+        "documents": args.docs,
+        "queries": args.queries,
+        "work_root": work_root,
+        "results": results,
+    }
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    print(format_markdown(results))
+    for result in results:
+        if not result.get("available"):
+            print("{0}: {1}".format(result["engine"], result["reason"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bulk_insert_planning.py
+++ b/tests/test_bulk_insert_planning.py
@@ -1,0 +1,192 @@
+"""Focused tests for the linear-time shared insert-many planner."""
+
+import importlib
+from types import SimpleNamespace
+
+import tinymongo as tm
+from tinymongo.indexes import IndexSpec
+
+
+core = importlib.import_module("tinymongo.tinymongo")
+
+
+def _collection():
+    return SimpleNamespace(full_name="app.items")
+
+
+def test_bulk_insert_planning_scales_with_documents_and_unique_indexes(
+    monkeypatch,
+):
+    existing = [
+        {"_id": index, "email": "existing-{0}@example.com".format(index)}
+        for index in range(100)
+    ]
+    documents = [
+        {"_id": index, "email": "new-{0}@example.com".format(index)}
+        for index in range(100, 2100)
+    ]
+    token_calls = 0
+    original_index_tokens = core.index_tokens
+
+    def counting_index_tokens(document, field):
+        nonlocal token_calls
+        token_calls += 1
+        return original_index_tokens(document, field)
+
+    def unexpected_pairwise_comparison(_left, _right):
+        raise AssertionError("supported BSON IDs should use typed identity keys")
+
+    monkeypatch.setattr(core, "index_tokens", counting_index_tokens)
+    monkeypatch.setattr(core, "bson_values_equal", unexpected_pairwise_comparison)
+
+    accepted, errors = core._plan_insert_many(
+        _collection(),
+        documents,
+        existing,
+        [IndexSpec("ignored"), IndexSpec("email", unique=True)],
+        ordered=False,
+    )
+
+    assert accepted == documents
+    assert errors == []
+    assert token_calls == len(existing) + len(documents)
+
+
+def test_bulk_insert_planning_preserves_bson_identity_and_unique_error_order():
+    existing = [{"_id": {"number": 1}, "email": "taken@example.com"}]
+    documents = [
+        {"_id": {"number": 1.0}, "email": "different@example.com"},
+        {"_id": "first", "email": "first@example.com"},
+        {"_id": "unique-conflict", "email": "taken@example.com"},
+        {"_id": "batch-conflict", "email": "first@example.com"},
+        {"_id": "last", "email": "last@example.com"},
+    ]
+
+    accepted, errors = core._plan_insert_many(
+        _collection(),
+        documents,
+        existing,
+        [IndexSpec("email", unique=True)],
+        ordered=False,
+    )
+
+    assert [document["_id"] for document in accepted] == ["first", "last"]
+    assert [error["index"] for error in errors] == [0, 2, 3]
+    assert errors[0]["keyPattern"] == {"_id": 1}
+    assert errors[1]["keyPattern"] == {"email": 1}
+    assert errors[2]["keyValue"] == {"email": "first@example.com"}
+
+
+def test_bulk_insert_planning_retains_fallback_and_legacy_conflict_behavior():
+    unsupported_id = object()
+    accepted, errors = core._plan_insert_many(
+        _collection(),
+        [{"_id": unsupported_id}, {"_id": unsupported_id}],
+        [],
+        [],
+        ordered=False,
+    )
+
+    assert accepted == [{"_id": unsupported_id}]
+    assert errors[0]["index"] == 1
+
+    # A typed candidate still checks the rare untyped fallback bucket.  This
+    # is unreachable through public storage validation, but keeps the internal
+    # planner's compatibility fallback exact.
+    class TypedAlias:
+        def __eq__(self, other):
+            return other == "typed"
+
+    accepted, errors = core._plan_insert_many(
+        _collection(),
+        [{"_id": "other"}, {"_id": "typed"}],
+        [{"_id": TypedAlias()}],
+        [],
+        ordered=False,
+    )
+    assert accepted == [{"_id": "other"}]
+    assert errors[0]["index"] == 1
+
+    existing = [
+        {"_id": "one", "email": "duplicate@example.com"},
+        {"_id": "two", "email": "duplicate@example.com"},
+    ]
+    accepted, errors = core._plan_insert_many(
+        _collection(),
+        [{"_id": "three", "email": "otherwise-new@example.com"}],
+        existing,
+        [IndexSpec("email", unique=True)],
+        ordered=True,
+    )
+
+    assert accepted == []
+    assert errors[0]["keyPattern"] == {"email": 1}
+    assert "documents 'one' and 'two'" in errors[0]["errmsg"]
+
+
+def test_engine_insert_many_uses_prevalidated_backend_hook():
+    class Engine:
+        def __init__(self):
+            self.received = None
+
+        def find(self, _collection, _filter):
+            return []
+
+        def get_index_specs(self, _collection):
+            return []
+
+        def insert_many(self, *_args, **_kwargs):
+            raise AssertionError("the duplicate backend preflight was used")
+
+        def insert_many_prevalidated(self, collection, documents, **kwargs):
+            self.received = (collection, documents, kwargs)
+            return list(range(len(documents)))
+
+    engine = Engine()
+    collection = SimpleNamespace(
+        full_name="app.items",
+        tablename="items",
+        parent=SimpleNamespace(engine=engine),
+    )
+    documents = [{"_id": 1}, {"_id": 2}]
+
+    results, accepted, errors = core._execute_engine_insert_many(
+        collection,
+        documents,
+        ordered=True,
+        bypass_document_validation=True,
+    )
+
+    assert results == [0, 1]
+    assert accepted == documents
+    assert errors == []
+    assert engine.received == (
+        "items",
+        documents,
+        {"bypass_document_validation": True},
+    )
+
+
+def test_sqlite_public_bulk_insert_scans_existing_documents_once(
+    tmp_path,
+    monkeypatch,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.items
+    backend = collection.parent.engine
+    original_find = backend.find
+    calls = []
+
+    def tracked_find(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_find(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "find", tracked_find)
+    try:
+        result = collection.insert_many(
+            [{"_id": index, "value": index} for index in range(100)]
+        )
+        assert len(result.inserted_ids) == 100
+        assert len(calls) == 1
+    finally:
+        client.close()

--- a/tests/test_sqlite_bulk_updates.py
+++ b/tests/test_sqlite_bulk_updates.py
@@ -1,0 +1,270 @@
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import tinymongo as tm
+
+from tinymongo.errors import DuplicateKeyError, WriteError
+from tinymongo.indexes import parse_index_spec
+from tinymongo.table_backends import SQLiteTableBackend
+
+
+class _TrackedConnection:
+    def __init__(self, connection):
+        self.connection = connection
+        self.execute_calls = []
+        self.executemany_calls = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.closes = 0
+
+    def execute(self, sql, params=()):
+        self.execute_calls.append((sql, params))
+        return self.connection.execute(sql, params)
+
+    def executemany(self, sql, params):
+        rows = list(params)
+        self.executemany_calls.append((sql, rows))
+        return self.connection.executemany(sql, rows)
+
+    def commit(self):
+        self.commits += 1
+        return self.connection.commit()
+
+    def rollback(self):
+        self.rollbacks += 1
+        return self.connection.rollback()
+
+    def close(self):
+        self.closes += 1
+        return self.connection.close()
+
+
+def test_sqlite_bulk_update_uses_one_transaction_and_executemany(tmp_path, monkeypatch):
+    backend = SQLiteTableBackend(str(tmp_path / "bulk.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1, "group": "selected", "count": 1},
+            {"_id": 2, "group": "selected", "count": 2},
+            {"_id": 3, "group": "other", "count": 3},
+        ],
+    )
+
+    # Isolate the update transaction from the existing collection/catalog
+    # preflights so the test can assert its connection and commit behavior.
+    monkeypatch.setattr(backend, "create_collection", lambda _collection: None)
+    monkeypatch.setattr(backend, "get_index_specs", lambda _collection: [])
+    tracked = _TrackedConnection(backend._connect())
+    monkeypatch.setattr(backend, "_connect", lambda: tracked)
+
+    assert backend.update_many(
+        "items", {"group": "selected"}, {"$inc": {"count": 10}}
+    ) == [1, 2]
+
+    assert [sql for sql, _params in tracked.execute_calls] == [
+        "BEGIN IMMEDIATE",
+        'SELECT _id, data FROM "items"',
+    ]
+    assert len(tracked.executemany_calls) == 1
+    assert tracked.executemany_calls[0][0] == (
+        'UPDATE "items" SET data = ? WHERE _id = ?'
+    )
+    assert len(tracked.executemany_calls[0][1]) == 2
+    assert tracked.commits == 1
+    assert tracked.rollbacks == 0
+    assert tracked.closes == 1
+
+    reopened = SQLiteTableBackend(backend.path)
+    assert [doc["count"] for doc in reopened.find("items", {})] == [11, 12, 3]
+
+
+def test_sqlite_bulk_update_validates_unique_post_image_atomically(tmp_path):
+    backend = SQLiteTableBackend(str(tmp_path / "unique.sqlite"))
+    backend.insert_many(
+        "users",
+        [
+            {"_id": 1, "team": "compiler", "email": "one@example.com"},
+            {"_id": 2, "team": "compiler", "email": "two@example.com"},
+            {"_id": 3, "team": "docs", "email": "three@example.com"},
+        ],
+    )
+    backend.create_index("users", parse_index_spec("email", unique=True))
+
+    with pytest.raises(DuplicateKeyError):
+        backend.update_many(
+            "users",
+            {"team": "compiler"},
+            {"$set": {"email": "shared@example.com"}},
+        )
+
+    assert [doc["email"] for doc in backend.find("users", {})] == [
+        "one@example.com",
+        "two@example.com",
+        "three@example.com",
+    ]
+
+
+def test_sqlite_bulk_update_one_stops_after_first_noop(tmp_path):
+    backend = SQLiteTableBackend(str(tmp_path / "single.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1, "group": "selected", "state": "done"},
+            {"_id": 2, "group": "selected", "state": "pending"},
+        ],
+    )
+
+    assert (
+        backend.update_many(
+            "items",
+            {"group": "selected"},
+            {"$set": {"state": "done"}},
+            multi=False,
+        )
+        == []
+    )
+    assert backend.find_one("items", {"_id": 2})["state"] == "pending"
+
+
+def test_sqlite_bulk_update_rolls_back_when_later_document_is_invalid(tmp_path):
+    backend = SQLiteTableBackend(str(tmp_path / "rollback.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1, "group": "selected", "count": 1},
+            {"_id": 2, "group": "selected", "count": "not-a-number"},
+        ],
+    )
+
+    with pytest.raises(WriteError):
+        backend.update_many("items", {"group": "selected"}, {"$inc": {"count": 1}})
+
+    assert backend.find_one("items", {"_id": 1})["count"] == 1
+
+
+def test_sqlite_bulk_update_maps_native_integrity_errors(tmp_path, monkeypatch):
+    backend = SQLiteTableBackend(str(tmp_path / "integrity.sqlite"))
+    backend.insert_many("items", [{"_id": 1, "value": "before"}])
+
+    original_connect = backend._connect
+
+    class _FailingConnection(_TrackedConnection):
+        def executemany(self, sql, params):
+            raise sqlite3.IntegrityError("native unique conflict")
+
+    monkeypatch.setattr(backend, "create_collection", lambda _collection: None)
+    monkeypatch.setattr(backend, "get_index_specs", lambda _collection: [])
+    failing = _FailingConnection(original_connect())
+    monkeypatch.setattr(backend, "_connect", lambda: failing)
+
+    with pytest.raises(DuplicateKeyError, match="native unique conflict"):
+        backend.update_many("items", {}, {"$set": {"value": "after"}})
+
+    assert failing.commits == 0
+    assert failing.rollbacks == 1
+
+
+def test_sqlite_public_updates_use_single_backend_result_hook(tmp_path, monkeypatch):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.items
+    collection.insert_many(
+        [
+            {"_id": 1, "group": "selected", "state": "done"},
+            {"_id": 2, "group": "selected", "state": "pending"},
+            {"_id": 3, "group": "other", "state": "pending"},
+        ]
+    )
+    backend = collection.parent.engine
+    calls = []
+    original_hook = backend.update_many_with_result
+
+    def tracked_hook(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_hook(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "update_many_with_result", tracked_hook)
+    monkeypatch.setattr(
+        backend,
+        "update_many",
+        lambda *args, **kwargs: pytest.fail("the legacy backend update was called"),
+    )
+
+    many = collection.update_many({"group": "selected"}, {"$set": {"state": "done"}})
+    one = collection.update_one({"group": "other"}, {"$set": {"state": "finished"}})
+
+    assert (many.matched_count, many.modified_count) == (2, 1)
+    assert (one.matched_count, one.modified_count) == (1, 1)
+    assert [call[1]["multi"] for call in calls] == [True, False]
+    assert all(call[1]["validate_document"] is not None for call in calls)
+
+
+def test_sqlite_concurrent_clients_do_not_lose_increment_updates(tmp_path):
+    location = str(tmp_path / "concurrent")
+    setup = tm.TinyMongoClient(location, backend="sqlite")
+    setup.app.items.insert_one({"_id": "counter", "count": 0})
+    setup.close()
+
+    workers = 6
+    start = threading.Barrier(workers)
+
+    def increment(_worker):
+        client = tm.TinyMongoClient(location, backend="sqlite")
+        try:
+            start.wait(timeout=10)
+            result = client.app.items.update_one(
+                {"_id": "counter"},
+                {"$inc": {"count": 1}},
+            )
+            return result.matched_count, result.modified_count
+        finally:
+            client.close()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(increment, range(workers)))
+
+    assert results == [(1, 1)] * workers
+    reader = tm.TinyMongoClient(location, backend="sqlite")
+    try:
+        assert reader.app.items.find_one({"_id": "counter"})["count"] == workers
+    finally:
+        reader.close()
+
+
+def test_sqlite_public_result_hook_preserves_upsert(tmp_path):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.items
+
+    result = collection.update_one(
+        {"_id": "new", "group": "selected"},
+        {"$set": {"state": "created"}},
+        upsert=True,
+    )
+
+    assert result.matched_count == 0
+    assert result.modified_count == 0
+    assert result.upserted_id == "new"
+    assert collection.find_one({"_id": "new"}) == {
+        "_id": "new",
+        "group": "selected",
+        "state": "created",
+    }
+
+
+def test_sqlite_result_hook_preserves_decimal128_quiet_nan_count(tmp_path):
+    bson = pytest.importorskip("bson")
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.items
+    collection.insert_one({"_id": "nan", "amount": bson.Decimal128("NaN")})
+
+    result = collection.update_one(
+        {"_id": "nan"},
+        {"$inc": {"amount": bson.Decimal128("0")}},
+    )
+
+    assert result.matched_count == 1
+    assert result.modified_count == 1
+    assert (
+        collection.find_one({"_id": "nan"})["amount"].bid == bson.Decimal128("NaN").bid
+    )

--- a/tests/test_sqlite_read_optimizations.py
+++ b/tests/test_sqlite_read_optimizations.py
@@ -1,0 +1,547 @@
+"""Regression tests for SQLite point and declared-index read fast paths."""
+
+import asyncio
+from contextlib import contextmanager
+import re
+import sqlite3
+
+import pytest
+
+import tinymongo as tm
+from tinymongo import table_backends
+from tinymongo.errors import DuplicateKeyError
+from tinymongo.indexes import parse_index_spec
+
+
+def _collection(tmp_path, name="items"):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    return client, client.app[name]
+
+
+def _track_sqlite_work(monkeypatch):
+    """Record statements and payload decodes without depending on backend hooks."""
+
+    statements = []
+    decodes = []
+    original_connect = table_backends.sqlite3.connect
+    original_loads = table_backends._json_loads
+
+    def traced_connect(*args, **kwargs):
+        connection = original_connect(*args, **kwargs)
+        connection.set_trace_callback(statements.append)
+        return connection
+
+    def tracked_loads(value):
+        decodes.append(value)
+        return original_loads(value)
+
+    monkeypatch.setattr(table_backends.sqlite3, "connect", traced_connect)
+    monkeypatch.setattr(table_backends, "_json_loads", tracked_loads)
+    return statements, decodes
+
+
+def _payload_selects(statements):
+    return [
+        statement
+        for statement in statements
+        if statement.lstrip().upper().startswith("SELECT")
+        and " DATA " in " {0} ".format(statement.upper())
+    ]
+
+
+def _assert_primary_key_lookup(statements):
+    payload_selects = _payload_selects(statements)
+    assert payload_selects
+    assert all(" WHERE " in statement.upper() for statement in payload_selects)
+    assert any("_ID" in statement.upper() for statement in payload_selects)
+
+
+def test_sqlite_direct_id_hit_and_miss_use_bounded_primary_key_reads(
+    tmp_path, monkeypatch
+):
+    client, collection = _collection(tmp_path, "point_reads")
+    collection.insert_many(
+        [
+            {"_id": index, "name": "item-{0}".format(index), "body": "x" * 10_000}
+            for index in range(12)
+        ]
+    )
+    statements, decodes = _track_sqlite_work(monkeypatch)
+
+    try:
+        assert collection.find_one({"_id": 11})["name"] == "item-11"
+        assert len(decodes) == 1
+        _assert_primary_key_lookup(statements)
+
+        statements.clear()
+        decodes.clear()
+        assert collection.find_one({"_id": 99}) is None
+        assert decodes == []
+        _assert_primary_key_lookup(statements)
+    finally:
+        client.close()
+
+
+def test_sqlite_regex_id_and_logical_id_filters_keep_general_read_paths(tmp_path):
+    client, collection = _collection(tmp_path, "general_id_reads")
+    collection.insert_many(
+        [
+            {"_id": "alpha", "value": 1},
+            {"_id": "beta", "value": 2},
+        ]
+    )
+
+    try:
+        assert collection.find_one({"_id": re.compile("^a")})["_id"] == "alpha"
+        logical = {"$and": [{"_id": "beta"}]}
+        assert [row["_id"] for row in collection.find(logical).limit(1)] == ["beta"]
+        assert collection.count_documents(logical) == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_direct_id_eq_projection_count_and_cursor_bounds(tmp_path, monkeypatch):
+    client, collection = _collection(tmp_path, "point_consumers")
+    collection.insert_many(
+        [
+            {"_id": 1, "name": "Ada", "body": "x" * 10_000},
+            {"_id": 2, "name": "Grace", "body": "y" * 10_000},
+        ]
+    )
+    statements, decodes = _track_sqlite_work(monkeypatch)
+
+    try:
+        assert collection.find_one({"_id": {"$eq": 2}}, {"name": 1, "_id": 0}) == {
+            "name": "Grace"
+        }
+        assert len(decodes) == 1
+        _assert_primary_key_lookup(statements)
+
+        statements.clear()
+        decodes.clear()
+        assert collection.count_documents({"_id": {"$eq": 2}}) == 1
+        assert collection.count_documents({"_id": {"$eq": 99}}) == 0
+        assert len(decodes) == 1
+        _assert_primary_key_lookup(statements)
+
+        assert list(collection.find({"_id": 2}).skip(1).limit(1)) == []
+    finally:
+        client.close()
+
+
+def test_sqlite_direct_id_keeps_typed_and_legacy_string_collisions_exact(tmp_path):
+    client, collection = _collection(tmp_path, "legacy_ids")
+    backend = collection.parent.engine
+    backend.create_collection(collection.name)
+    connection = backend._connect()
+    try:
+        connection.execute(
+            'INSERT INTO "legacy_ids" (_id, data) VALUES (?, ?)',
+            ("1", table_backends._json_dumps({"_id": 1, "kind": "legacy-number"})),
+        )
+        connection.execute(
+            'INSERT INTO "legacy_ids" (_id, data) VALUES (?, ?)',
+            (
+                "legacy-container-row",
+                table_backends._json_dumps({"_id": [1, 2], "kind": "legacy-container"}),
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    collection.insert_many(
+        [
+            {"_id": "1", "kind": "current-string"},
+            {"_id": True, "kind": "boolean"},
+        ]
+    )
+
+    try:
+        assert collection.find_one({"_id": 1})["kind"] == "legacy-number"
+        assert collection.find_one({"_id": 1.0})["kind"] == "legacy-number"
+        assert collection.find_one({"_id": "1"})["kind"] == "current-string"
+        assert collection.find_one({"_id": True})["kind"] == "boolean"
+        assert collection.find_one({"_id": [1, 2]})["kind"] == "legacy-container"
+        assert collection.find_one({"_id": {"$eq": "1"}})["kind"] == ("current-string")
+    finally:
+        client.close()
+
+
+def test_sqlite_extended_bson_id_uses_the_bounded_primary_key_path(
+    tmp_path, monkeypatch
+):
+    bson = pytest.importorskip("bson")
+    client, collection = _collection(tmp_path, "bson_points")
+    target = bson.ObjectId("00000000000000000000000b")
+    collection.insert_many(
+        [{"_id": index, "body": "x" * 10_000} for index in range(12)]
+        + [{"_id": target, "body": "target"}]
+    )
+    statements, decodes = _track_sqlite_work(monkeypatch)
+
+    try:
+        assert collection.find_one({"_id": target}) == {
+            "_id": target,
+            "body": "target",
+        }
+        assert len(decodes) == 1
+        _assert_primary_key_lookup(statements)
+    finally:
+        client.close()
+
+
+def test_sqlite_repeated_point_reads_do_not_repeat_setup_sql(tmp_path, monkeypatch):
+    client, collection = _collection(tmp_path, "initialized_reads")
+    collection.insert_one({"_id": 1, "name": "Ada"})
+    statements, _decodes = _track_sqlite_work(monkeypatch)
+
+    try:
+        for _ in range(3):
+            assert collection.find_one({"_id": 1})["name"] == "Ada"
+
+        setup_sql = "\n".join(statements).upper()
+        assert "CREATE TABLE" not in setup_sql
+        assert "JOURNAL_MODE" not in setup_sql
+        assert "NAME='TINYDB'" not in setup_sql
+        assert "NAME = 'TINYDB'" not in setup_sql
+    finally:
+        client.close()
+
+
+def test_sqlite_double_checked_lifecycle_cache_rechecks(tmp_path, monkeypatch):
+    backend = table_backends.SQLiteTableBackend(str(tmp_path / "lifecycle.sqlite"))
+
+    @contextmanager
+    def initialize_while_waiting():
+        backend._sqlite_initialized = True
+        yield
+
+    monkeypatch.setattr(backend, "_write_lock", initialize_while_waiting)
+    backend._ensure_sqlite_initialized()
+
+    backend._sqlite_initialized = True
+
+    @contextmanager
+    def create_collection_while_waiting():
+        backend._ready_collections.add("items")
+        yield
+
+    monkeypatch.setattr(backend, "_write_lock", create_collection_while_waiting)
+    backend.create_collection("items")
+    backend._migrate_legacy_blob()
+
+    spec = parse_index_spec("value")
+
+    @contextmanager
+    def create_index_while_waiting():
+        backend._ready_type_indexes.add(("items", spec.name))
+        yield
+
+    backend._ready_type_indexes.clear()
+    monkeypatch.setattr(backend, "_write_lock", create_index_while_waiting)
+    backend._ensure_type_index_on_connection(None, "items", spec)
+
+
+def test_sqlite_initialized_collection_recovers_after_an_external_drop(tmp_path):
+    first, collection = _collection(tmp_path, "externally_dropped")
+    collection.insert_one({"_id": 1, "name": "before"})
+    second = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    try:
+        assert second.app.drop_collection("externally_dropped") is True
+        assert collection.find_one({"_id": 1}) is None
+        collection.insert_one({"_id": 2, "name": "after"})
+        assert collection.find_one({"_id": 2})["name"] == "after"
+    finally:
+        second.close()
+        first.close()
+
+
+def test_async_sqlite_direct_id_uses_same_exact_fast_path(tmp_path, monkeypatch):
+    sync_client, collection = _collection(tmp_path, "async_points")
+    collection.insert_many(
+        [
+            {"_id": 1, "name": "Ada", "body": "x" * 10_000},
+            {"_id": 2, "name": "Grace", "body": "y" * 10_000},
+        ]
+    )
+    sync_client.close()
+    statements, decodes = _track_sqlite_work(monkeypatch)
+
+    async def scenario():
+        client = tm.AsyncTinyMongoClient(str(tmp_path), backend="sqlite")
+        try:
+            found = await client.app.async_points.find_one(
+                {"_id": {"$eq": 2}}, {"name": 1, "_id": 0}
+            )
+            assert found == {"name": "Grace"}
+            assert await client.app.async_points.count_documents({"_id": 99}) == 0
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+    assert len(decodes) == 1
+    _assert_primary_key_lookup(statements)
+
+
+def test_sqlite_declared_index_unions_scalar_and_array_members(tmp_path):
+    client, collection = _collection(tmp_path, "indexed_union")
+    collection.insert_many(
+        [
+            {"_id": "scalar", "value": "match"},
+            {"_id": "array", "value": ["other", "match"]},
+            {"_id": "other", "value": "other"},
+            {"_id": "number", "value": 1},
+            {"_id": "boolean", "value": True},
+            {"_id": "object-array", "value": [{"nested": 1}]},
+        ]
+    )
+    collection.create_index("value", name="value_lookup")
+
+    try:
+        assert {row["_id"] for row in collection.find({"value": "match"})} == {
+            "scalar",
+            "array",
+        }
+        assert {row["_id"] for row in collection.find({"value": {"$eq": "match"}})} == {
+            "scalar",
+            "array",
+        }
+        assert collection.count_documents({"value": {"$eq": "match"}}) == 2
+        assert {row["_id"] for row in collection.find({"value": True})} == {"boolean"}
+        assert {row["_id"] for row in collection.find({"value": {"$eq": True}})} == {
+            "boolean"
+        }
+        assert {row["_id"] for row in collection.find({"value": 1})} == {"number"}
+    finally:
+        client.close()
+
+
+def test_sqlite_bounded_index_read_stops_after_enough_exact_matches(
+    tmp_path, monkeypatch
+):
+    client, collection = _collection(tmp_path, "indexed_bounds")
+    collection.insert_many(
+        [{"_id": index, "value": "match", "body": "x" * 10_000} for index in range(20)]
+        + [{"_id": 100, "value": ["match"], "body": "y" * 10_000}]
+    )
+    collection.create_index("value")
+    _statements, decodes = _track_sqlite_work(monkeypatch)
+
+    try:
+        assert len(list(collection.find({"value": "match"}).limit(1))) == 1
+        assert len(decodes) == 1
+
+        decodes.clear()
+        assert len(list(collection.find({"value": "match"}).skip(2).limit(1))) == 1
+        assert len(decodes) == 3
+    finally:
+        client.close()
+
+
+def test_sqlite_indexed_array_candidates_decode_only_matching_rows(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "indexed_array_candidates")
+    collection.insert_many(
+        [
+            {"_id": index, "tags": ["match" if index == 197 else "other"]}
+            for index in range(250)
+        ]
+    )
+    collection.create_index("tags")
+    _statements, decodes = _track_sqlite_work(monkeypatch)
+
+    try:
+        assert [row["_id"] for row in collection.find({"tags": "match"})] == [197]
+        assert len(decodes) == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_external_table_drop_rebuilds_cataloged_native_indexes(tmp_path):
+    client, collection = _collection(tmp_path, "raw_drop_recovery")
+    collection.insert_one({"_id": 1, "value": "before"})
+    collection.create_index("value", name="value_lookup")
+    backend = collection.parent.engine
+    spec = parse_index_spec("value", name="value_lookup")
+    physical_name = backend._physical_index_name(collection.name, spec)
+
+    connection = sqlite3.connect(backend.path)
+    try:
+        connection.execute('DROP TABLE "raw_drop_recovery"')
+        connection.commit()
+    finally:
+        connection.close()
+
+    try:
+        assert list(collection.find({"value": "before"})) == []
+        collection.insert_one({"_id": 2, "value": "after"})
+        assert collection.find_one({"value": "after"})["_id"] == 2
+
+        connection = sqlite3.connect(backend.path)
+        try:
+            native_names = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'index'"
+                ).fetchall()
+            }
+        finally:
+            connection.close()
+        assert physical_name in native_names
+        assert physical_name + "_types" in native_names
+    finally:
+        client.close()
+
+
+def test_sqlite_indexed_read_propagates_catalog_failures(tmp_path, monkeypatch):
+    client, collection = _collection(tmp_path, "indexed_catalog_failure")
+    collection.insert_one({"_id": 1, "value": "match"})
+    collection.create_index("value")
+    backend = collection.parent.engine
+
+    def fail_catalog(_connection, _collection_name):
+        raise DuplicateKeyError("unsafe index migration")
+
+    monkeypatch.setattr(
+        backend,
+        "_get_query_index_specs_on_connection",
+        fail_catalog,
+    )
+    try:
+        with pytest.raises(DuplicateKeyError, match="unsafe index migration"):
+            list(collection.find({"value": "match"}))
+    finally:
+        client.close()
+
+
+def test_sqlite_indexed_huge_integer_falls_back_to_exact_python_matcher(tmp_path):
+    client, collection = _collection(tmp_path, "indexed_huge_integer")
+    huge = 2**100
+    collection.insert_one({"_id": 1, "value": huge})
+    collection.create_index("value")
+
+    try:
+        assert collection.find_one({"value": huge})["_id"] == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_find_falls_back_after_general_sql_compiler_failure(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "general_find_fallback")
+    collection.insert_many(
+        [
+            {"_id": 1, "present": True},
+            {"_id": 2},
+        ]
+    )
+    backend = collection.parent.engine
+
+    def fail_compile(_filter):
+        raise RuntimeError("compiler unavailable")
+
+    monkeypatch.setattr(backend.compiler, "compile", fail_compile)
+    try:
+        assert [
+            row["_id"]
+            for row in backend.find(collection.name, {"present": {"$exists": True}})
+        ] == [1]
+    finally:
+        client.close()
+
+
+def test_sqlite_rebuilds_missing_unique_and_dotted_index_storage(tmp_path):
+    client, unique_collection = _collection(tmp_path, "unique_rebuild")
+    unique_collection.insert_many(
+        [
+            {"_id": 1, "value": "one"},
+            {"_id": 2, "value": "two"},
+        ]
+    )
+    unique_collection.create_index("value", name="value_unique", unique=True)
+    backend = unique_collection.parent.engine
+    unique_spec = parse_index_spec("value", name="value_unique", unique=True)
+    unique_name = backend._physical_index_name(unique_collection.name, unique_spec)
+
+    connection = sqlite3.connect(backend.path)
+    try:
+        for name in (unique_name, unique_name + "_lookup", unique_name + "_types"):
+            connection.execute(
+                "DROP INDEX IF EXISTS {0}".format(
+                    table_backends._quote_identifier(name)
+                )
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+    try:
+        assert unique_collection.find_one({"value": "one"})["_id"] == 1
+
+        dotted_spec = parse_index_spec("profile.name", name="profile_name")
+        backend.create_index(unique_collection.name, dotted_spec)
+        with backend._sqlite_state_lock:
+            backend._ready_type_indexes.discard(
+                (unique_collection.name, dotted_spec.name)
+            )
+        assert backend.create_index(unique_collection.name, dotted_spec) == (
+            dotted_spec.name
+        )
+
+        connection = sqlite3.connect(backend.path)
+        try:
+            names = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'index'"
+                ).fetchall()
+            }
+        finally:
+            connection.close()
+        assert unique_name in names
+        assert unique_name + "_lookup" in names
+        assert unique_name + "_types" in names
+        dotted_name = backend._physical_index_name(
+            unique_collection.name,
+            dotted_spec,
+        )
+        assert dotted_name in names
+        assert dotted_name + "_types" not in names
+    finally:
+        client.close()
+
+
+def test_sqlite_companion_type_index_covers_multikey_candidate_plan(tmp_path):
+    client, collection = _collection(tmp_path, "indexed_plan")
+    collection.insert_many(
+        [
+            {"_id": index, "value": ["match"] if index == 7 else "other"}
+            for index in range(12)
+        ]
+    )
+    collection.create_index("value", name="value_lookup")
+    backend = collection.parent.engine
+    spec = parse_index_spec("value", name="value_lookup")
+    physical_name = backend._physical_index_name(collection.name, spec)
+    path = table_backends._sql_literal(table_backends._json_path("value"))
+    connection = sqlite3.connect(backend.path)
+    try:
+        plan = connection.execute(
+            "EXPLAIN QUERY PLAN SELECT data FROM {table} "
+            "WHERE json_type(data, {path}) IN ('array', 'object')".format(
+                table=table_backends._quote_identifier(collection.name),
+                path=path,
+            )
+        ).fetchall()
+    finally:
+        connection.close()
+        client.close()
+
+    details = " ".join(str(row[-1]) for row in plan)
+    assert "USING INDEX" in details.upper()
+    assert physical_name in details

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -617,6 +617,8 @@ def _simple_scalar_equality(filter_doc):
     if not isinstance(filter_doc, Mapping) or len(filter_doc) != 1:
         return None
     field, expected = next(iter(filter_doc.items()))
+    if isinstance(expected, dict) and set(expected) == {"$eq"}:
+        expected = expected["$eq"]
     if (
         not isinstance(field, str)
         or field.startswith("$")
@@ -628,6 +630,25 @@ def _simple_scalar_equality(filter_doc):
     ):
         return None
     return field, expected
+
+
+def _direct_id_equality(filter_doc):
+    """Return the operand for an exact single-field ``_id`` query."""
+
+    if not isinstance(filter_doc, Mapping) or set(filter_doc) != {"_id"}:
+        return _MISSING
+    expected = filter_doc["_id"]
+    if is_bson_regex(expected):
+        return _MISSING
+    if isinstance(expected, Mapping) and any(
+        str(key).startswith("$") for key in expected
+    ):
+        if set(expected) != {"$eq"}:
+            return _MISSING
+        expected = expected["$eq"]
+        if is_bson_regex(expected):
+            return _MISSING
+    return expected
 
 
 def _reject_remote_unique_values(documents, specs):
@@ -1981,6 +2002,14 @@ class SQLiteTableBackend(TableBackend):
     extension = ".sqlite"
     index_catalog_table = "__tinymongo_indexes"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sqlite_state_lock = threading.RLock()
+        self._sqlite_initialized = False
+        self._ready_collections = set()
+        self._ready_type_indexes = set()
+        self._query_index_cache = {}
+
     def _physical_index_name(self, collection, spec):
         identity = "{0}\x00{1}\x00{2}".format(
             self.database or "default", collection, spec.name
@@ -2000,9 +2029,62 @@ class SQLiteTableBackend(TableBackend):
         return conn
 
     def _connect(self):
-        conn = self._read_connect()
-        conn.execute("PRAGMA journal_mode=WAL")
-        return conn
+        self._ensure_sqlite_initialized()
+        return self._read_connect()
+
+    def _ensure_sqlite_initialized(self):
+        """Run persistent SQLite setup and legacy migration once per engine."""
+
+        with self._sqlite_state_lock:
+            if self._sqlite_initialized:
+                return
+
+        # Legacy migration writes collection tables, and WAL changes persistent
+        # database state.  Use the same process/file lock as ordinary writes so
+        # two clients opening an older file cannot race the one-time upgrade.
+        with self._write_lock():
+            with self._sqlite_state_lock:
+                if self._sqlite_initialized:
+                    return
+                conn = self._read_connect()
+                try:
+                    conn.execute("PRAGMA journal_mode=WAL")
+                    self._migrate_legacy_blob_on_connection(conn)
+                finally:
+                    conn.close()
+                self._sqlite_initialized = True
+
+    @staticmethod
+    def _is_missing_collection_error(exc):
+        return (
+            isinstance(exc, sqlite3.OperationalError)
+            and "no such table" in str(exc).lower()
+        )
+
+    def _forget_collection(self, collection):
+        with self._sqlite_state_lock:
+            self._ready_collections.discard(collection)
+            self._ready_type_indexes = {
+                key for key in self._ready_type_indexes if key[0] != collection
+            }
+            self._query_index_cache.pop(collection, None)
+
+    def _run_collection_read(self, collection, operation):
+        """Run one connection-scoped read, recovering once from an external drop."""
+
+        for attempt in range(2):
+            self.create_collection(collection)
+            conn = self._connect()
+            try:
+                return operation(conn)
+            except Exception as exc:
+                if attempt or not self._is_missing_collection_error(exc):
+                    raise
+                self._forget_collection(collection)
+            finally:
+                conn.close()
+
+        raise AssertionError("unreachable SQLite collection retry")  # pragma: no cover
 
     def _ensure_index_catalog(self, conn):
         conn.execute(
@@ -2115,77 +2197,105 @@ class SQLiteTableBackend(TableBackend):
         ).fetchone()
         return "stale" if stale is not None else "ready"
 
-    def get_index_specs(self, collection):
-        conn = self._read_connect()
-        try:
-            state = self._index_catalog_state(conn)
-            if state == "absent":
-                return []
-            if state == "stale":
-                # Index-token migrations change persisted expression-index
-                # keys. Serialize only this one-time upgrade, then leave normal
-                # catalog reads lock-free so SQLite WAL readers stay concurrent.
-                conn.close()
-                with self._write_lock():
-                    migration_conn = self._connect()
-                    try:
-                        self._ensure_index_catalog(migration_conn)
-                    finally:
-                        migration_conn.close()
-                conn = self._read_connect()
-            rows = conn.execute(
-                "SELECT index_name, field_name, unique_flag FROM {0} "
-                "WHERE collection_name = ? ORDER BY index_name".format(
-                    _quote_identifier(self.index_catalog_table)
-                ),
-                (collection,),
-            ).fetchall()
-            return [
-                IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
-                for row in rows
-            ]
-        finally:
-            conn.close()
+    def _get_index_specs_on_connection(self, conn, collection):
+        """Read current index metadata without opening a second connection."""
 
-    def _migrate_legacy_blob(self):
+        state = self._index_catalog_state(conn)
+        if state == "absent":
+            return []
+        if state == "stale":
+            # Index-token migrations change persisted expression-index keys.
+            # Serialize only this one-time upgrade; ordinary catalog reads stay
+            # lock-free and always consult durable metadata for cross-process
+            # create/drop visibility.
+            with self._write_lock():
+                self._ensure_index_catalog(conn)
+        rows = conn.execute(
+            "SELECT index_name, field_name, unique_flag FROM {0} "
+            "WHERE collection_name = ? ORDER BY index_name".format(
+                _quote_identifier(self.index_catalog_table)
+            ),
+            (collection,),
+        ).fetchall()
+        return [
+            IndexSpec(field=row[1], name=row[0], unique=bool(row[2])) for row in rows
+        ]
+
+    def _get_query_index_specs_on_connection(self, conn, collection):
+        """Return fresh-enough query metadata with one cheap schema check.
+
+        Query planning may safely cache index specifications because a stale
+        entry only changes whether SQLite attempts an equivalent candidate
+        query; it never governs uniqueness validation. ``schema_version``
+        still makes index creation or removal by another process visible on
+        the next read without reopening and migrating the catalog every time.
+        """
+
+        schema_version = int(conn.execute("PRAGMA schema_version").fetchone()[0])
+        with self._sqlite_state_lock:
+            cached = self._query_index_cache.get(collection)
+            if cached is not None and cached[0] == schema_version:
+                return cached[1]
+            # A peer may have dropped either the table or one physical
+            # expression index. Reconcile this collection's persisted index
+            # storage before trusting a new or changed catalog snapshot.
+            self._ready_type_indexes = {
+                key for key in self._ready_type_indexes if key[0] != collection
+            }
+
+        specs = self._get_index_specs_on_connection(conn, collection)
+        with self._sqlite_state_lock:
+            self._query_index_cache[collection] = (schema_version, specs)
+        return specs
+
+    def get_index_specs(self, collection):
         conn = self._connect()
         try:
-            has_legacy = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='tinydb'"
-            ).fetchone()
-            if not has_legacy:
-                return
-            row = conn.execute("SELECT data FROM tinydb WHERE id = 1").fetchone()
-            if not row or not row[0]:  # pragma: no cover - corrupt legacy fallback
-                conn.execute("DROP TABLE tinydb")
-                conn.commit()
-                return
-            data = _json_loads(row[0])
-            for collection, docs in data.items():
-                conn.execute(
-                    "CREATE TABLE IF NOT EXISTS {0} (_id TEXT PRIMARY KEY, data TEXT NOT NULL)".format(
-                        _quote_identifier(collection)
-                    )
-                )
-                rows = [
-                    (_physical_id_key(doc.get("_id", eid)), _json_dumps(doc))
-                    for eid, doc in (docs or {}).items()
-                    if isinstance(doc, dict)
-                ]
-                if rows:
-                    conn.executemany(
-                        "INSERT OR REPLACE INTO {0} (_id, data) VALUES (?, ?)".format(
-                            _quote_identifier(collection)
-                        ),
-                        rows,
-                    )
-            conn.execute("DROP TABLE tinydb")
-            conn.commit()
+            return self._get_index_specs_on_connection(conn, collection)
         finally:
             conn.close()
 
+    def _migrate_legacy_blob_on_connection(self, conn):
+        has_legacy = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='tinydb'"
+        ).fetchone()
+        if not has_legacy:
+            return
+        row = conn.execute("SELECT data FROM tinydb WHERE id = 1").fetchone()
+        if not row or not row[0]:  # pragma: no cover - corrupt legacy fallback
+            conn.execute("DROP TABLE tinydb")
+            conn.commit()
+            return
+        data = _json_loads(row[0])
+        migrated_collections = []
+        for collection, docs in data.items():
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS {0} (_id TEXT PRIMARY KEY, data TEXT NOT NULL)".format(
+                    _quote_identifier(collection)
+                )
+            )
+            rows = [
+                (_physical_id_key(doc.get("_id", eid)), _json_dumps(doc))
+                for eid, doc in (docs or {}).items()
+                if isinstance(doc, dict)
+            ]
+            if rows:
+                conn.executemany(
+                    "INSERT OR REPLACE INTO {0} (_id, data) VALUES (?, ?)".format(
+                        _quote_identifier(collection)
+                    ),
+                    rows,
+                )
+            migrated_collections.append(collection)
+        conn.execute("DROP TABLE tinydb")
+        conn.commit()
+        self._ready_collections.update(migrated_collections)
+
+    def _migrate_legacy_blob(self):
+        self._ensure_sqlite_initialized()
+
     def list_collections(self):
-        self._migrate_legacy_blob()
+        self._ensure_sqlite_initialized()
         conn = self._connect()
         try:
             rows = conn.execute(
@@ -2196,17 +2306,27 @@ class SQLiteTableBackend(TableBackend):
             conn.close()
 
     def create_collection(self, collection):
-        self._migrate_legacy_blob()
-        conn = self._connect()
-        try:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS {0} (_id TEXT PRIMARY KEY, data TEXT NOT NULL)".format(
-                    _quote_identifier(collection)
-                )
-            )
-            conn.commit()
-        finally:
-            conn.close()
+        self._ensure_sqlite_initialized()
+        with self._sqlite_state_lock:
+            if collection in self._ready_collections:
+                return
+
+        with self._write_lock():
+            with self._sqlite_state_lock:
+                if collection in self._ready_collections:
+                    return
+                conn = self._connect()
+                try:
+                    conn.execute(
+                        "CREATE TABLE IF NOT EXISTS {0} "
+                        "(_id TEXT PRIMARY KEY, data TEXT NOT NULL)".format(
+                            _quote_identifier(collection)
+                        )
+                    )
+                    conn.commit()
+                finally:
+                    conn.close()
+                self._ready_collections.add(collection)
 
     @_write_locked
     def drop_collection(self, collection):
@@ -2224,6 +2344,7 @@ class SQLiteTableBackend(TableBackend):
                 (collection,),
             )
             conn.commit()
+            self._forget_collection(collection)
             return existed
         finally:
             conn.close()
@@ -2234,6 +2355,29 @@ class SQLiteTableBackend(TableBackend):
         existing_docs = self.find(collection, {})
         self.validate_unique_post_image(collection, existing_docs + docs)
         _validate_physical_ids(existing_docs, docs)
+        return self._insert_rows(collection, docs)
+
+    @_write_locked
+    def insert_many_prevalidated(
+        self,
+        collection,
+        docs,
+        bypass_document_validation=False,
+    ):
+        """Insert a collection-planned batch without repeating its full scan.
+
+        The public collection planner has already checked BSON-aware ``_id``
+        identity and every durable unique-index token while holding this
+        backend's cross-process write lock. Native SQLite constraints remain
+        the final authority if a non-TinyMongo writer races that preflight.
+        """
+
+        self.create_collection(collection)
+        return self._insert_rows(collection, docs)
+
+    def _insert_rows(self, collection, docs):
+        """Serialize and commit one already validated SQLite insert batch."""
+
         rows = [(_physical_id_key(doc["_id"]), _json_dumps(doc)) for doc in docs]
         conn = self._connect()
         try:
@@ -2248,8 +2392,64 @@ class SQLiteTableBackend(TableBackend):
         finally:
             conn.close()
 
+    def _find_direct_id(self, collection, filter_doc, projection=None):
+        """Resolve one exact ``_id`` predicate through SQLite's primary key."""
+
+        expected = _direct_id_equality(filter_doc)
+        if expected is _MISSING:
+            return _MISSING
+
+        table = _quote_identifier(collection)
+        candidates = _physical_id_candidates(expected)
+
+        def load_rows(conn):
+            rows = conn.execute(
+                "SELECT _id, data FROM {0} WHERE _id IN ({1})".format(
+                    table,
+                    ", ".join("?" for _ in candidates),
+                ),
+                candidates,
+            ).fetchall()
+            documents = []
+            for row_id, data in rows:
+                document = _restore_legacy_document_id(
+                    row_id,
+                    _json_loads(data),
+                    requested_id=expected,
+                )
+                if matches_filter(document, filter_doc):
+                    documents.append(document)
+
+            if not documents and _requires_legacy_id_scan(expected):
+                # Container IDs and older datetime strings cannot always be
+                # enumerated.  Preserve the compatibility scan only for these
+                # uncommon misses; ordinary missing IDs remain primary-key
+                # lookups.
+                documents = []
+                for row_id, data in conn.execute(
+                    "SELECT _id, data FROM {0}".format(table)
+                ):
+                    document = _restore_legacy_document_id(
+                        row_id,
+                        _json_loads(data),
+                        requested_id=expected,
+                    )
+                    if matches_filter(document, filter_doc):
+                        documents.append(document)
+
+            if projection is not None:
+                documents = [
+                    project_document(document, projection) for document in documents
+                ]
+            return documents
+
+        return self._run_collection_read(collection, load_rows)
+
     def find(self, collection, filter_doc=None, sort=None, skip=None, limit=None):
         self.create_collection(collection)
+        direct = self._find_direct_id(collection, filter_doc)
+        if direct is not _MISSING:
+            return direct
         indexed = self._find_indexed_scalar_with_array_union(collection, filter_doc)
         if indexed is not None:
             return indexed
@@ -2262,11 +2462,10 @@ class SQLiteTableBackend(TableBackend):
         try:
             where, params = self.compiler.compile(filter_doc)
             sql = "SELECT data FROM {0}{1}".format(_quote_identifier(collection), where)
-            conn = self._connect()
-            try:
-                rows = conn.execute(sql, params).fetchall()
-            finally:
-                conn.close()
+            rows = self._run_collection_read(
+                collection,
+                lambda conn: conn.execute(sql, params).fetchall(),
+            )
             documents = [_json_loads(row[0]) for row in rows]
             return _postfilter_id_candidates(
                 documents,
@@ -2301,8 +2500,8 @@ class SQLiteTableBackend(TableBackend):
         """Decode rows until the requested number of Python matches is found."""
 
         sql = "SELECT data FROM {0}".format(_quote_identifier(collection))
-        conn = self._connect()
-        try:
+
+        def scan(conn):
             documents = []
             matched = 0
             for row in conn.execute(sql):
@@ -2316,8 +2515,8 @@ class SQLiteTableBackend(TableBackend):
                 if limit and len(documents) >= limit:
                     break
             return documents
-        finally:
-            conn.close()
+
+        return self._run_collection_read(collection, scan)
 
     def find_bounded(self, collection, filter_doc=None, skip=0, limit=0):
         """Return an unsorted cursor window without decoding later rows.
@@ -2329,9 +2528,17 @@ class SQLiteTableBackend(TableBackend):
         """
 
         self.create_collection(collection)
-        indexed = self._find_indexed_scalar_with_array_union(collection, filter_doc)
+        direct = self._find_direct_id(collection, filter_doc)
+        if direct is not _MISSING:
+            return self._bounded_slice(direct, skip, limit)
+        indexed = self._find_indexed_scalar_with_array_union(
+            collection,
+            filter_doc,
+            skip=skip,
+            limit=limit,
+        )
         if indexed is not None:
-            return self._bounded_slice(indexed, skip, limit)
+            return indexed
         if requires_python_filter(filter_doc):
             return self._scan_bounded(collection, filter_doc, skip, limit)
         try:
@@ -2348,11 +2555,10 @@ class SQLiteTableBackend(TableBackend):
                 where,
                 bounds,
             )
-            conn = self._connect()
-            try:
-                rows = conn.execute(sql, params + bound_params).fetchall()
-            finally:
-                conn.close()
+            rows = self._run_collection_read(
+                collection,
+                lambda conn: conn.execute(sql, params + bound_params).fetchall(),
+            )
             return [_json_loads(row[0]) for row in rows]
         except Exception:
             return self._scan_bounded(collection, filter_doc, skip, limit)
@@ -2361,6 +2567,12 @@ class SQLiteTableBackend(TableBackend):
         """Count matching SQLite rows without retaining document payloads."""
 
         self.create_collection(collection)
+        direct = self._find_direct_id(collection, filter_doc)
+        if direct is not _MISSING:
+            return len(direct)
+        indexed = self._find_indexed_scalar_with_array_union(collection, filter_doc)
+        if indexed is not None:
+            return len(indexed)
         if requires_python_filter(filter_doc):
             return self._count_filtered_scan(collection, filter_doc)
         try:
@@ -2371,11 +2583,10 @@ class SQLiteTableBackend(TableBackend):
                 _quote_identifier(collection),
                 where,
             )
-            conn = self._connect()
-            try:
-                row = conn.execute(sql, params).fetchone()
-            finally:
-                conn.close()
+            row = self._run_collection_read(
+                collection,
+                lambda conn: conn.execute(sql, params).fetchone(),
+            )
             # SQLite always returns one row for ``COUNT(*)``.
             return int(row[0])
         except Exception:
@@ -2385,15 +2596,15 @@ class SQLiteTableBackend(TableBackend):
         """Count exact Python-filter matches while releasing each row promptly."""
 
         sql = "SELECT data FROM {0}".format(_quote_identifier(collection))
-        conn = self._connect()
-        try:
+
+        def count(conn):
             return sum(
                 1
                 for row in conn.execute(sql)
                 if matches_filter(_json_loads(row[0]), filter_doc)
             )
-        finally:
-            conn.close()
+
+        return self._run_collection_read(collection, count)
 
     def find_projected(self, collection, filter_doc, projection):
         """Return projected rows through the established backend hook."""
@@ -2445,13 +2656,22 @@ class SQLiteTableBackend(TableBackend):
         """
 
         self.create_collection(collection)
-        indexed = self._find_indexed_scalar_with_array_union(
+        direct = self._find_direct_id(
             collection,
             filter_doc,
             projection=projection,
         )
+        if direct is not _MISSING:
+            return self._bounded_slice(direct, skip, limit)
+        indexed = self._find_indexed_scalar_with_array_union(
+            collection,
+            filter_doc,
+            projection=projection,
+            skip=skip,
+            limit=limit,
+        )
         if indexed is not None:
-            return self._bounded_slice(indexed, skip, limit)
+            return indexed
 
         if requires_python_filter(filter_doc):
             return self._scan_projected(
@@ -2488,21 +2708,6 @@ class SQLiteTableBackend(TableBackend):
                 skip=skip,
                 limit=limit,
             )
-            direct_id_equality = (
-                isinstance(filter_doc, Mapping)
-                and set(filter_doc) == {"_id"}
-                and not isinstance(filter_doc["_id"], Mapping)
-            )
-            if direct_id_equality and documents:
-                return documents
-            if _filter_requires_legacy_id_scan(filter_doc):
-                return self._scan_projected(
-                    collection,
-                    projection,
-                    predicate=lambda document: matches_filter(document, filter_doc),
-                    skip=skip,
-                    limit=limit,
-                )
             return documents
         except Exception:
             return self._scan_projected(
@@ -2565,8 +2770,8 @@ class SQLiteTableBackend(TableBackend):
             "SELECT _id, json_type(data, {path}), "
             "json_extract(data, {path}) FROM {table}{where}{bounds}"
         ).format(path=path, table=table, where=where, bounds=bounds)
-        conn = self._connect()
-        try:
+
+        def scan(conn):
             documents = []
             cursor = conn.execute(sql, params + bound_params)
             for physical_id, kind, value in cursor:
@@ -2584,8 +2789,8 @@ class SQLiteTableBackend(TableBackend):
                     )
                 documents.append(document)
             return documents
-        finally:
-            conn.close()
+
+        return self._run_collection_read(collection, scan)
 
     def _scan_projected(
         self,
@@ -2608,8 +2813,8 @@ class SQLiteTableBackend(TableBackend):
             where,
             bounds,
         )
-        conn = self._connect()
-        try:
+
+        def scan(conn):
             documents = []
             matched = 0
             cursor = conn.execute(sql, (params or []) + bound_params)
@@ -2624,63 +2829,338 @@ class SQLiteTableBackend(TableBackend):
                 if predicate is not None and limit and len(documents) >= limit:
                     break
             return documents
-        finally:
-            conn.close()
+
+        return self._run_collection_read(collection, scan)
+
+    def _type_index_name(self, collection, spec):
+        return self._physical_index_name(collection, spec) + "_types"
+
+    def _ensure_type_index_on_connection(self, conn, collection, spec):
+        """Reconcile native scalar and array-candidate indexes for one spec."""
+
+        key = (collection, spec.name)
+        with self._sqlite_state_lock:
+            if key in self._ready_type_indexes:
+                return
+
+        with self._write_lock():
+            with self._sqlite_state_lock:
+                if key in self._ready_type_indexes:
+                    return
+                path = _sql_literal(_json_path(spec.field))
+                table = _quote_identifier(collection)
+                physical_name = self._physical_index_name(collection, spec)
+                physical_exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+                    (physical_name,),
+                ).fetchone()
+                if physical_exists is None and spec.unique:
+                    documents = [
+                        _json_loads(row[0])
+                        for row in conn.execute(
+                            "SELECT data FROM {0}".format(table)
+                        ).fetchall()
+                    ]
+                    validate_unique_documents(documents, [spec])
+
+                scalar_expression = "json_extract(data, {0})".format(path)
+                constraint_expression = scalar_expression
+                if spec.unique:
+                    constraint_expression = "tinymongo_unique_token(data, {0})".format(
+                        _sql_literal(spec.field)
+                    )
+                conn.execute(
+                    "CREATE {unique}INDEX IF NOT EXISTS {name} ON {table} "
+                    "({expression})".format(
+                        unique="UNIQUE " if spec.unique else "",
+                        name=_quote_identifier(physical_name),
+                        table=table,
+                        expression=constraint_expression,
+                    )
+                )
+                if spec.unique:
+                    conn.execute(
+                        "CREATE INDEX IF NOT EXISTS {name} ON {table} "
+                        "({expression})".format(
+                            name=_quote_identifier(physical_name + "_lookup"),
+                            table=table,
+                            expression=scalar_expression,
+                        )
+                    )
+                if "." not in spec.field:
+                    type_expression = "json_type(data, {0})".format(path)
+                    conn.execute(
+                        "CREATE INDEX IF NOT EXISTS {name} ON {table} ({expression}) "
+                        "WHERE {expression} IN ('array', 'object')".format(
+                            name=_quote_identifier(
+                                self._type_index_name(collection, spec)
+                            ),
+                            table=table,
+                            expression=type_expression,
+                        )
+                    )
+                conn.commit()
+                self._ready_type_indexes.add(key)
 
     def _find_indexed_scalar_with_array_union(
         self,
         collection,
         filter_doc,
         projection=None,
+        skip=0,
+        limit=0,
     ):
         equality = _simple_scalar_equality(filter_doc)
         if equality is None:
             return None
-        field, _ = equality
+        field, expected = equality
         if "." in field:
             return None
-        if not any(spec.field == field for spec in self.get_index_specs(collection)):
-            return None
 
-        where, params = self.compiler.compile(filter_doc)
-        path = _sql_literal(_json_path(field))
-        scalar_sql = (
-            "SELECT data FROM {table}{where} "
-            "AND json_type(data, {path}) IN "
-            "('text', 'integer', 'real', 'true', 'false')"
-        ).format(
-            table=_quote_identifier(collection),
-            where=where,
-            path=path,
-        )
-        array_sql = (
-            "SELECT data FROM {table} WHERE json_type(data, {path}) "
-            "IN ('array', 'object')"
-        ).format(table=_quote_identifier(collection), path=path)
-        conn = self._connect()
-        try:
+        def indexed_read(conn):
+            spec = next(
+                (
+                    candidate
+                    for candidate in self._get_query_index_specs_on_connection(
+                        conn, collection
+                    )
+                    if candidate.field == field
+                ),
+                None,
+            )
+            if spec is None:
+                return _MISSING
+
+            self._ensure_type_index_on_connection(conn, collection, spec)
+            where, params = self.compiler.compile(filter_doc)
+            path = _sql_literal(_json_path(field))
+            if isinstance(expected, bool):
+                scalar_types = ("true" if expected else "false",)
+            elif isinstance(expected, str):
+                scalar_types = ("text",)
+            else:
+                scalar_types = ("integer", "real")
+            scalar_sql = (
+                "SELECT data FROM {table}{where} "
+                "AND json_type(data, {path}) IN ({types})"
+            ).format(
+                table=_quote_identifier(collection),
+                where=where,
+                path=path,
+                types=", ".join(_sql_literal(kind) for kind in scalar_types),
+            )
+            type_expression = "json_type(data, {0})".format(path)
+            if isinstance(expected, bool):
+                member_predicate = "item.type = {0} AND item.value = ?".format(
+                    _sql_literal("true" if expected else "false")
+                )
+                member_params = [int(expected)]
+                candidate_predicate = (
+                    "{type_expression} = 'array' AND EXISTS ("
+                    "SELECT 1 FROM json_each(data, {path}) AS item "
+                    "WHERE {member_predicate})"
+                ).format(
+                    type_expression=type_expression,
+                    path=path,
+                    member_predicate=member_predicate,
+                )
+            elif isinstance(expected, str):
+                member_params = [expected]
+                candidate_predicate = (
+                    "{type_expression} = 'array' AND EXISTS ("
+                    "SELECT 1 FROM json_each(data, {path}) AS item "
+                    "WHERE item.type = 'text' AND item.value = ?)"
+                ).format(type_expression=type_expression, path=path)
+            else:
+                member_params = [expected]
+                candidate_predicate = (
+                    "({type_expression} = 'object' OR "
+                    "({type_expression} = 'array' AND EXISTS ("
+                    "SELECT 1 FROM json_each(data, {path}) AS item WHERE "
+                    "(item.type IN ('integer', 'real') AND item.value = ?) "
+                    "OR item.type = 'object')))"
+                ).format(type_expression=type_expression, path=path)
+            array_sql = (
+                "SELECT data FROM {table} WHERE {type_expression} "
+                "IN ('array', 'object') AND ({candidate_predicate})"
+            ).format(
+                table=_quote_identifier(collection),
+                type_expression=type_expression,
+                candidate_predicate=candidate_predicate,
+            )
             documents = []
-            for sql, sql_params in ((scalar_sql, params), (array_sql, [])):
+            matched = 0
+            branches = (
+                (scalar_sql, params, False),
+                (array_sql, member_params, True),
+            )
+            for sql, sql_params, needs_postfilter in branches:
                 for row in conn.execute(sql, sql_params):
                     document = _json_loads(row[0])
-                    if matches_filter(document, filter_doc):
-                        documents.append(
-                            project_document(document, projection)
-                            if projection is not None
-                            else document
-                        )
+                    if needs_postfilter and not matches_filter(document, filter_doc):
+                        continue
+                    if matched < skip:
+                        matched += 1
+                        continue
+                    documents.append(
+                        project_document(document, projection)
+                        if projection is not None
+                        else document
+                    )
+                    matched += 1
+                    if limit and len(documents) >= limit:
+                        return documents
             return documents
-        finally:
-            conn.close()
+
+        try:
+            result = self._run_collection_read(collection, indexed_read)
+        except OverflowError:
+            # Python's sqlite3 adapter cannot bind integers outside signed
+            # 64-bit range. The exact Python matcher remains the safe path for
+            # those otherwise valid BSON numeric values.
+            return None
+        return None if result is _MISSING else result
 
     def _all_docs_unfiltered(self, collection):
+        rows = self._run_collection_read(
+            collection,
+            lambda conn: conn.execute(
+                "SELECT data FROM {0}".format(_quote_identifier(collection))
+            ).fetchall(),
+        )
+        return [_json_loads(row[0]) for row in rows]
+
+    @_write_locked
+    def update_many(self, collection, filter_doc, update_doc, multi=True):
+        """Apply a SQLite update batch in one read-check-write transaction."""
+
+        updated_ids, _matched_count, _modified_count = self._update_many_transaction(
+            collection,
+            filter_doc,
+            update_doc,
+            multi=multi,
+        )
+        return updated_ids
+
+    @_write_locked
+    def update_many_with_result(
+        self,
+        collection,
+        filter_doc,
+        update_doc,
+        multi=True,
+        validate_document=None,
+    ):
+        """Update a batch and return public ``matched``/``modified`` counts.
+
+        ``TinyMongoCollection`` discovers this optional hook at runtime.  It
+        lets SQLite own the candidate read, validation, and write transaction
+        instead of repeating those preflights in both the collection and the
+        backend.  The callback preserves collection-level document validation
+        without coupling the storage engine to a particular client class.
+        """
+
+        _updated_ids, matched_count, modified_count = self._update_many_transaction(
+            collection,
+            filter_doc,
+            update_doc,
+            multi=multi,
+            validate_document=validate_document,
+        )
+        return matched_count, modified_count
+
+    def _update_many_transaction(
+        self,
+        collection,
+        filter_doc,
+        update_doc,
+        multi=True,
+        validate_document=None,
+    ):
+        """Return changed IDs and result counts from one SQLite transaction.
+
+        The generic table-backend implementation delegates every changed
+        document to :meth:`replace_one`.  For SQLite that turns an update of
+        ``m`` rows into ``m`` complete collection scans and ``m`` commits,
+        because each replacement must revalidate the durable unique indexes.
+        Read the collection once instead, build and validate its complete
+        post-image once, then write all changed rows as a single transaction.
+
+        The physical row key is retained from SQLite rather than recomputed
+        from the logical ``_id``.  That keeps updates compatible with legacy
+        databases whose row keys predate typed physical IDs.
+        """
+
         self.create_collection(collection)
+        specs = self.get_index_specs(collection)
+        table = _quote_identifier(collection)
         conn = self._connect()
         try:
-            rows = conn.execute(
-                "SELECT data FROM {0}".format(_quote_identifier(collection))
-            ).fetchall()
-            return [_json_loads(row[0]) for row in rows]
+            # Acquire SQLite's writer reservation before selecting candidates.
+            # Together with TinyMongo's cross-process write lock this keeps the
+            # validated post-image and the committed rows in the same atomic
+            # read-check-write unit.
+            conn.execute("BEGIN IMMEDIATE")
+            rows = conn.execute("SELECT _id, data FROM {0}".format(table)).fetchall()
+            originals = [(row_id, _json_loads(data)) for row_id, data in rows]
+
+            matches = [
+                (row_id, document)
+                for row_id, document in originals
+                if matches_filter(document, filter_doc)
+            ]
+            if not multi:
+                matches = matches[:1]
+
+            replacements = []
+            replacement_by_row_id = {}
+            modified_count = 0
+            from .tinymongo import _update_document_modified
+
+            for row_id, document in matches:
+                updated = self.apply_update(document, update_doc)
+                if validate_document is not None:
+                    validate_document(updated)
+                modified_count += int(
+                    _update_document_modified(document, updated, update_doc)
+                )
+                if storage_values_equal(updated, document):
+                    continue
+                replacements.append((row_id, document, updated))
+                replacement_by_row_id[row_id] = updated
+
+            if not matches:
+                conn.rollback()
+                return [], 0, 0
+
+            post_image = [
+                replacement_by_row_id.get(row_id, document)
+                for row_id, document in originals
+            ]
+            validate_unique_documents(post_image, specs)
+
+            if replacements:
+                conn.executemany(
+                    "UPDATE {0} SET data = ? WHERE _id = ?".format(table),
+                    [
+                        (_json_dumps(updated), row_id)
+                        for row_id, _old, updated in replacements
+                    ],
+                )
+                conn.commit()
+            else:
+                conn.rollback()
+            return (
+                [original["_id"] for _row_id, original, _updated in replacements],
+                len(matches),
+                modified_count,
+            )
+        except sqlite3.IntegrityError as exc:
+            conn.rollback()
+            raise DuplicateKeyError(str(exc))
+        except Exception:
+            conn.rollback()
+            raise
         finally:
             conn.close()
 
@@ -2746,6 +3226,11 @@ class SQLiteTableBackend(TableBackend):
         self.create_collection(collection)
         existing = self._check_index_compatibility(collection, spec)
         if existing is not None:
+            conn = self._connect()
+            try:
+                self._ensure_type_index_on_connection(conn, collection, existing)
+            finally:
+                conn.close()
             return existing.name
         if spec.unique:
             validate_unique_documents(self.find(collection, {}), [spec])
@@ -2761,8 +3246,7 @@ class SQLiteTableBackend(TableBackend):
             try:
                 self._ensure_index_catalog(conn)
                 conn.execute(
-                    "CREATE {0}INDEX IF NOT EXISTS {1} ON {2} "
-                    "({3})".format(
+                    "CREATE {0}INDEX IF NOT EXISTS {1} ON {2} ({3})".format(
                         "UNIQUE " if spec.unique else "",
                         _quote_identifier(name),
                         _quote_identifier(collection),
@@ -2776,6 +3260,18 @@ class SQLiteTableBackend(TableBackend):
                             _quote_identifier(name + "_lookup"),
                             _quote_identifier(collection),
                             path,
+                        )
+                    )
+                if "." not in spec.field:
+                    type_expression = "json_type(data, {0})".format(path)
+                    conn.execute(
+                        "CREATE INDEX IF NOT EXISTS {name} ON {table} ({expression}) "
+                        "WHERE {expression} IN ('array', 'object')".format(
+                            name=_quote_identifier(
+                                self._type_index_name(collection, spec)
+                            ),
+                            table=_quote_identifier(collection),
+                            expression=type_expression,
                         )
                     )
                 conn.execute(
@@ -2792,6 +3288,9 @@ class SQLiteTableBackend(TableBackend):
                     ),
                 )
                 conn.commit()
+                with self._sqlite_state_lock:
+                    self._ready_type_indexes.add((collection, spec.name))
+                    self._query_index_cache.pop(collection, None)
             except sqlite3.IntegrityError as exc:
                 raise DuplicateKeyError(str(exc))
         finally:
@@ -2826,12 +3325,20 @@ class SQLiteTableBackend(TableBackend):
                 )
             )
             conn.execute(
+                "DROP INDEX IF EXISTS {0}".format(
+                    _quote_identifier(self._type_index_name(collection, spec))
+                )
+            )
+            conn.execute(
                 "DELETE FROM {0} WHERE collection_name = ? AND index_name = ?".format(
                     _quote_identifier(self.index_catalog_table)
                 ),
                 (collection, spec.name),
             )
             conn.commit()
+            with self._sqlite_state_lock:
+                self._ready_type_indexes.discard((collection, spec.name))
+                self._query_index_cache.pop(collection, None)
         finally:
             conn.close()
 
@@ -3856,8 +4363,9 @@ class RemoteSQLTableBackend(TableBackend):
 
         self._execute(
             conn,
-            "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS "
-            "data_ordered {1} NULL".format(table, self.ordered_data_type),
+            "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS data_ordered {1} NULL".format(
+                table, self.ordered_data_type
+            ),
         )
 
     def drop_collection(self, collection):
@@ -4351,8 +4859,7 @@ class PostgresTableBackend(RemoteSQLTableBackend):
         else:
             path = ", ".join(_sql_literal(part) for part in spec.field.split("."))
             expression = (
-                "(COALESCE(jsonb_extract_path(data, {0}), "
-                "'null'::jsonb))".format(path)
+                "(COALESCE(jsonb_extract_path(data, {0}), 'null'::jsonb))".format(path)
             )
         self._execute(
             conn,
@@ -4400,7 +4907,7 @@ class PostgresTableBackend(RemoteSQLTableBackend):
             ", {0}".format(self.placeholder) for _ in unique_specs
         )
         sql = (
-            "INSERT INTO {0} (_id, data, data_ordered{1}) " "VALUES ({2}, {3}, {2}{4})"
+            "INSERT INTO {0} (_id, data, data_ordered{1}) VALUES ({2}, {3}, {2}{4})"
         ).format(
             self._quote(self._table_name(collection)),
             token_columns,
@@ -4724,7 +5231,7 @@ class MySQLTableBackend(RemoteSQLTableBackend):
             ", {0}".format(self.placeholder) for _ in unique_specs
         )
         sql = (
-            "INSERT INTO {0} (_id, data, data_ordered{1}) " "VALUES ({2}, {2}, {2}{3})"
+            "INSERT INTO {0} (_id, data, data_ordered{1}) VALUES ({2}, {2}, {2}{3})"
         ).format(
             self._quote(self._table_name(collection)),
             token_columns,

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -72,6 +72,7 @@ from .indexes import (
     emit_index_plan_warnings,
     index_catalog_id,
     index_spec_signature,
+    index_tokens,
     parse_index_spec,
     plan_index_models,
     validate_unique_documents,
@@ -187,38 +188,101 @@ def _duplicate_write_error(collection, index, document, spec=None, error=None):
     }
 
 
-def _first_unique_conflict(existing_documents, document, specs):
-    """Return the first unique index violated by ``document``, if any."""
+def _insert_id_state(existing_documents):
+    """Build the typed identity lookup used by bulk-insert planning.
+
+    Valid storage documents always have a recursive BSON identity key.  The
+    fallback list keeps this internal helper correct for unsupported values as
+    well, without making ordinary batches pay for pairwise comparisons.
+    """
+
+    identities = set()
+    fallback_ids = []
+    all_ids = []
+    for document in existing_documents:
+        value = document["_id"]
+        identity = bson_value_identity_key(value)
+        if identity is None:
+            fallback_ids.append(value)
+        else:
+            identities.add(identity)
+        all_ids.append(value)
+    return identities, fallback_ids, all_ids
+
+
+def _unique_insert_state(existing_documents, specs):
+    """Build one token-to-owner map for each unique index in ``specs``."""
+
+    states = []
     for spec in specs:
         if not spec.unique:
             continue
-        try:
-            validate_unique_documents(existing_documents + [document], [spec])
-        except DuplicateKeyError as error:
-            return spec, error
-    return None, None
+        owners = {}
+        existing_error = None
+        for document in existing_documents:
+            for token in index_tokens(document, spec.field):
+                if token in owners and existing_error is None:
+                    # A valid index cannot normally begin in this state.  If a
+                    # legacy or custom backend does, preserve the exact error
+                    # text and first-conflict ordering of the prior validator.
+                    try:
+                        validate_unique_documents(existing_documents, [spec])
+                    except DuplicateKeyError as error:
+                        existing_error = error
+                owners.setdefault(token, document)
+        states.append((spec, owners, existing_error))
+    return states
 
 
 def _plan_insert_many(collection, documents, existing_documents, specs, ordered):
     """Split a batch into inserts and duplicate-key write errors."""
-    existing_ids = [document["_id"] for document in existing_documents]
+    id_identities, fallback_ids, all_ids = _insert_id_state(existing_documents)
+    unique_states = _unique_insert_state(existing_documents, specs)
     accepted = []
     write_errors = []
 
     for index, document in enumerate(documents):
         duplicate_error = None
-        if any(bson_values_equal(document["_id"], value) for value in existing_ids):
+        value = document["_id"]
+        identity = bson_value_identity_key(value)
+        if identity is None:
+            duplicate_id = any(
+                bson_values_equal(value, existing) for existing in all_ids
+            )
+        elif identity in id_identities:
+            duplicate_id = True
+        else:
+            # Storage validation normally makes this list empty.  Retain the
+            # exact comparison fallback for direct callers of the planner.
+            duplicate_id = any(
+                bson_values_equal(value, existing) for existing in fallback_ids
+            )
+
+        if duplicate_id:
             duplicate_error = _duplicate_write_error(collection, index, document)
         else:
-            spec, error = _first_unique_conflict(existing_documents, document, specs)
-            if spec is not None:
-                duplicate_error = _duplicate_write_error(
-                    collection,
-                    index,
-                    document,
-                    spec=spec,
-                    error=error,
+            candidate_tokens = []
+            for spec, owners, existing_error in unique_states:
+                tokens = index_tokens(document, spec.field)
+                candidate_tokens.append((owners, tokens))
+                owner = next(
+                    (owners[token] for token in tokens if token in owners), None
                 )
+                error = existing_error
+                if owner is not None and error is None:
+                    try:
+                        validate_unique_documents([owner, document], [spec])
+                    except DuplicateKeyError as conflict:
+                        error = conflict
+                if error is not None:
+                    duplicate_error = _duplicate_write_error(
+                        collection,
+                        index,
+                        document,
+                        spec=spec,
+                        error=error,
+                    )
+                    break
 
         if duplicate_error is not None:
             write_errors.append(duplicate_error)
@@ -226,8 +290,14 @@ def _plan_insert_many(collection, documents, existing_documents, specs, ordered)
                 break
         else:
             accepted.append(document)
-            existing_documents.append(document)
-            existing_ids.append(document["_id"])
+            if identity is None:
+                fallback_ids.append(value)
+            else:
+                id_identities.add(identity)
+            all_ids.append(value)
+            for owners, tokens in candidate_tokens:
+                for token in tokens:
+                    owners[token] = document
 
     return accepted, write_errors
 
@@ -261,7 +331,12 @@ def _execute_engine_insert_many(
         if not accepted:
             return [], accepted, write_errors
         try:
-            results = engine.insert_many(
+            insert_prevalidated = getattr(
+                engine,
+                "insert_many_prevalidated",
+                engine.insert_many,
+            )
+            results = insert_prevalidated(
                 collection.tablename,
                 accepted,
                 bypass_document_validation=bypass_document_validation is True,
@@ -2792,7 +2867,24 @@ class TinyMongoCollection(object):
         upsert = kwargs.get("upsert") is True
 
         if self.parent.engine is not None:
-            matches = self.parent.engine.find(self.tablename, query, limit=1)
+            update_with_result = getattr(
+                self.parent.engine,
+                "update_many_with_result",
+                None,
+            )
+            if callable(update_with_result):
+                matched_count, modified_count = update_with_result(
+                    self.tablename,
+                    query,
+                    doc,
+                    multi=False,
+                    validate_document=self._validate_storage_document,
+                )
+                if matched_count or not upsert:
+                    return _update_result(matched_count, modified_count)
+                matches = []
+            else:
+                matches = self.parent.engine.find(self.tablename, query, limit=1)
             if not matches:
                 if upsert:
                     inserted = _document_for_upsert(query, doc)
@@ -2898,7 +2990,24 @@ class TinyMongoCollection(object):
         upsert = kwargs.get("upsert") is True
 
         if self.parent.engine is not None:
-            matches = self.parent.engine.find(self.tablename, query)
+            update_with_result = getattr(
+                self.parent.engine,
+                "update_many_with_result",
+                None,
+            )
+            if callable(update_with_result):
+                matched_count, modified_count = update_with_result(
+                    self.tablename,
+                    query,
+                    doc,
+                    multi=True,
+                    validate_document=self._validate_storage_document,
+                )
+                if matched_count or not upsert:
+                    return _update_result(matched_count, modified_count)
+                matches = []
+            else:
+                matches = self.parent.engine.find(self.tablename, query)
             if not matches and upsert:
                 inserted = _document_for_upsert(query, doc)
                 self._validate_storage_document(inserted)


### PR DESCRIPTION
## Summary

This PR substantially speeds up TinyMongo's SQLite backend while preserving its MongoDB-compatible document semantics.

It adds fast paths for bulk inserts, bulk updates, exact `_id` lookups, and indexed equality queries. It also adds a reproducible comparison harness for TinyMongo SQLite, raw SQLite, and a real MongoDB server.

## What changed

### Bulk writes

- Replace pairwise duplicate planning during `insert_many()` with typed BSON identity maps and per-unique-index token maps.
- Add a prevalidated SQLite batch-insert path that writes one prepared batch in one transaction.
- Add a transactional SQLite bulk-update path that scans once, applies and validates all post-images, performs one `executemany()`, and commits once.
- Preserve ordered/unordered bulk error behavior, exact BSON identity rules, unique-index enforcement, rollback guarantees, and PyMongo-shaped result counts.

### Reads and indexes

- Add direct primary-key reads for exact `_id` and `$eq` filters.
- Reuse the direct path for `find`, `find_one`, projections, limits, and counts.
- Cache one-time SQLite initialization and collection readiness while recovering safely from externally removed tables.
- Cache index metadata with SQLite schema-version checks.
- Use scalar expression indexes for exact equality queries and indexed counts.
- Narrow array/object candidates with companion indexes and `json_each` before applying TinyMongo's exact BSON matcher.
- Restore missing native indexes from catalog metadata and allow real storage or migration failures to surface instead of silently falling back.

### Validation and documentation

- Add focused regression coverage for bulk planning, transactional updates, typed IDs, indexed reads, projections, limits, external schema changes, rollback, and sync/async parity.
- Add `bench_sqlite_comparison.py` for side-by-side TinyMongo SQLite, raw SQLite, and MongoDB measurements.
- Record actual SQLite durability settings and explicitly run MongoDB with `WriteConcern(w=1, j=True)`, asserting that writes are acknowledged.
- Document the methodology, storage caveats, before/after results, and implementation notes.

## Local performance snapshot

On the same machine and workload, the existing 1,000-document SQLite benchmark changed approximately as follows:

- batch inserts: 566 to 15,046 documents/second (~27x)
- point lookup average: 1.821 ms to 0.431 ms (~4.2x lower latency)
- update of 100 documents: 2.984 s to 0.023 s (~130x faster)

The 10,000-document comparison is documented in `docs/BENCHMARKS.md`. Raw SQLite remains a lower-bound comparison because it does not implement TinyMongo's BSON, query, validation, or update semantics.

## Validation

- Full unit suite: 3,562 passed, 1 skipped
- Strict coverage run: 100% statements and branches
- Focused SQLite performance/regression tests: 32 passed
- Ruff: passed
- Black: passed
- Python compilation and Python 3.9 grammar checks: passed
- `git diff --check`: passed
- Real MongoDB 8.0 comparison: passed with acknowledged, journaled writes
