### PR TITLE
Fix TM-037 timestamp writes and TM-038 $pull predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@
   full-scan fallback for released legacy-store formats.
 
 ### Fixed
+- **TM-037:** Direct, non-`_id` `Timestamp(0, 0)` values now receive a
+  process-local logical timestamp during inserts and replacement writes.
+  Nested, array, `_id`, and modifier-update values remain literal, and
+  caller-owned documents are not rewritten.
+- **TM-038:** `$pull` now accepts `$exists`, `$type`, `$ne`, `$mod`, `$all`,
+  `$size`, and document-field `$not` through the shared query matcher.
+  Top-level `$not` remains a code-`2` write error, while document-level
+  `$expr` now matches MongoDB's refusal code `224`.
 - **TM-039:** Replacement upserts now retain an `_id` pinned by a top-level
   direct value or sole `$eq` predicate, return that exact value through
   `upserted_id`, and leave the inserted document findable through the caller's

--- a/README.md
+++ b/README.md
@@ -469,10 +469,12 @@ As in PyMongo, `update_one()` and `update_many()` require update operators; use
 `replace_one()` for full-document replacement. `$push` accepts `$each`,
 `$position`, `$sort`, and `$slice`; `$addToSet` accepts `$each`; and `$pull`
 accepts literals, document conditions, ranges, `$in`, `$nin`, `$regex` with
-optional `$options`, and `$elemMatch`. MongoDB does not accept a top-level
-`$not` as a `$pull` condition, so TinyMongo reports `WriteError` code `2` for
-that shape as well. `$pullAll` removes every array item BSON-equal to any
-literal in its operand array.
+optional `$options`, `$elemMatch`, `$exists`, `$type`, `$ne`, `$mod`, `$all`,
+`$size`, and document-field `$not`. MongoDB does not accept a top-level `$not`
+as a `$pull` condition, so TinyMongo reports `WriteError` code `2` for that
+shape as well; document-level `$expr` is likewise refused with MongoDB's code
+`224`. `$pullAll` removes every array item BSON-equal to any literal in its
+operand array.
 
 `$pull` and `$pullAll` are true no-ops when their target field is missing: they
 do not create an empty array, change an `$exists: false` result, or add to
@@ -742,6 +744,14 @@ and recursively encoded scope. Earlier TinyMongo releases stored `Code` as an
 ordinary string, so those legacy values cannot be distinguished from intended
 strings or recovered automatically; rewrite them from an authoritative source
 if the distinction matters.
+
+Following MongoDB's write boundary, a direct, non-`_id` `Timestamp(0, 0)`
+receives a process-local logical timestamp when inserted or used in a
+replacement write. The same value remains literal inside nested documents or
+arrays, as an `_id`, or when written by an update modifier such as `$set`.
+Separate TinyMongo processes do not share this clock, so generated timestamps
+are not a cross-process uniqueness mechanism.
+
 Native compiled patterns retain their Python representation; `bson.Regex`
 values retain their BSON representation, pattern, and flags. Regex identity is
 the pattern plus MongoDB's canonical option string. Preserving a native

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -193,12 +193,14 @@ with the follow-up audit of his
 - [x] **TM-036:** Exempt `MinKey` and `MaxKey` range operands from BSON type
   bracketing so inclusive whole-range scans work through `find()`, aggregation
   `$match`, and `$pull`, including missing fields and stored boundary values.
-- [ ] **TM-037:** Decide whether top-level `Timestamp(0, 0)` inserts should
-  receive MongoDB's server timestamp or remain a documented embedded-database
-  difference.
-- [ ] **TM-038:** Extend `$pull` through the shared matcher for the remaining
+- [x] **TM-037:** Stamp direct, non-`_id` `Timestamp(0, 0)` values during
+  inserts and replacement writes with a process-local logical clock while
+  preserving literal zeros in nested values, arrays, IDs, and modifier
+  updates, matching MongoDB's write boundary.
+- [x] **TM-038:** Extend `$pull` through the shared matcher for the remaining
   measured predicate set: `$exists`, `$type`, `$ne`, `$mod`, `$all`, `$size`,
-  and document-field `$not`.
+  and document-field `$not`; preserve top-level `$not` code `2` and MongoDB's
+  `$expr` refusal code `224`.
 
 #### Mike's [TM-039 replacement-upsert follow-up](https://github.com/schapman1974/tinymongo/issues/136#issuecomment-5174549635)
 
@@ -538,6 +540,8 @@ Exit criteria:
      and `$pop` across synchronous and asynchronous clients.
    - [x] Complete Mike's TM-031 through TM-035 `$pull`, `$pullAll`, error-code,
      and remaining measured BSON compatibility findings.
+   - [x] Complete Mike's TM-036 through TM-038 range, zero-timestamp, and
+     remaining `$pull` predicate follow-ups.
 7. [ ] Implement GridFS on stable BSON, index, and cursor foundations.
 8. [ ] Build the wire-server foundation, followed by read-only Compass browsing and
    then editing support.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -12,7 +12,8 @@ release line.
 - The common update subset now includes `$rename`, `$min`, `$max`, `$pop`, and
   `$pullAll` in addition to `$set`, `$unset`, `$inc`, `$push`, `$pull`, and
   `$addToSet`. `$pull` supports ranges, `$in`, `$nin`, `$regex` with optional
-  `$options`, and `$elemMatch`; `$pullAll` uses literal BSON equality. The
+  `$options`, `$elemMatch`, `$exists`, `$type`, `$ne`, `$mod`, `$all`, `$size`,
+  and document-field `$not`; `$pullAll` uses literal BSON equality. The
   operators use MongoDB-compatible dotted-path, BSON comparison, array,
   immutable `_id`, and atomic error behavior across synchronous and
   asynchronous clients.
@@ -85,6 +86,10 @@ pip install ".[all]"
   dependency-free. Native compiled patterns deliberately continue to read back
   as `re.Pattern`; PyMongo normally returns `bson.Regex` for the corresponding
   BSON value.
+- Direct, non-`_id` `Timestamp(0, 0)` values in inserts and replacements now
+  receive a process-local logical timestamp. Nested, array, `_id`, and
+  modifier-update zeros remain literal; callers that need a stored zero should
+  nest it or use `$set`. Separate processes do not share the logical clock.
 - New `Code` values preserve their BSON type, source, and optional recursive
   scope. Older TinyMongo releases stored `Code` as an ordinary string, so no
   migration can distinguish those values from intentional strings or recover

--- a/tests/contracts/test_array_update_contract.py
+++ b/tests/contracts/test_array_update_contract.py
@@ -286,6 +286,89 @@ def test_pull_query_operator_family_matches_mongodb(contract_target):
     ]
 
 
+def test_tm038_pull_remaining_field_predicates_match_mongodb(contract_target):
+    collection = contract_target.collection
+    collection.insert_many(
+        [
+            {"_id": "exists", "values": [{"a": 1}, {"b": 2}, {}]},
+            {"_id": "type", "values": [1, "x", [1, 2], {"a": 1}]},
+            {"_id": "ne", "values": [1, 2, 3]},
+            {"_id": "mod", "values": [1, 2, 3, 4]},
+            {"_id": "all", "values": [[1, 2], [1], [2, 1, 3], 1]},
+            {"_id": "size", "values": [[1, 2], [1], [], 1]},
+            {
+                "_id": "not",
+                "values": [{"score": 1}, {"score": 8}, {"other": 2}],
+            },
+        ]
+    )
+
+    predicates = {
+        "exists": {"a": {"$exists": False}},
+        "type": {"$type": "array"},
+        "ne": {"$ne": 2},
+        "mod": {"$mod": [2, 0]},
+        "all": {"$all": [1, 2]},
+        "size": {"$size": 2},
+        "not": {"score": {"$not": {"$gte": 5}}},
+    }
+    for document_id, predicate in predicates.items():
+        collection.update_one(
+            {"_id": document_id},
+            {"$pull": {"values": predicate}},
+        )
+
+    assert collection.find_one({"_id": "exists"})["values"] == [{"a": 1}]
+    assert collection.find_one({"_id": "type"})["values"] == [
+        1,
+        "x",
+        {"a": 1},
+    ]
+    assert collection.find_one({"_id": "ne"})["values"] == [2]
+    assert collection.find_one({"_id": "mod"})["values"] == [1, 3]
+    assert collection.find_one({"_id": "all"})["values"] == [[1], 1]
+    assert collection.find_one({"_id": "size"})["values"] == [[1], [], 1]
+    assert collection.find_one({"_id": "not"})["values"] == [{"score": 8}]
+
+
+def test_tm038_pull_expr_errors_are_preflighted_like_mongodb(contract_target):
+    collection = contract_target.collection
+    original = {
+        "_id": "expr",
+        "values": [{"score": 1}, {"score": 2}],
+    }
+    collection.insert_one(original)
+
+    expressions = [
+        {"$expr": {"$eq": [1, 1]}},
+        {"$or": [{"$expr": {"$eq": [1, 1]}}, {"score": 2}]},
+        {"$and": [{"score": {"$gte": 1}}, {"$expr": {"$eq": [1, 1]}}]},
+        {"$nor": [{"$expr": {"$eq": [1, 1]}}, {"score": 3}]},
+    ]
+    for expression in expressions:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one(
+                {"_id": "expr"},
+                {"$pull": {"values": expression}},
+            )
+        assert caught.value.code == 224
+        assert collection.find_one({"_id": "expr"}) == original
+
+    nested_code_two = [
+        {"score": {"$expr": {"$eq": [1, 1]}}},
+        {"score": {"$not": {"$unknown": 1}}},
+        {"$elemMatch": {"$expr": {"$eq": [1, 1]}}},
+    ]
+    for expression in nested_code_two:
+        with pytest.raises(_WRITE_ERRORS) as caught:
+            collection.update_one(
+                {"_id": "expr"},
+                {"$pull": {"values": expression}},
+            )
+        assert caught.value.code == 2
+        assert collection.find_one({"_id": "expr"}) == original
+
+
 def test_pull_missing_fields_are_true_noops(contract_target):
     collection = contract_target.collection
     collection.insert_many(

--- a/tests/contracts/test_bson_value_types_contract.py
+++ b/tests/contracts/test_bson_value_types_contract.py
@@ -225,3 +225,104 @@ def test_tm035_scoped_code_honors_recursive_client_read_options(contract_target)
     assert type(script.scope) is OrderedDict
     assert type(script.scope["nested"]) is OrderedDict
     assert script.scope["at"].utcoffset() == timezone.utc.utcoffset(None)
+
+
+def test_tm037_zero_timestamp_write_boundaries_match_mongodb(contract_target):
+    collection = contract_target.collection
+    zero = Timestamp(0, 0)
+
+    inserted = {
+        "_id": "insert-one",
+        "first": zero,
+        "second": zero,
+        "zero-seconds-only": Timestamp(0, 1),
+        "zero-increment-only": Timestamp(1, 0),
+        "nested": {"value": zero},
+        "values": [zero],
+    }
+    collection.insert_one(inserted)
+
+    stored = collection.find_one({"_id": "insert-one"})
+    assert inserted["first"] == zero
+    assert inserted["second"] == zero
+    assert stored["first"] != zero
+    assert stored["second"] != zero
+    assert stored["first"] != stored["second"]
+    assert stored["zero-seconds-only"] == Timestamp(0, 1)
+    assert stored["zero-increment-only"] == Timestamp(1, 0)
+    assert stored["nested"]["value"] == zero
+    assert stored["values"] == [zero]
+
+    batch = [
+        {"_id": "insert-many-a", "stamp": zero},
+        {"_id": "insert-many-b", "stamp": zero},
+    ]
+    collection.insert_many(batch)
+
+    batch_stamps = [
+        collection.find_one({"_id": document["_id"]})["stamp"] for document in batch
+    ]
+    assert [document["stamp"] for document in batch] == [zero, zero]
+    assert all(stamp != zero for stamp in batch_stamps)
+    assert batch_stamps[0] != batch_stamps[1]
+
+    collection.insert_one({"_id": zero, "stamp": zero})
+    timestamp_id = collection.find_one({"_id": zero})
+    assert timestamp_id["_id"] == zero
+    assert timestamp_id["stamp"] != zero
+
+    replacement = {"stamp": zero, "nested": {"value": zero}}
+    collection.replace_one({"_id": "insert-one"}, replacement)
+    replaced = collection.find_one({"_id": "insert-one"})
+    assert replacement["stamp"] == zero
+    assert replaced["stamp"] != zero
+    assert replaced["nested"]["value"] == zero
+
+    collection.update_one(
+        {"_id": "insert-one"},
+        {"$set": {"stamp": zero, "nested.value": zero}},
+    )
+    updated = collection.find_one({"_id": "insert-one"})
+    assert updated["stamp"] == zero
+    assert updated["nested"]["value"] == zero
+
+    collection.update_one(
+        {"_id": "modifier-upsert"},
+        {"$set": {"stamp": zero}},
+        upsert=True,
+    )
+    assert collection.find_one({"_id": "modifier-upsert"})["stamp"] == zero
+
+    collection.update_one(
+        {"_id": "filter-upsert", "stamp": zero},
+        {"$set": {"value": 1}},
+        upsert=True,
+    )
+    assert collection.find_one({"_id": "filter-upsert"})["stamp"] == zero
+
+    upsert_replacement = {"stamp": zero, "nested": {"value": zero}}
+    result = collection.replace_one(
+        {"_id": "replacement-upsert"},
+        upsert_replacement,
+        upsert=True,
+    )
+    upserted = collection.find_one({"_id": result.upserted_id})
+    assert upsert_replacement["stamp"] == zero
+    assert upserted["stamp"] != zero
+    assert upserted["nested"]["value"] == zero
+
+
+def test_tm037_zero_timestamp_insert_many_honors_unique_indexes(contract_target):
+    collection = contract_target.collection
+    zero = Timestamp(0, 0)
+    collection.create_index("stamp", unique=True)
+    documents = [
+        {"_id": "unique-{0}".format(index), "stamp": zero} for index in range(3)
+    ]
+
+    collection.insert_many(documents)
+
+    stored = list(collection.find({}))
+    assert [document["stamp"] for document in documents] == [zero, zero, zero]
+    assert all(document["stamp"] != zero for document in stored)
+    assert len({document["stamp"] for document in stored}) == 3

--- a/tests/test_array_update_modifiers.py
+++ b/tests/test_array_update_modifiers.py
@@ -315,7 +315,7 @@ def test_pull_all_uses_literal_bson_equality_and_validates_operands():
         ({"$and": [1]}, "requires an array of documents"),
         ({"$or": []}, "requires an array of documents"),
         ({"$not": {"$unknown": 1}}, "does not support query operator"),
-        ({"$all": [2]}, "does not support query operator"),
+        ({"$all": 2}, r"\$all requires an array"),
         ({"$not": {"$eq": 2}}, "does not support query operator"),
         ({"$options": "i"}, r"\$options requires \$regex"),
         ({"$regex": "["}, "regex pattern is not valid"),

--- a/tests/test_bson_value_types.py
+++ b/tests/test_bson_value_types.py
@@ -9,7 +9,9 @@ import pytest
 
 import tinymongo as tm
 from tinymongo import bson_codec, bson_types
+from tinymongo import tinymongo as core
 from tinymongo.errors import (
+    BulkWriteError,
     InvalidDocument,
     OperationFailure,
     TinyMongoNotSupportedError,
@@ -22,6 +24,122 @@ Code = bson.Code
 MaxKey = bson.MaxKey
 MinKey = bson.MinKey
 Timestamp = bson.Timestamp
+
+
+def test_tm037_logical_timestamp_clock_and_copy_boundaries(monkeypatch):
+    clock = iter((1000, 1000, 999, 1001))
+    monkeypatch.setattr(core.time_module, "time", lambda: next(clock))
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_SECONDS", 0)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_INCREMENT", 0)
+
+    assert core._next_server_timestamp() == Timestamp(1000, 1)
+    assert core._next_server_timestamp() == Timestamp(1000, 2)
+    assert core._next_server_timestamp() == Timestamp(1000, 3)
+    assert core._next_server_timestamp() == Timestamp(1001, 1)
+
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_SECONDS", 2000)
+    monkeypatch.setattr(
+        core,
+        "_SERVER_TIMESTAMP_INCREMENT",
+        core._MAX_TIMESTAMP_COMPONENT,
+    )
+    monkeypatch.setattr(core.time_module, "time", lambda: 2000)
+    assert core._next_server_timestamp() == Timestamp(2001, 1)
+
+    zero = Timestamp(0, 0)
+    original = {
+        "_id": zero,
+        "stamp": zero,
+        "near-zero": Timestamp(0, 1),
+        "nested": {"stamp": zero},
+    }
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_SECONDS", 0)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_INCREMENT", 0)
+    monkeypatch.setattr(core.time_module, "time", lambda: 1002)
+    stamped = core._stamp_top_level_server_timestamps(original)
+
+    assert stamped is not original
+    assert original["stamp"] == zero
+    assert stamped["_id"] == zero
+    assert stamped["stamp"] == Timestamp(1002, 1)
+    assert stamped["near-zero"] == Timestamp(0, 1)
+    assert stamped["nested"]["stamp"] == zero
+
+    unchanged = {"stamp": Timestamp(1, 0)}
+    assert core._stamp_top_level_server_timestamps(unchanged) is unchanged
+
+    monkeypatch.setattr(core, "_TIMESTAMP", None)
+    unavailable = {"stamp": zero}
+    assert core._stamp_top_level_server_timestamps(unavailable) is unavailable
+
+
+def test_tm037_ordered_and_unordered_batches_consume_expected_increments(
+    monkeypatch,
+):
+    monkeypatch.setattr(core.time_module, "time", lambda: 1000)
+    zero = Timestamp(0, 0)
+    client = tm.TinyMongoClient(backend="memory")
+
+    ordered = client.tm037.ordered
+    ordered.insert_one({"_id": "duplicate"})
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_SECONDS", 0)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_INCREMENT", 0)
+    ordered_documents = [
+        {"_id": "accepted", "stamp": zero},
+        {"_id": "duplicate", "stamp": zero},
+        {"_id": "not-processed", "stamp": zero},
+    ]
+    with pytest.raises(BulkWriteError) as ordered_error:
+        ordered.insert_many(ordered_documents, ordered=True)
+    ordered.insert_one({"_id": "after", "stamp": zero})
+
+    ordered_operation = ordered_error.value.details["writeErrors"][0]["op"]
+    assert ordered_operation is ordered_documents[1]
+    assert ordered_operation["stamp"] == zero
+    assert ordered.find_one({"_id": "accepted"})["stamp"] == Timestamp(1000, 1)
+    assert ordered.find_one({"_id": "not-processed"}) is None
+    assert ordered.find_one({"_id": "after"})["stamp"] == Timestamp(1000, 3)
+
+    unordered = client.tm037.unordered
+    unordered.insert_one({"_id": "duplicate"})
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_SECONDS", 0)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_INCREMENT", 0)
+    unordered_documents = [
+        {"_id": "accepted", "stamp": zero},
+        {"_id": "duplicate", "stamp": zero},
+        {"_id": "continued", "stamp": zero},
+    ]
+    with pytest.raises(BulkWriteError) as unordered_error:
+        unordered.insert_many(unordered_documents, ordered=False)
+    unordered.insert_one({"_id": "after", "stamp": zero})
+
+    unordered_operation = unordered_error.value.details["writeErrors"][0]["op"]
+    assert unordered_operation is unordered_documents[1]
+    assert unordered_operation["stamp"] == zero
+    assert unordered.find_one({"_id": "accepted"})["stamp"] == Timestamp(1000, 1)
+    assert unordered.find_one({"_id": "continued"})["stamp"] == Timestamp(1000, 3)
+    assert unordered.find_one({"_id": "after"})["stamp"] == Timestamp(1000, 4)
+    client.close()
+
+
+def test_tm037_invalid_insert_does_not_advance_clock_or_replace_error_document(
+    monkeypatch,
+):
+    monkeypatch.setattr(core.time_module, "time", lambda: 1000)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_SECONDS", 0)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_INCREMENT", 0)
+    zero = Timestamp(0, 0)
+    client = tm.TinyMongoClient(backend="memory")
+    collection = client.tm037.validation
+    invalid = {"_id": "invalid", "stamp": zero, "bad": object()}
+
+    with pytest.raises(InvalidDocument) as caught:
+        collection.insert_one(invalid)
+
+    assert caught.value.document is invalid
+    collection.insert_one({"_id": "valid", "stamp": zero})
+    assert collection.find_one({"_id": "valid"})["stamp"] == Timestamp(1000, 1)
+    client.close()
 
 
 @pytest.mark.parametrize(

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import threading
+import time as time_module
 from uuid import uuid4
 
 from tinydb import Query, TinyDB, where  # type: ignore[attr-defined]
@@ -34,6 +35,7 @@ from .bson_types import (
     is_bson_string,
     object_id_type,
     supported_bson_types,
+    timestamp_type,
 )
 from .aggregation import AggregationEngine, aggregation_capabilities
 from .sorting import bson_document_sort_value_key, sort_documents
@@ -110,6 +112,11 @@ def Q(query, key):
 _MISSING = object()
 _CODE = code_type()
 _DECIMAL128 = decimal128_type()
+_TIMESTAMP = timestamp_type()
+_SERVER_TIMESTAMP_LOCK = threading.Lock()
+_SERVER_TIMESTAMP_SECONDS = 0
+_SERVER_TIMESTAMP_INCREMENT = 0
+_MAX_TIMESTAMP_COMPONENT = 2**32 - 1
 
 
 def _generate_document_id():
@@ -119,6 +126,46 @@ def _generate_document_id():
     if object_id_class is not None:
         return object_id_class()
     return generate_id()
+
+
+def _next_server_timestamp():
+    """Return a process-local logical timestamp shaped like MongoDB's server time."""
+
+    global _SERVER_TIMESTAMP_SECONDS, _SERVER_TIMESTAMP_INCREMENT
+
+    with _SERVER_TIMESTAMP_LOCK:
+        seconds = max(int(time_module.time()), _SERVER_TIMESTAMP_SECONDS)
+        increment = (
+            _SERVER_TIMESTAMP_INCREMENT + 1
+            if seconds == _SERVER_TIMESTAMP_SECONDS
+            else 1
+        )
+        if increment > _MAX_TIMESTAMP_COMPONENT:
+            seconds += 1
+            increment = 1
+        _SERVER_TIMESTAMP_SECONDS = seconds
+        _SERVER_TIMESTAMP_INCREMENT = increment
+        return _TIMESTAMP(seconds, increment)
+
+
+def _stamp_top_level_server_timestamps(document):
+    """Stamp direct non-``_id`` ``Timestamp(0, 0)`` values without mutation."""
+
+    if _TIMESTAMP is None:
+        return document
+
+    stamped = None
+    for key, value in document.items():
+        if (
+            key != "_id"
+            and isinstance(value, _TIMESTAMP)
+            and value.time == 0
+            and value.inc == 0
+        ):
+            if stamped is None:
+                stamped = copy.deepcopy(document)
+            stamped[key] = _next_server_timestamp()
+    return document if stamped is None else stamped
 
 
 def _get_nested(doc, path, default=_MISSING):
@@ -165,7 +212,14 @@ def _delete_result(deleted_count):
     return DeleteResult(raw_result={"n": deleted_count, "ok": 1.0})
 
 
-def _duplicate_write_error(collection, index, document, spec=None, error=None):
+def _duplicate_write_error(
+    collection,
+    index,
+    document,
+    spec=None,
+    error=None,
+    operation=_MISSING,
+):
     """Describe one duplicate insert using PyMongo's bulk error shape."""
     field = "_id" if spec is None else spec.field
     index_name = "_id_" if spec is None else spec.name
@@ -184,7 +238,7 @@ def _duplicate_write_error(collection, index, document, spec=None, error=None):
         "errmsg": message,
         "keyPattern": {field: 1 if spec is None else spec.direction},
         "keyValue": {field: value},
-        "op": document,
+        "op": document if operation is _MISSING else operation,
     }
 
 
@@ -234,14 +288,29 @@ def _unique_insert_state(existing_documents, specs):
     return states
 
 
-def _plan_insert_many(collection, documents, existing_documents, specs, ordered):
+def _plan_insert_many(
+    collection,
+    documents,
+    existing_documents,
+    specs,
+    ordered,
+    original_documents=None,
+):
     """Split a batch into inserts and duplicate-key write errors."""
+    if original_documents is None:
+        original_documents = list(documents)
     id_identities, fallback_ids, all_ids = _insert_id_state(existing_documents)
     unique_states = _unique_insert_state(existing_documents, specs)
     accepted = []
     write_errors = []
 
     for index, document in enumerate(documents):
+        # MongoDB resolves direct all-zero timestamps as each insert reaches
+        # duplicate and unique-index validation. Replacing the local list item
+        # preserves caller mappings, stops after an ordered failure, and lets a
+        # native-race retry reuse the same generated value.
+        document = _stamp_top_level_server_timestamps(document)
+        documents[index] = document
         duplicate_error = None
         value = document["_id"]
         identity = bson_value_identity_key(value)
@@ -259,7 +328,12 @@ def _plan_insert_many(collection, documents, existing_documents, specs, ordered)
             )
 
         if duplicate_id:
-            duplicate_error = _duplicate_write_error(collection, index, document)
+            duplicate_error = _duplicate_write_error(
+                collection,
+                index,
+                document,
+                operation=original_documents[index],
+            )
         else:
             candidate_tokens = []
             for spec, owners, existing_error in unique_states:
@@ -281,6 +355,7 @@ def _plan_insert_many(collection, documents, existing_documents, specs, ordered)
                         document,
                         spec=spec,
                         error=error,
+                        operation=original_documents[index],
                     )
                     break
 
@@ -307,10 +382,13 @@ def _execute_engine_insert_many(
     documents,
     ordered,
     bypass_document_validation,
+    original_documents=None,
 ):
     """Plan and execute a table-backend batch, retrying native races."""
 
     engine = collection.parent.engine
+    if original_documents is None:
+        original_documents = list(documents)
     last_error = None
     accepted = []
     write_errors = []
@@ -343,6 +421,7 @@ def _execute_engine_insert_many(
             existing_documents,
             specs,
             ordered,
+            original_documents=original_documents,
         )
         if not accepted:
             return [], accepted, write_errors
@@ -377,6 +456,7 @@ def _execute_engine_insert_many(
             conflict_index,
             conflict_document,
             error=last_error,
+            operation=original_documents[conflict_index],
         )
     )
     write_errors.sort(key=lambda item: item["index"])
@@ -426,15 +506,22 @@ _ADD_TO_SET_MODIFIERS = frozenset(("$each",))
 _PULL_COMPARISON_OPERATORS = frozenset(("$gt", "$gte", "$lt", "$lte"))
 _PULL_FIELD_OPERATORS = frozenset(
     (
+        "$all",
         "$elemMatch",
         "$eq",
+        "$exists",
         "$in",
+        "$mod",
+        "$ne",
         "$nin",
         "$options",
         "$regex",
+        "$size",
+        "$type",
     )
     + tuple(_PULL_COMPARISON_OPERATORS)
 )
+_PULL_DOCUMENT_FIELD_OPERATORS = _PULL_FIELD_OPERATORS | frozenset(("$not",))
 _PULL_LOGICAL_OPERATORS = frozenset(("$and", "$or", "$nor"))
 
 
@@ -683,7 +770,7 @@ def _validate_update_path_conflicts(update_doc):
                 )
 
 
-def _validate_pull_field_condition(condition):
+def _validate_pull_field_condition(condition, *, document_field=False):
     """Validate the operators applied to one array element or document field."""
 
     if not isinstance(condition, Mapping):
@@ -697,8 +784,11 @@ def _validate_pull_field_condition(condition):
     if len(operator_keys) != len(condition):
         _raise_write_error("$pull cannot mix field and document query operators")
 
+    allowed_operators = (
+        _PULL_DOCUMENT_FIELD_OPERATORS if document_field else _PULL_FIELD_OPERATORS
+    )
     for key, operand in condition.items():
-        if key not in _PULL_FIELD_OPERATORS:
+        if key not in allowed_operators:
             _raise_write_error("$pull does not support query operator {0}".format(key))
         if key in _PULL_COMPARISON_OPERATORS and is_bson_regex(operand):
             _raise_write_error("Can't have RegEx as arg to non-equality predicate")
@@ -712,6 +802,8 @@ def _validate_pull_field_condition(condition):
         validate_filter_operators({"value": condition})
     except OperationFailure as error:
         _raise_write_error(str(error), code=error.code or 2)
+    except TinyMongoNotSupportedError as error:
+        _raise_write_error(str(error), code=2)
 
 
 def _validate_pull_document_condition(condition):
@@ -729,12 +821,14 @@ def _validate_pull_document_condition(condition):
                 )
             for clause in operand:
                 _validate_pull_document_condition(clause)
+        elif key == "$expr":
+            _raise_write_error("$expr is not allowed in this context", code=224)
         elif isinstance(key, str) and key.startswith("$"):
             _raise_write_error(
                 "$pull does not support document query operator {0}".format(key)
             )
         else:
-            _validate_pull_field_condition(operand)
+            _validate_pull_field_condition(operand, document_field=True)
 
 
 def _validate_pull_condition(condition):
@@ -746,6 +840,8 @@ def _validate_pull_condition(condition):
     operator_keys = [
         key for key in condition if isinstance(key, str) and key.startswith("$")
     ]
+    if "$expr" in operator_keys:
+        _raise_write_error("$expr is not allowed in this context", code=224)
     if any(key in _PULL_LOGICAL_OPERATORS for key in operator_keys):
         _validate_pull_document_condition(condition)
     elif operator_keys:
@@ -1162,7 +1258,7 @@ def _replacement_document_for_upsert(query, replacement):
     # MongoDB stores ``_id`` first even when it was inferred from the filter.
     inserted = {"_id": copy.deepcopy(inserted_id)}
     inserted.update(copy.deepcopy(replacement))
-    return inserted
+    return _stamp_top_level_server_timestamps(inserted)
 
 
 def _simple_equality_filter(_filter):
@@ -2544,15 +2640,16 @@ class TinyMongoCollection(object):
         else:
             _id = doc["_id"] = _generate_document_id()
         self._validate_storage_document(doc)
+        stored_doc = _stamp_top_level_server_timestamps(doc)
 
         if self.parent.engine is not None:
             self.parent.engine.validate_unique_post_image(
                 self.tablename,
-                self.parent.engine.find(self.tablename, {}) + [doc],
+                self.parent.engine.find(self.tablename, {}) + [stored_doc],
             )
             result = self.parent.engine.insert_many(
                 self.tablename,
-                [doc],
+                [stored_doc],
                 bypass_document_validation=kwargs.get("bypass_document_validation")
                 is True,
             )
@@ -2573,8 +2670,8 @@ class TinyMongoCollection(object):
                 None,
             )
             if existing is None:
-                self._validate_unique_post_image(documents + [doc])
-                eid = self.table.insert(doc)
+                self._validate_unique_post_image(documents + [stored_doc])
+                eid = self.table.insert(stored_doc)
             else:
                 raise DuplicateKeyError(
                     "_id:{0} already exists in collection:{1}".format(
@@ -2629,20 +2726,23 @@ class TinyMongoCollection(object):
                 _id = doc["_id"] = _generate_document_id()
             _ids.append(_id)
 
+        stored_docs = list(docs)
+
         # Validate TinyMongo's one storage batch at the JSON boundary before
         # changing storage. PyMongo can split very large inputs across multiple
         # wire batches, so TinyMongo intentionally provides a stronger
         # whole-list guarantee here.
-        for index, doc in enumerate(docs):
+        for index, doc in enumerate(stored_docs):
             self._validate_storage_document(doc, index=index)
 
         engine = self.parent.engine
         if engine is not None:
             results, accepted, write_errors = _execute_engine_insert_many(
                 self,
-                docs,
+                stored_docs,
                 ordered,
                 bypass_document_validation,
+                original_documents=docs,
             )
             if write_errors:
                 raise BulkWriteError(_bulk_write_details(len(accepted), write_errors))
@@ -2655,10 +2755,11 @@ class TinyMongoCollection(object):
             self._refresh_table()
             accepted, write_errors = _plan_insert_many(
                 self,
-                docs,
+                stored_docs,
                 self.table.all(),
                 list(self._index_specs.values()),
                 ordered,
+                original_documents=docs,
             )
 
             if accepted:
@@ -3184,6 +3285,7 @@ class TinyMongoCollection(object):
             updated = {"_id": item["_id"]}
             updated.update(copy.deepcopy(replacement))
             updated["_id"] = item["_id"]
+            updated = _stamp_top_level_server_timestamps(updated)
             self._validate_storage_document(updated)
             modified = not storage_values_equal(updated, item)
             if modified:
@@ -3241,6 +3343,7 @@ class TinyMongoCollection(object):
             updated = {"_id": item["_id"]}
             updated.update(copy.deepcopy(replacement))
             updated["_id"] = item["_id"]
+            updated = _stamp_top_level_server_timestamps(updated)
             self._validate_storage_document(updated)
             modified = not storage_values_equal(updated, item)
             if modified:


### PR DESCRIPTION
## Summary

This draft implements Mike's remaining TM-037 and TM-038 findings from #136.

- TM-037 now gives direct, non-`_id` `Timestamp(0, 0)` values a logical timestamp during inserts and replacement writes.
- TM-038 now allows the remaining MongoDB-supported `$pull` predicates through the shared matcher: `$exists`, `$type`, `$ne`, `$mod`, `$all`, `$size`, and document-field `$not`.
- The roadmap, README, migration guide, and changelog describe the completed behavior and its boundaries.

## Why

TM-037 was a write-boundary gap. TinyMongo's BSON codec correctly preserved literal timestamps, but collection writes never applied MongoDB's special handling for an all-zero timestamp.

TM-038 was primarily a validation gap. The shared query matcher already evaluated the requested predicates correctly, but the `$pull` allowlist rejected them before matching could begin. A few nested validation paths also leaked `TinyMongoNotSupportedError` instead of a MongoDB-shaped write error.

## Implementation details

### TM-037

- Adds a thread-safe, process-local logical timestamp clock based on the current second and a monotonically increasing increment.
- Stamps only direct top-level `Timestamp(0, 0)` values during `insert_one()`, processed `insert_many()` operations, matched replacements, and replacement upserts.
- Leaves nested values, array members, `_id`, near-zero timestamps, `$set`, and modifier upserts literal.
- Preserves caller-owned mappings, including the original operation exposed by `BulkWriteError`.
- Validates caller input before advancing the clock.
- Preserves MongoDB's ordered/unordered batch behavior: a rejected processed document consumes an increment, while later operations after an ordered failure do not.
- Reuses prepared timestamps across native duplicate-race retries and handles increment rollover.
- Uses generated timestamps during unique-index validation.

Because embedded backends do not share one server clock, the logical clock is process-local and is explicitly documented as unsuitable for cross-process uniqueness.

### TM-038

- Expands the `$pull` field predicate allowlist without duplicating matcher logic.
- Allows `$not` only on a named field within an embedded-document predicate.
- Keeps top-level `$not` invalid with `WriteError` code `2`.
- Keeps document-level `$expr` unsupported, matching MongoDB's `WriteError` code `224`, including beneath `$and`, `$or`, and `$nor`.
- Keeps field-level and nested `$expr`/unknown-operator failures at code `2`.
- Preflights all failures before mutation so updates remain atomic.

## User impact

The behavior is shared by synchronous and asynchronous clients and all embedded backends. Applications can now use the measured `$pull` predicate set without backend-specific handling, while zero timestamp writes follow MongoDB's operation and nesting boundaries.

## Validation

- Full suite: **3,695 passed**, 1 skipped, 531 deselected.
- Coverage: **100% statements and 100% branches** across all `tinymongo/*` modules.
- Real MongoDB 8.0 controls: **8 passed** for the TM-037/TM-038 sync and async contracts.
- `ruff check tinymongo tests`
- `black --check tinymongo tests`
- `git diff --check`
