### PR TITLE
Preserve replacement upsert IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
   cached without losing recovery from external collection drops.
 
 ### Fixed
+- **TM-039:** Replacement upserts now retain an `_id` pinned by a top-level
+  direct value or sole `$eq` predicate, return that exact value through
+  `upserted_id`, and leave the inserted document findable through the caller's
+  chosen key. Conflicting replacement IDs fail with MongoDB's immutable-field
+  code instead of silently inserting under the wrong key, and stored
+  replacements keep `_id` first.
 - Update and delete operations now expose PyMongo-shaped reply mappings through
   `raw_result`, including `n`, `nModified`, `updatedExisting`, `upserted`, and
   `ok` where applicable. Counts and upsert IDs are derived from that shared

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -200,6 +200,13 @@ with the follow-up audit of his
   measured predicate set: `$exists`, `$type`, `$ne`, `$mod`, `$all`, `$size`,
   and document-field `$not`.
 
+#### Mike's [TM-039 replacement-upsert follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5174549635)
+
+- [x] **TM-039:** Preserve an `_id` pinned by a replacement-upsert top-level
+  direct value or sole `$eq` predicate across every backend and synchronous or
+  asynchronous client, including the returned `upserted_id` and immediate
+  lookup by the same key.
+
 - [x] **Remote SQL numeric uniqueness:** Persist versioned, fixed-width digests
   of canonical BSON scalar tokens for PostgreSQL and MariaDB/MySQL unique
   indexes. Native constraints now enforce exact cross-process equality for

--- a/tests/contracts/test_crud_contract.py
+++ b/tests/contracts/test_crud_contract.py
@@ -2,10 +2,20 @@
 
 import pytest
 
+from tinymongo.errors import WriteError as TinyMongoWriteError
+
 from .support import observe
 
 
 pytestmark = pytest.mark.contract
+
+_WRITE_ERRORS = (TinyMongoWriteError,)
+try:
+    from pymongo.errors import WriteError as PyMongoWriteError
+except ImportError:  # pragma: no cover - optional dependency guard
+    pass
+else:
+    _WRITE_ERRORS += (PyMongoWriteError,)
 
 
 def test_insert_query_sort_and_count(contract_target):
@@ -106,6 +116,86 @@ def test_replace_upsert_and_delete_metadata(contract_target):
         "name": "Grace",
         "active": True,
     }
+
+
+@pytest.mark.parametrize(
+    ("query", "pinned_id"),
+    [
+        ({"_id": 77}, 77),
+        ({"_id": {"$eq": "pinned-key"}}, "pinned-key"),
+        ({"_id": 88, "state": "missing"}, 88),
+        ({"_id": None}, None),
+    ],
+)
+def test_replace_upsert_preserves_equality_bound_id(contract_target, query, pinned_id):
+    collection = contract_target.collection
+    replacement = {"value": 7}
+
+    result = collection.replace_one(query, replacement, upsert=True)
+
+    assert replacement == {"value": 7}
+    assert result.raw_result == {
+        "n": 1,
+        "nModified": 0,
+        "ok": 1.0,
+        "updatedExisting": False,
+        "upserted": pinned_id,
+    }
+    expected_matched = 1 if pinned_id is None else 0
+    assert (result.matched_count, result.modified_count) == (expected_matched, 0)
+    assert result.did_upsert is True
+    assert result.upserted_id == pinned_id
+    assert collection.find_one({"_id": pinned_id}) == {
+        "_id": pinned_id,
+        "value": 7,
+    }
+
+
+def test_replace_upsert_stores_id_first(contract_target):
+    collection = contract_target.collection
+    replacement = {"value": 7}
+
+    result = collection.replace_one({"_id": 77}, replacement, upsert=True)
+    stored = collection.find_one({"_id": 77})
+
+    assert result.upserted_id == 77
+    assert list(stored) == ["_id", "value"]
+
+
+def test_replace_upsert_accepts_bson_equal_filter_and_replacement_ids(
+    contract_target,
+):
+    collection = contract_target.collection
+    replacement = {"value": 7, "_id": 1.0}
+
+    result = collection.replace_one(
+        {"_id": 1},
+        replacement,
+        upsert=True,
+    )
+    stored = collection.find_one({"_id": 1})
+
+    assert list(replacement) == ["value", "_id"]
+    assert type(result.upserted_id) is float
+    assert type(stored["_id"]) is float
+    assert list(stored) == ["_id", "value"]
+    assert stored["value"] == 7
+
+
+def test_replace_upsert_rejects_conflicting_filter_and_replacement_ids(
+    contract_target,
+):
+    collection = contract_target.collection
+
+    with pytest.raises(_WRITE_ERRORS) as caught:
+        collection.replace_one(
+            {"_id": "filter-id"},
+            {"_id": "replacement-id", "value": 7},
+            upsert=True,
+        )
+
+    assert caught.value.code == 66
+    assert collection.count_documents({}) == 0
 
 
 def test_duplicate_id_has_a_shared_error_category(contract_target):

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -1118,6 +1118,37 @@ def _document_for_upsert(query, update_doc):
     return _apply_update_document(document, update_doc)
 
 
+def _replacement_document_for_upsert(query, replacement):
+    """Preserve a top-level direct or sole-``$eq`` ``_id`` during upsert."""
+
+    query_id = _MISSING
+    if isinstance(query, Mapping) and "_id" in query:
+        query_id = _direct_id_equality({"_id": query["_id"]})
+
+    replacement_id = replacement.get("_id", _MISSING)
+    if (
+        query_id is not _MISSING
+        and replacement_id is not _MISSING
+        and not bson_values_equal(query_id, replacement_id)
+    ):
+        _raise_write_error(
+            "After applying the update, the (immutable) field '_id' was found "
+            "to have been altered",
+            code=66,
+        )
+
+    inserted_id = replacement_id
+    if inserted_id is _MISSING:
+        inserted_id = query_id
+    if inserted_id is _MISSING:
+        inserted_id = _generate_document_id()
+
+    # MongoDB stores ``_id`` first even when it was inferred from the filter.
+    inserted = {"_id": copy.deepcopy(inserted_id)}
+    inserted.update(copy.deepcopy(replacement))
+    return inserted
+
+
 def _simple_equality_filter(_filter):
     if not isinstance(_filter, Mapping) or len(_filter) != 1:
         return None
@@ -3122,9 +3153,7 @@ class TinyMongoCollection(object):
             item = self.parent.engine.find_one(self.tablename, query)
             if item is None:
                 if kwargs.get("upsert") is True:
-                    inserted = copy.deepcopy(replacement)
-                    if "_id" not in inserted:
-                        inserted["_id"] = _generate_document_id()
+                    inserted = _replacement_document_for_upsert(query, replacement)
                     self._validate_storage_document(inserted)
                     self.parent.engine.validate_unique_post_image(
                         self.tablename,
@@ -3185,9 +3214,7 @@ class TinyMongoCollection(object):
                 item = self.table.get(allcond)
             if item is None:
                 if kwargs.get("upsert") is True:
-                    inserted = copy.deepcopy(replacement)
-                    if "_id" not in inserted:
-                        inserted["_id"] = _generate_document_id()
+                    inserted = _replacement_document_for_upsert(query, replacement)
                     self._validate_storage_document(inserted)
                     self._validate_unique_post_image(self.table.all() + [inserted])
                     self.table.insert(inserted)


### PR DESCRIPTION
## Summary

- preserve a replacement-upsert `_id` supplied by a top-level direct filter value or sole `$eq` predicate
- reject conflicting filter and replacement IDs with MongoDB-compatible write error code 66
- compare candidate IDs with BSON equality, retain the replacement's BSON numeric representation, and store `_id` first
- add shared sync/async contracts for every TinyMongo backend and real MongoDB
- record TM-039 as complete in the changelog and roadmap

## Why

TM-039 exposed a silent compatibility bug in `replace_one(..., upsert=True)`. Given:

```python
collection.replace_one({"_id": 77}, {"value": 7}, upsert=True)
```

MongoDB inserts the document under `_id=77`, reports `upserted_id == 77`, and makes the document immediately findable by the same filter. TinyMongo instead generated a new `ObjectId`, acknowledged the write, and left the document unreachable through the caller's chosen key.

The two replacement-upsert storage paths constructed their insert documents independently and only consulted the replacement. This PR moves that construction into one shared helper.

## Compatibility details

The contracts cover:

- direct integer, string, and explicit-null IDs
- sole `$eq` predicates
- an `_id` predicate combined with another top-level condition
- exact PyMongo-shaped `raw_result`, `upserted_id`, `did_upsert`, matched count, and modified count
- canonical `_id`-first storage
- BSON-equivalent numeric IDs such as filter `1` and replacement `1.0`
- atomic code-66 failure when the filter and replacement pin different IDs
- caller replacement-document immutability

This intentionally implements Mike's focused TM-039 report. More complex logical inference through `$and`, singleton `$in`, or mixed operator documents remains part of the broader replacement/upsert edge work in #101.

## Validation

- `coverage run --branch -m pytest`: **3,632 passed, 1 skipped**
- coverage report: **100% statements and branches**
- focused local sync/async backend matrix: **80 passed**
- focused real MongoDB 8.2 sync/async contract: **16 passed**
- `ruff check .`
- `black --check .`
- `mypy --ignore-missing-imports tinymongo`
- `python -m compileall -q tinymongo tests/contracts/test_crud_contract.py`

Addresses TM-039 in #136.
