### PR TITLE
Fix TM-040 SQLite batch scaling with targeted conflict probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   collection-listing hints, and runs a pinned real-Beanie CRUD smoke contract.
 - A reproducible comparison benchmark now runs the same JSON-document workload
   against TinyMongo SQLite, raw `sqlite3`, and an optional real MongoDB server.
+- A TM-040 SQLite scaling benchmark reports successive fixed-size insert
+  windows, first-to-last throughput, and the number of existing rows decoded
+  during duplicate preflight.
 
 ### Changed
 - SQLite bulk inserts now use BSON-aware identity sets and one-pass unique-index
@@ -20,6 +23,12 @@
   declared scalar indexes use bounded reads plus a companion candidate index
   for array and object values. One-time migration, WAL, and collection setup is
   cached without losing recovery from external collection drops.
+- **TM-040:** Repeated SQLite `insert_many()` batches without user-created
+  unique indexes now probe only incoming `_id` candidates through the native
+  primary key instead of rereading and BSON-decoding the entire collection.
+  BSON-aware ordered and unordered planning remains shared, while unique
+  indexes, Decimal128 IDs, and non-enumerable legacy IDs retain the conservative
+  full-scan fallback for released legacy-store formats.
 
 ### Fixed
 - **TM-039:** Replacement upserts now retain an `_id` pinned by a top-level

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,6 +207,23 @@ with the follow-up audit of his
   asynchronous client, including the returned `upserted_id` and immediate
   lookup by the same key.
 
+#### Mike's [TM-040 SQLite batch-scaling follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5186712357)
+
+- [x] **TM-040:** Replace repeated collection-wide SQLite duplicate preflights
+  with chunked primary-key probes for the incoming `_id` candidates when no
+  user-created unique index requires complete token state. Preserve exact BSON
+  identity, ordered and unordered partial failures, native-race retries, and
+  compatibility with released legacy-store formats through conservative
+  fallbacks.
+- [x] Add a fixed-200-batch scaling benchmark that reports successive
+  collection-size windows and decoded existing-row counts. On the local
+  30,000-document comparison, the targeted path reduced total time from
+  18.90 seconds to 3.94 seconds and removed a 5.35x first-to-last slowdown.
+
+The normalized unique-token ledger remains a possible later optimization for
+bulk inserts into collections with user-created unique indexes. TM-040's
+measured no-index application path no longer needs that larger migration.
+
 - [x] **Remote SQL numeric uniqueness:** Persist versioned, fixed-width digests
   of canonical BSON scalar tokens for PostgreSQL and MariaDB/MySQL unique
   indexes. Native constraints now enforce exact cross-process equality for

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -6,6 +6,40 @@ for making universal performance claims.
 
 ## SQLite performance work: 2026-08-04
 
+### Fixed-size batch scaling (TM-040)
+
+The earlier benchmark inserted one large batch, which could not expose the
+collection-size curve reported by Mike Kennedy. The TM-040 benchmark instead
+inserts 200 documents per call and reports successive collection-size windows:
+
+```bash
+.venv/bin/python tests/benchmarks/bench_sqlite_insert_scaling.py \
+  --docs 75000 \
+  --batch-size 200 \
+  --window-size 7600 \
+  --repeats 3 \
+  --json-output /tmp/tinymongo-tm040-scaling.json
+```
+
+An apples-to-apples 30,000-document run compared `master` immediately before
+TM-040 at commit `673734f` with the targeted primary-key preflight. Each side
+used Python 3.9.6 on `macOS-26.2-arm64-arm-64bit`, the same interpreter,
+document generator, batch size, decode instrumentation, and host:
+
+| SQLite measurement | Total s | Overall docs/s | First-window docs/s | Last-window docs/s | First/last slowdown | Existing rows decoded |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Before targeted preflight | 18.904 | 1,587 | 5,005 | 935 | 5.35x | 2,235,000 |
+| After targeted preflight | 3.939 | 7,615 | 7,696 | 7,090 | 1.09x | 0 |
+
+The 75,000-document, three-run result after TM-040 had a 10.966-second median,
+6,839 overall documents per second, and a 1.25x first-to-last ratio. All three
+runs decoded zero existing payloads during insert preflight. These results
+cover the ordinary no-unique-index path; collections with user-created unique
+indexes deliberately retain complete Python validation until an exact
+multikey-token ledger is justified.
+
+### SQLite, raw SQLite, and MongoDB comparison
+
 The focused comparison uses the same 10,000 JSON-shaped documents and performs:
 
 - One `insert_many()` batch.

--- a/tests/benchmarks/bench_sqlite_insert_scaling.py
+++ b/tests/benchmarks/bench_sqlite_insert_scaling.py
@@ -1,0 +1,222 @@
+"""Measure successive fixed-size SQLite ``insert_many`` batches.
+
+TM-040 is about the shape of the throughput curve, not one large-batch
+average. This local benchmark therefore reports each collection-size window
+and counts how many existing payloads the insert preflight BSON-decodes.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import platform
+import statistics
+import sys
+import tempfile
+import time
+
+import tinymongo as tm
+import tinymongo.table_backends as table_backends
+
+
+def _documents(start, count):
+    return [
+        {
+            "_id": "doc-{0}".format(index),
+            "show_id": index % 1000,
+            "title": "Episode {0}".format(index),
+            "published": index,
+            "payload": {"tags": ["python", "database"], "active": True},
+        }
+        for index in range(start, start + count)
+    ]
+
+
+def _run_once(documents, batch_size, window_size, work_root=None):
+    batch_results = []
+    decoded_existing_rows = 0
+    original_loads = table_backends._json_loads
+
+    def tracked_loads(value):
+        nonlocal decoded_existing_rows
+        decoded_existing_rows += 1
+        return original_loads(value)
+
+    with tempfile.TemporaryDirectory(
+        prefix="tinymongo-tm040-",
+        dir=work_root,
+    ) as folder:
+        client = tm.TinyMongoClient(folder, backend="sqlite")
+        try:
+            collection = client.benchmark.records
+            table_backends._json_loads = tracked_loads
+            started = time.perf_counter()
+            try:
+                for offset in range(0, documents, batch_size):
+                    count = min(batch_size, documents - offset)
+                    batch_documents = _documents(offset, count)
+                    batch_started = time.perf_counter()
+                    result = collection.insert_many(batch_documents)
+                    seconds = time.perf_counter() - batch_started
+                    if len(result.inserted_ids) != count:
+                        raise AssertionError("TinyMongo inserted the wrong batch size")
+                    batch_results.append(
+                        {
+                            "start": offset,
+                            "end": offset + count,
+                            "documents": count,
+                            "seconds": seconds,
+                        }
+                    )
+            finally:
+                total_seconds = time.perf_counter() - started
+                table_backends._json_loads = original_loads
+
+            conn = collection.parent.engine._connect()
+            try:
+                stored = conn.execute('SELECT COUNT(*) FROM "records"').fetchone()[0]
+            finally:
+                conn.close()
+            if stored != documents:
+                raise AssertionError(
+                    "TinyMongo stored {0} documents, expected {1}".format(
+                        stored,
+                        documents,
+                    )
+                )
+        finally:
+            table_backends._json_loads = original_loads
+            client.close()
+
+    windows = []
+    for window_start in range(0, documents, window_size):
+        window_end = min(window_start + window_size, documents)
+        batches = [
+            batch
+            for batch in batch_results
+            if batch["start"] >= window_start and batch["end"] <= window_end
+        ]
+        seconds = sum(batch["seconds"] for batch in batches)
+        count = sum(batch["documents"] for batch in batches)
+        windows.append(
+            {
+                "start": window_start,
+                "end": window_end,
+                "documents": count,
+                "seconds": seconds,
+                "docs_per_second": count / seconds if seconds else 0.0,
+            }
+        )
+
+    return {
+        "total_seconds": total_seconds,
+        "docs_per_second": documents / total_seconds if total_seconds else 0.0,
+        "decoded_existing_rows": decoded_existing_rows,
+        "windows": windows,
+    }
+
+
+def run_benchmark(documents, batch_size, window_size, repeats, work_root=None):
+    runs = [
+        _run_once(documents, batch_size, window_size, work_root=work_root)
+        for _ in range(repeats)
+    ]
+    windows = []
+    for index in range(len(runs[0]["windows"])):
+        samples = [run["windows"][index] for run in runs]
+        median_seconds = statistics.median(sample["seconds"] for sample in samples)
+        windows.append(
+            {
+                "start": samples[0]["start"],
+                "end": samples[0]["end"],
+                "documents": samples[0]["documents"],
+                "median_seconds": median_seconds,
+                "median_docs_per_second": (
+                    samples[0]["documents"] / median_seconds if median_seconds else 0.0
+                ),
+            }
+        )
+
+    median_total_seconds = statistics.median(run["total_seconds"] for run in runs)
+    slowdowns = [
+        run["windows"][0]["docs_per_second"] / run["windows"][-1]["docs_per_second"]
+        for run in runs
+        if run["windows"][-1]["docs_per_second"]
+    ]
+    return {
+        "documents": documents,
+        "batch_size": batch_size,
+        "window_size": window_size,
+        "repeats": repeats,
+        "environment": {
+            "platform": platform.platform(),
+            "python": sys.version,
+        },
+        "median_total_seconds": median_total_seconds,
+        "median_docs_per_second": (
+            documents / median_total_seconds if median_total_seconds else 0.0
+        ),
+        "first_to_last_slowdown": statistics.median(slowdowns),
+        "decoded_existing_rows": [run["decoded_existing_rows"] for run in runs],
+        "windows": windows,
+        "runs": runs,
+    }
+
+
+def format_markdown(result):
+    rows = [
+        "| Collection size | Documents | Median seconds | Median docs/s |",
+        "| ---: | ---: | ---: | ---: |",
+    ]
+    for window in result["windows"]:
+        rows.append(
+            "| {start:,}-{end:,} | {documents:,} | {median_seconds:.3f} | "
+            "{median_docs_per_second:,.0f} |".format(**window)
+        )
+    rows.extend(
+        [
+            "",
+            "Median total: {0:.3f}s ({1:,.0f} docs/s)".format(
+                result["median_total_seconds"],
+                result["median_docs_per_second"],
+            ),
+            "First/last slowdown: {0:.2f}x".format(result["first_to_last_slowdown"]),
+            "Existing rows decoded per run: {0}".format(
+                result["decoded_existing_rows"]
+            ),
+        ]
+    )
+    return "\n".join(rows)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--docs", type=int, default=75000)
+    parser.add_argument("--batch-size", type=int, default=200)
+    parser.add_argument("--window-size", type=int, default=7600)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--work-root")
+    parser.add_argument("--json-output")
+    args = parser.parse_args(argv)
+    if min(args.docs, args.batch_size, args.window_size, args.repeats) <= 0:
+        parser.error("document, batch, window, and repeat counts must be positive")
+    if args.window_size % args.batch_size:
+        parser.error("--window-size must be divisible by --batch-size")
+
+    result = run_benchmark(
+        args.docs,
+        args.batch_size,
+        args.window_size,
+        args.repeats,
+        work_root=args.work_root,
+    )
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as handle:
+            json.dump(result, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    print(format_markdown(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bulk_insert_planning.py
+++ b/tests/test_bulk_insert_planning.py
@@ -1,9 +1,14 @@
-"""Focused tests for the linear-time shared insert-many planner."""
+"""Focused tests for shared and backend-targeted insert-many planning."""
 
+from datetime import datetime, timezone
 import importlib
 from types import SimpleNamespace
 
+import pytest
+
 import tinymongo as tm
+import tinymongo.table_backends as table_backends
+from tinymongo.errors import BulkWriteError
 from tinymongo.indexes import IndexSpec
 
 
@@ -167,12 +172,129 @@ def test_engine_insert_many_uses_prevalidated_backend_hook():
     )
 
 
-def test_sqlite_public_bulk_insert_scans_existing_documents_once(
+def test_engine_insert_many_uses_optional_conflict_candidate_hook():
+    class Engine:
+        def __init__(self):
+            self.candidate_calls = []
+
+        def find(self, *_args, **_kwargs):
+            raise AssertionError("the conflict-candidate hook was ignored")
+
+        def get_index_specs(self, _collection):
+            return []
+
+        def find_insert_conflict_candidates(self, collection, documents, specs):
+            self.candidate_calls.append((collection, documents, specs))
+            return [{"_id": "existing"}]
+
+        def insert_many(self, _collection, documents, **_kwargs):
+            return list(range(len(documents)))
+
+    engine = Engine()
+    collection = SimpleNamespace(
+        full_name="app.items",
+        tablename="items",
+        parent=SimpleNamespace(engine=engine),
+    )
+    documents = [{"_id": "existing"}, {"_id": "new"}]
+
+    results, accepted, errors = core._execute_engine_insert_many(
+        collection,
+        documents,
+        ordered=False,
+        bypass_document_validation=False,
+    )
+
+    assert results == [0]
+    assert accepted == [{"_id": "new"}]
+    assert [error["index"] for error in errors] == [0]
+    assert engine.candidate_calls == [("items", documents, [])]
+
+
+def test_sqlite_public_bulk_insert_queries_only_incoming_id_candidates(
     tmp_path,
     monkeypatch,
 ):
     client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
     collection = client.app.items
+    backend = collection.parent.engine
+    collection.insert_one({"_id": "late-conflict"})
+    original_connect = backend._connect
+    statements = []
+
+    def tracked_connect():
+        conn = original_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("ordinary SQLite batches must not scan the collection")
+
+    monkeypatch.setattr(backend, "_connect", tracked_connect)
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    try:
+        documents = [
+            {"_id": "new-{0}".format(index), "value": index} for index in range(1000)
+        ] + [{"_id": "late-conflict"}]
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many(documents, ordered=False)
+        assert caught.value.details["nInserted"] == 1000
+        assert caught.value.details["writeErrors"][0]["index"] == 1000
+        candidate_reads = [
+            statement
+            for statement in statements
+            if statement.startswith('SELECT data FROM "items"')
+        ]
+        assert len(candidate_reads) >= 2
+        assert all(" WHERE _id IN (" in statement for statement in candidate_reads)
+    finally:
+        client.close()
+
+
+def test_sqlite_targeted_preflight_decodes_only_matching_bson_ids(
+    tmp_path,
+    monkeypatch,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.items
+    collection.insert_one({"_id": 1, "value": "existing"})
+    backend = collection.parent.engine
+    original_loads = table_backends._json_loads
+    decoded = []
+
+    def tracked_loads(value):
+        decoded.append(value)
+        return original_loads(value)
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("the BSON identity conflict should use a PK probe")
+
+    monkeypatch.setattr(table_backends, "_json_loads", tracked_loads)
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    documents = [
+        {"_id": 1.0, "value": "numeric duplicate"},
+        {"_id": True, "value": "boolean remains distinct"},
+        {"_id": 2, "value": "new"},
+    ]
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many(documents, ordered=False)
+
+        assert caught.value.details["nInserted"] == 2
+        assert [error["index"] for error in caught.value.details["writeErrors"]] == [0]
+        assert len(decoded) == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_unique_indexes_keep_conservative_insert_preflight(
+    tmp_path,
+    monkeypatch,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.users
+    collection.create_index("email", unique=True)
+    collection.insert_one({"_id": "seed", "email": "taken@example.com"})
     backend = collection.parent.engine
     original_find = backend.find
     calls = []
@@ -183,10 +305,237 @@ def test_sqlite_public_bulk_insert_scans_existing_documents_once(
 
     monkeypatch.setattr(backend, "find", tracked_find)
     try:
-        result = collection.insert_many(
-            [{"_id": index, "value": index} for index in range(100)]
+        with pytest.raises(BulkWriteError):
+            collection.insert_many([{"_id": "duplicate", "email": "taken@example.com"}])
+        assert len(calls) == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_nonunique_indexes_keep_targeted_insert_preflight(
+    tmp_path,
+    monkeypatch,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.users
+    collection.create_index("email")
+    collection.insert_one({"_id": "seed", "email": "seed@example.com"})
+    backend = collection.parent.engine
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("nonunique indexes cannot reject an insert")
+
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    try:
+        result = collection.insert_many([{"_id": "new", "email": "seed@example.com"}])
+        assert result.inserted_ids == ["new"]
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("existing_id", "incoming_id"),
+    [
+        (0, -0.0),
+        (2**60, float(2**60)),
+        (int(1e23), 1e23),
+    ],
+)
+def test_sqlite_targeted_preflight_preserves_exact_numeric_id_duplicates(
+    tmp_path,
+    monkeypatch,
+    existing_id,
+    incoming_id,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.numbers
+    collection.insert_one({"_id": existing_id})
+    backend = collection.parent.engine
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("current numeric IDs should use their typed PK")
+
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many([{"_id": incoming_id}])
+        assert caught.value.details["writeErrors"][0]["index"] == 0
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("existing_id", "incoming_id"),
+    [
+        (True, 1),
+        (2**53 + 1, float(2**53 + 1)),
+        (10**23, 1e23),
+    ],
+)
+def test_sqlite_targeted_preflight_keeps_distinct_numeric_ids_separate(
+    tmp_path,
+    monkeypatch,
+    existing_id,
+    incoming_id,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.numbers
+    collection.insert_one({"_id": existing_id})
+    backend = collection.parent.engine
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("current numeric IDs should use their typed PK")
+
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    try:
+        result = collection.insert_many([{"_id": incoming_id}])
+        assert result.inserted_ids == [incoming_id]
+    finally:
+        client.close()
+
+
+def _insert_legacy_sqlite_row(backend, collection, row_id, document):
+    backend.create_collection(collection)
+    conn = backend._connect()
+    try:
+        conn.execute(
+            'INSERT INTO "{0}" (_id, data) VALUES (?, ?)'.format(collection),
+            (row_id, table_backends._json_dumps(document)),
         )
-        assert len(result.inserted_ids) == 100
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_sqlite_targeted_preflight_finds_legacy_negative_zero(tmp_path, monkeypatch):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.legacy_zero
+    backend = collection.parent.engine
+    _insert_legacy_sqlite_row(
+        backend,
+        collection.tablename,
+        "-0.0",
+        {"_id": -0.0},
+    )
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("enumerable legacy zero aliases should use a PK probe")
+
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    try:
+        with pytest.raises(BulkWriteError):
+            collection.insert_many([{"_id": 0.0}])
+    finally:
+        client.close()
+
+
+def test_sqlite_targeted_preflight_filters_legacy_key_false_positives(
+    tmp_path,
+    monkeypatch,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.legacy_string
+    backend = collection.parent.engine
+    _insert_legacy_sqlite_row(
+        backend,
+        collection.tablename,
+        "1",
+        {"_id": "1"},
+    )
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("the enumerable legacy key should use a PK probe")
+
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    try:
+        result = collection.insert_many([{"_id": 1}])
+        assert result.inserted_ids == [1]
+    finally:
+        client.close()
+
+
+def test_sqlite_decimal_id_uses_safe_legacy_scan_fallback(tmp_path, monkeypatch):
+    Decimal128 = pytest.importorskip("bson").Decimal128
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.legacy_decimal
+    backend = collection.parent.engine
+    _insert_legacy_sqlite_row(
+        backend,
+        collection.tablename,
+        "1",
+        {"_id": 1},
+    )
+    original_find = backend.find
+    calls = []
+
+    def tracked_find(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_find(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "find", tracked_find)
+    try:
+        with pytest.raises(BulkWriteError):
+            collection.insert_many([{"_id": Decimal128("1.00")}])
+        assert len(calls) == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_current_decimal_id_uses_typed_key_for_numeric_alias(
+    tmp_path,
+    monkeypatch,
+):
+    Decimal128 = pytest.importorskip("bson").Decimal128
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.current_decimal
+    collection.insert_one({"_id": Decimal128("1.00")})
+    backend = collection.parent.engine
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("current Decimal128 rows share the typed numeric key")
+
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    try:
+        with pytest.raises(BulkWriteError):
+            collection.insert_many([{"_id": 1}])
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("existing_id", "incoming_id"),
+    [
+        (
+            datetime(2026, 8, 4, 12, 30),
+            datetime(2026, 8, 4, 12, 30, tzinfo=timezone.utc),
+        ),
+        (
+            {"first": 1, "second": 2},
+            {"first": 1, "second": 2},
+        ),
+    ],
+)
+def test_sqlite_non_enumerable_ids_use_legacy_scan_fallback(
+    tmp_path,
+    monkeypatch,
+    existing_id,
+    incoming_id,
+):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app.legacy_fallback
+    collection.insert_one({"_id": existing_id})
+    backend = collection.parent.engine
+    original_find = backend.find
+    calls = []
+
+    def tracked_find(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_find(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "find", tracked_find)
+    try:
+        with pytest.raises(BulkWriteError):
+            collection.insert_many([{"_id": incoming_id}])
         assert len(calls) == 1
     finally:
         client.close()

--- a/tests/test_insert_many_semantics.py
+++ b/tests/test_insert_many_semantics.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 
 import tinymongo
+import tinymongo.table_backends as table_backends
 from tinymongo.asyncio import AsyncTinyMongoClient
 from tinymongo.errors import BulkWriteError, DuplicateKeyError, InvalidDocument
 from tinymongo.tinymongo import TinyMongoCollection
@@ -84,6 +85,116 @@ def test_unordered_insert_many_continues_and_reports_every_duplicate(tmp_path, b
         "last",
     }
     client.close()
+
+
+@pytest.mark.parametrize(
+    ("ordered", "expected_inserted", "expected_errors"),
+    [
+        (True, 1, [1]),
+        (False, 2, [1, 2]),
+    ],
+)
+def test_sqlite_targeted_preflight_preserves_batch_duplicate_semantics(
+    tmp_path,
+    monkeypatch,
+    ordered,
+    expected_inserted,
+    expected_errors,
+):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.targeted
+    collection.insert_one({"_id": "seed"})
+    backend = collection.parent.engine
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("scalar IDs should use targeted SQLite preflight")
+
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    documents = [
+        {"_id": "first"},
+        {"_id": "seed"},
+        {"_id": "first"},
+        {"_id": "last"},
+    ]
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many(documents, ordered=ordered)
+
+        assert caught.value.details["nInserted"] == expected_inserted
+        assert [
+            error["index"] for error in caught.value.details["writeErrors"]
+        ] == expected_errors
+        conn = backend._connect()
+        try:
+            stored = conn.execute('SELECT COUNT(*) FROM "targeted"').fetchone()[0]
+        finally:
+            conn.close()
+        assert stored == expected_inserted + 1
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("ordered", "expected_inserted", "expected_count"),
+    [
+        (True, 1, 3),
+        (False, 2, 4),
+    ],
+)
+def test_sqlite_targeted_preflight_replans_a_native_id_race(
+    tmp_path,
+    monkeypatch,
+    ordered,
+    expected_inserted,
+    expected_count,
+):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.native_race
+    backend = collection.parent.engine
+    collection.insert_one({"_id": "seed"})
+    original_insert_rows = backend._insert_rows
+    attempts = 0
+
+    def racing_insert_rows(collection_name, documents):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            conn = backend._connect()
+            try:
+                conn.execute(
+                    'INSERT INTO "native_race" (_id, data) VALUES (?, ?)',
+                    (
+                        table_backends._physical_id_key("raced"),
+                        table_backends._json_dumps({"_id": "raced"}),
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+            return original_insert_rows(collection_name, documents)
+        return original_insert_rows(collection_name, documents)
+
+    def unexpected_full_scan(*_args, **_kwargs):
+        raise AssertionError("the native-race retry should repeat the PK probe")
+
+    monkeypatch.setattr(backend, "_insert_rows", racing_insert_rows)
+    monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    documents = [{"_id": "first"}, {"_id": "raced"}, {"_id": "last"}]
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many(documents, ordered=ordered)
+
+        assert attempts == 2
+        assert caught.value.details["nInserted"] == expected_inserted
+        assert [error["index"] for error in caught.value.details["writeErrors"]] == [1]
+        conn = backend._connect()
+        try:
+            stored = conn.execute('SELECT COUNT(*) FROM "native_race"').fetchone()[0]
+        finally:
+            conn.close()
+        assert stored == expected_count
+    finally:
+        client.close()
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -59,6 +59,7 @@ _DECIMAL128 = decimal128_type()
 _ID_RATIO_HEX_TAG = "exact-ratio-hex-v1"
 _SAFE_JSON_INTEGER_BITS = 1800
 _SQLITE_UNIQUE_TOKEN_VERSION = 3
+_SQLITE_CONFLICT_QUERY_SIZE = 900
 _REMOTE_UNIQUE_TOKEN_VERSION = 1
 _OBJECT_STORE_SCHEMES = {"s3", "gs", "gcs", "az", "azure", "abfs", "abfss"}
 _PHYSICAL_ID_PREFIX = "__tinymongo_id_v2__:"
@@ -262,6 +263,8 @@ def _physical_id_candidates(value):
                     legacy.append(str(-0.0))
     elif isinstance(value, float) and math.isfinite(value) and value.is_integer():
         legacy.append(str(int(value)))
+        if value == 0:
+            legacy.extend(("0.0", "-0.0"))
 
     return tuple(dict.fromkeys([current] + legacy))
 
@@ -273,6 +276,17 @@ def _requires_legacy_id_scan(value):
         return True
     identity = bson_identity_key(value)
     return identity is not None and identity[0] == "datetime"
+
+
+def _requires_legacy_insert_scan(value):
+    """Return whether an insert preflight cannot enumerate every legacy key."""
+
+    # Decimal128 support arrived after typed physical IDs. An incoming decimal
+    # can still equal an int/float row written by a released pre-typed codec,
+    # whose string key may not preserve the decimal's scale.
+    return _requires_legacy_id_scan(value) or (
+        _DECIMAL128 is not None and isinstance(value, _DECIMAL128)
+    )
 
 
 def _validate_physical_ids(existing_documents, new_documents):
@@ -2356,6 +2370,48 @@ class SQLiteTableBackend(TableBackend):
         self.validate_unique_post_image(collection, existing_docs + docs)
         _validate_physical_ids(existing_docs, docs)
         return self._insert_rows(collection, docs)
+
+    def find_insert_conflict_candidates(self, collection, documents, specs):
+        """Load SQLite rows whose primary keys can conflict with a batch.
+
+        ``None`` asks the collection planner to use its conservative full
+        scan. Candidate rows may be a superset; the shared BSON-aware planner
+        remains the semantic authority.
+        """
+
+        if any(spec.unique for spec in specs) or any(
+            _requires_legacy_insert_scan(document["_id"]) for document in documents
+        ):
+            return None
+
+        candidates = tuple(
+            dict.fromkeys(
+                candidate
+                for document in documents
+                for candidate in _physical_id_candidates(document["_id"])
+            )
+        )
+        if not candidates:  # pragma: no cover - public batches are non-empty
+            return []
+
+        table = _quote_identifier(collection)
+
+        def load_candidates(conn):
+            rows = []
+            for offset in range(0, len(candidates), _SQLITE_CONFLICT_QUERY_SIZE):
+                chunk = candidates[offset : offset + _SQLITE_CONFLICT_QUERY_SIZE]
+                rows.extend(
+                    conn.execute(
+                        "SELECT data FROM {0} WHERE _id IN ({1})".format(
+                            table,
+                            ", ".join("?" for _ in chunk),
+                        ),
+                        chunk,
+                    ).fetchall()
+                )
+            return [_json_loads(row[0]) for row in rows]
+
+        return self._run_collection_read(collection, load_candidates)
 
     @_write_locked
     def insert_many_prevalidated(

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -320,12 +320,28 @@ def _execute_engine_insert_many(
     # re-read and re-plan so the public error still identifies the original
     # operation and preserves ordered/unordered semantics.
     for _attempt in range(3):
-        existing_documents = engine.find(collection.tablename, {})
+        find_candidates = getattr(
+            engine,
+            "find_insert_conflict_candidates",
+            None,
+        )
+        if not callable(find_candidates):
+            existing_documents = engine.find(collection.tablename, {})
+            specs = engine.get_index_specs(collection.tablename)
+        else:
+            specs = engine.get_index_specs(collection.tablename)
+            existing_documents = find_candidates(
+                collection.tablename,
+                documents,
+                specs,
+            )
+            if existing_documents is None:
+                existing_documents = engine.find(collection.tablename, {})
         accepted, write_errors = _plan_insert_many(
             collection,
             documents,
             existing_documents,
-            engine.get_index_specs(collection.tablename),
+            specs,
             ordered,
         )
         if not accepted:


### PR DESCRIPTION
## Summary

- add an optional backend conflict-candidate hook for bulk-insert planning
- make SQLite probe only incoming `_id` candidates through chunked primary-key queries
- keep the shared BSON-aware planner responsible for ordered/unordered errors and intra-batch duplicates
- retain conservative full scans for user-created unique indexes, incoming Decimal128 IDs that can alias released legacy numeric rows, and non-enumerable legacy datetime/container IDs
- include exact numeric, legacy-store, chunking, and native-race regressions
- add a fixed-200-batch TM-040 scaling benchmark and update the changelog, roadmap, and benchmark documentation

## Root cause

Every SQLite `insert_many()` call reread and BSON-decoded the entire existing collection before planning duplicate errors. Repeating 200-document batches therefore performed approximately O(total_documents² / batch_size) preflight work even though the actual SQLite inserts remained fast.

At 30,000 documents, the old path decoded 2,235,000 existing rows and slowed from 5,005 docs/s in the first window to 935 docs/s in the last.

## Performance

Local apples-to-apples results on Python 3.9.6 / macOS ARM64:

| Measurement | Before | After |
| --- | ---: | ---: |
| 30,000-document total | 18.904s | 3.939s |
| Overall throughput | 1,587 docs/s | 7,615 docs/s |
| First/last slowdown | 5.35x | 1.09x |
| Existing rows decoded | 2,235,000 | 0 |

The new 75,000-document benchmark completed in a 10.966-second median across three runs, at 6,839 docs/s overall with a 1.25x first-to-last ratio and zero existing-row decodes.

These are local relative measurements, not universal hardware claims.

## Correctness and compatibility

- non-SQLite backends keep their existing full-preflight behavior
- nonunique SQLite indexes remain eligible for the targeted path
- unique indexes retain complete token validation
- SQLite's native primary key remains the final race authority
- native conflicts are reread and replanned so original operation indices and ordered/unordered behavior remain intact
- legacy float `0.0` / `-0.0` aliases are both recognized
- current typed Decimal128 rows continue sharing exact numeric identity with int/float aliases

## Validation

- full default suite: 3,649 passed, 1 skipped, 523 deselected
- repository branch coverage: 100%
- final focused TM-040 suites passed after additional race and legacy hardening
- SQLite multi-process integration smoke passed
- Black, Ruff, and `git diff --check` passed

## Follow-up decision

A normalized unique-token ledger could later remove full scans for collections with user-created unique indexes. It is intentionally deferred because TM-040's measured no-index application path is now near-flat without that larger migration and concurrency surface.
