### PR TITLE
Accelerate targeted SQLite updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   BSON-aware ordered and unordered planning remains shared, while unique
   indexes, Decimal128 IDs, and non-enumerable legacy IDs retain the conservative
   full-scan fallback for released legacy-store formats.
+- SQLite `update_one()` and `update_many()` now select exact `_id` rows through
+  the primary key and declared non-unique index candidates for top-level
+  bool/int/float/string equality inside the existing atomic transaction. Exact
+  BSON post-filtering and natural first-match order are preserved, while
+  unique-index and uncertain legacy cases retain the complete validation scan.
 
 ### Fixed
 - **TM-037:** Direct, non-`_id` `Timestamp(0, 0)` values now receive a

--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ the Python API instead.
 SQLite, DuckDB, and Parquet compile supported Mongo-style filters into SQL over
 the `_id` column and JSON document payload. Unsupported filter shapes fall back
 to Python document matching so existing TinyMongo behavior remains available.
+SQLite also uses its primary key and declared non-unique indexes for top-level
+bool/int/float/string equality to restrict ordinary update candidates before
+BSON decoding. Collections with user-created unique indexes retain complete
+post-image validation.
 Older blob-format SQLite and DuckDB files are migrated to collection tables when
 opened.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -226,6 +226,23 @@ The normalized unique-token ledger remains a possible later optimization for
 bulk inserts into collections with user-created unique indexes. TM-040's
 measured no-index application path no longer needs that larger migration.
 
+#### SQLite candidate-selective updates
+
+- [x] Route exact `_id` updates through SQLite's primary key inside the existing
+  `BEGIN IMMEDIATE` transaction instead of BSON-decoding the complete
+  collection. Missing ordinary IDs decode no payload rows, while legacy
+  container and datetime IDs retain the compatibility scan when necessary.
+- [x] Reuse declared non-unique indexes for top-level bool/int/float/string
+  equality to restrict `update_one()` and `update_many()` to scalar plus
+  array/object candidates, then apply the exact shared BSON matcher in natural
+  row order. NaN, oversized integers, rich BSON predicates, dotted fields, and
+  collections with user-created unique indexes deliberately retain the
+  conservative full scan.
+- [x] Extend the SQLite/raw SQLite/MongoDB comparison benchmark with durable
+  `_id` point updates. In the controlled 10,000-document local comparison, the
+  TinyMongo point-update average fell from 98.653 ms to 4.330 ms (22.8x), and
+  the indexed 1,000-document update fell from 0.228 seconds to 0.144 seconds.
+
 - [x] **Remote SQL numeric uniqueness:** Persist versioned, fixed-width digests
   of canonical BSON scalar tokens for PostgreSQL and MariaDB/MySQL unique
   indexes. Native constraints now enforce exact cross-process equality for

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -4,7 +4,7 @@ These numbers are local benchmark results from the TinyMongo storage load
 benchmark. They are useful for comparing relative behavior on this machine, not
 for making universal performance claims.
 
-## SQLite performance work: 2026-08-04
+## SQLite performance work: 2026-08-04 through 2026-08-05
 
 ### Fixed-size batch scaling (TM-040)
 
@@ -44,6 +44,7 @@ The focused comparison uses the same 10,000 JSON-shaped documents and performs:
 
 - One `insert_many()` batch.
 - 200 warmed, deterministic `_id` point lookups.
+- 200 durable `_id` point updates using `$inc`.
 - 200 warmed equality queries through an index on `group`. Each query returns
   1,000 documents, for 200,000 decoded result rows in total.
 - One indexed update affecting 1,000 documents.
@@ -53,8 +54,8 @@ SQLite is a lower-bound comparison: it does not provide TinyMongo's BSON,
 MongoDB query, validation, or update semantics, and its update is native SQL.
 MongoDB 8.0 ran locally through PyMongo 4.17.0 in a disposable Docker container
 with a persistent Docker volume. Its collection explicitly used
-`WriteConcern(w=1, j=True)`, and the benchmark verifies that both measured
-writes were acknowledged. The two SQLite connections reported WAL mode with
+`WriteConcern(w=1, j=True)`, and the benchmark verifies that every measured
+write was acknowledged. The two SQLite connections reported WAL mode with
 `synchronous=NORMAL`.
 
 Command:
@@ -67,6 +68,9 @@ TINYMONGO_MONGODB_URI='mongodb://127.0.0.1:27017/?directConnection=true' \
     --json-output /tmp/tinymongo-sqlite-comparison.json
 ```
 
+The original 2026-08-04 capture below predates the point-update measurement;
+the 2026-08-05 follow-up records that new column separately.
+
 | Engine | Insert docs/s | Point avg ms | Point p95 ms | Indexed queries/s | Indexed rows/s | Update docs/s | Update s |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | tinymongo-sqlite | 18,985 | 0.414 | 0.470 | 116.7 | 116,688 | 5,054 | 0.198 |
@@ -78,6 +82,30 @@ MongoDB is not receiving an unacknowledged-write advantage in this run. MongoDB
 uses Docker's storage stack while SQLite uses the host filesystem, which means
 the absolute write-throughput comparison remains directional rather than a
 claim that the storage media are identical.
+
+### Candidate-selective SQLite updates: 2026-08-05
+
+The comparison driver now measures the ordinary durable
+`update_one({"_id": ...}, {"$inc": ...})` path as well as the existing indexed
+`update_many()` batch. The same updated driver ran against commit `8d627af`
+before candidate selection and against the working branch afterward. Both runs
+used 10,000 documents, 200 deterministic point updates, Python 3.9.6 on the
+same macOS host, and SQLite WAL with `synchronous=NORMAL`:
+
+| Engine or revision | Point update avg ms | Point update p95 ms | Indexed update 1,000 docs s | Indexed update docs/s |
+| --- | ---: | ---: | ---: | ---: |
+| TinyMongo SQLite before (`8d627af`) | 98.653 | 124.121 | 0.228 | 4,395 |
+| TinyMongo SQLite after | 4.330 | 4.965 | 0.144 | 6,968 |
+| Raw SQLite lower bound | 0.091 | 0.238 | 0.034 | 29,233 |
+
+The targeted TinyMongo point update is about 22.8x faster in this run. Decode
+instrumentation also changed from all 10,000 stored documents per `_id` update
+to one document for a hit and zero for an ordinary miss. Declared non-unique
+indexes now bound top-level bool/int/float/string equality-update candidates
+too; exact BSON matching still runs before any row changes. Collections with
+user-created unique indexes continue using complete post-image validation
+because overlapping multikey tokens and fail-closed legacy catalogs cannot
+safely rely on a simple native constraint alone.
 
 The same 1,000-document storage benchmark was captured immediately before and
 after the SQLite work on this machine:

--- a/tests/benchmarks/bench_sqlite_comparison.py
+++ b/tests/benchmarks/bench_sqlite_comparison.py
@@ -78,6 +78,7 @@ def _result(
     queries,
     insert_seconds,
     point_latencies,
+    point_update_latencies,
     indexed_seconds,
     indexed_rows,
     update_seconds,
@@ -94,6 +95,8 @@ def _result(
         ),
         "point_avg_ms": statistics.mean(point_latencies) * 1000,
         "point_p95_ms": _percentile(point_latencies, 95) * 1000,
+        "point_update_avg_ms": statistics.mean(point_update_latencies) * 1000,
+        "point_update_p95_ms": _percentile(point_update_latencies, 95) * 1000,
         "indexed_seconds": indexed_seconds,
         "indexed_queries_per_second": (
             queries / indexed_seconds if indexed_seconds else 0.0
@@ -159,6 +162,18 @@ def _run_tinymongo_sqlite_client(client, documents, queries):
             raise AssertionError("TinyMongo point lookup missed {0}".format(target))
         point_latencies.append(elapsed)
 
+    point_update_latencies = []
+    for target in targets:
+        elapsed, update_result = _time_call(
+            lambda target=target: collection.update_one(
+                {"_id": target},
+                {"$inc": {"point_updates": 1}},
+            )
+        )
+        if update_result.matched_count != 1 or update_result.modified_count != 1:
+            raise AssertionError("TinyMongo point update missed {0}".format(target))
+        point_update_latencies.append(elapsed)
+
     def indexed_queries():
         rows = 0
         for index in range(queries):
@@ -197,6 +212,7 @@ def _run_tinymongo_sqlite_client(client, documents, queries):
         queries,
         insert_seconds,
         point_latencies,
+        point_update_latencies,
         indexed_seconds,
         indexed_rows,
         update_seconds,
@@ -260,6 +276,25 @@ def _run_raw_sqlite_connection(conn, documents, queries):
         if found is None or found["_id"] != target:
             raise AssertionError("raw SQLite point lookup missed {0}".format(target))
         point_latencies.append(elapsed)
+
+    point_update_latencies = []
+    for target in targets:
+
+        def point_update(target=target):
+            cursor = conn.execute(
+                "UPDATE records SET data = json_set("
+                "data, '$.point_updates', "
+                "COALESCE(json_extract(data, '$.point_updates'), 0) + 1) "
+                "WHERE _id = ?",
+                (target,),
+            )
+            conn.commit()
+            return cursor.rowcount
+
+        elapsed, updated = _time_call(point_update)
+        if updated != 1:
+            raise AssertionError("raw SQLite point update missed {0}".format(target))
+        point_update_latencies.append(elapsed)
 
     def indexed_queries():
         rows_found = 0
@@ -326,6 +361,7 @@ def _run_raw_sqlite_connection(conn, documents, queries):
         queries,
         insert_seconds,
         point_latencies,
+        point_update_latencies,
         indexed_seconds,
         indexed_rows,
         update_seconds,
@@ -388,6 +424,20 @@ def _run_mongodb(documents, queries, mongo_uri):
                 raise AssertionError("MongoDB point lookup missed {0}".format(target))
             point_latencies.append(elapsed)
 
+        point_update_latencies = []
+        for target in targets:
+            elapsed, update_result = _time_call(
+                lambda target=target: collection.update_one(
+                    {"_id": target},
+                    {"$inc": {"point_updates": 1}},
+                )
+            )
+            if not update_result.acknowledged:
+                raise AssertionError("MongoDB did not acknowledge the point update")
+            if update_result.matched_count != 1 or update_result.modified_count != 1:
+                raise AssertionError("MongoDB point update missed {0}".format(target))
+            point_update_latencies.append(elapsed)
+
         def indexed_queries():
             rows = 0
             for index in range(queries):
@@ -428,6 +478,7 @@ def _run_mongodb(documents, queries, mongo_uri):
             queries,
             insert_seconds,
             point_latencies,
+            point_update_latencies,
             indexed_seconds,
             indexed_rows,
             update_seconds,
@@ -444,22 +495,23 @@ def _run_mongodb(documents, queries, mongo_uri):
 
 def format_markdown(results):
     rows = [
-        "| Engine | Insert docs/s | Point avg ms | Point p95 ms | "
+        "| Engine | Insert docs/s | Point read avg ms | Point read p95 ms | "
+        "Point update avg ms | Point update p95 ms | "
         "Indexed queries/s | Indexed rows/s | Update docs/s | Update s |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for result in results:
         if not result.get("available"):
             rows.append(
-                "| {0} | unavailable | unavailable | unavailable | "
-                "unavailable | unavailable | unavailable | unavailable |".format(
-                    result["engine"]
-                )
+                "| {0} | unavailable | unavailable | unavailable | unavailable | "
+                "unavailable | unavailable | unavailable | unavailable | "
+                "unavailable |".format(result["engine"])
             )
             continue
         rows.append(
             "| {engine} | {insert_docs_per_second:,.0f} | {point_avg_ms:.3f} | "
-            "{point_p95_ms:.3f} | {indexed_queries_per_second:,.1f} | "
+            "{point_p95_ms:.3f} | {point_update_avg_ms:.3f} | "
+            "{point_update_p95_ms:.3f} | {indexed_queries_per_second:,.1f} | "
             "{indexed_rows_per_second:,.0f} | {update_docs_per_second:,.0f} | "
             "{update_seconds:.3f} |".format(**result)
         )

--- a/tests/test_sqlite_bulk_updates.py
+++ b/tests/test_sqlite_bulk_updates.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import tinymongo as tm
+import tinymongo.table_backends as table_backends
 
 from tinymongo.errors import DuplicateKeyError, WriteError
 from tinymongo.indexes import parse_index_spec
@@ -65,7 +66,7 @@ def test_sqlite_bulk_update_uses_one_transaction_and_executemany(tmp_path, monke
 
     assert [sql for sql, _params in tracked.execute_calls] == [
         "BEGIN IMMEDIATE",
-        'SELECT _id, data FROM "items"',
+        'SELECT rowid, _id, data FROM "items" ORDER BY rowid',
     ]
     assert len(tracked.executemany_calls) == 1
     assert tracked.executemany_calls[0][0] == (
@@ -78,6 +79,151 @@ def test_sqlite_bulk_update_uses_one_transaction_and_executemany(tmp_path, monke
 
     reopened = SQLiteTableBackend(backend.path)
     assert [doc["count"] for doc in reopened.find("items", {})] == [11, 12, 3]
+
+
+def test_sqlite_exact_id_update_decodes_only_target_and_miss(
+    tmp_path,
+    monkeypatch,
+):
+    backend = SQLiteTableBackend(str(tmp_path / "targeted-id.sqlite"))
+    backend.insert_many(
+        "items",
+        [{"_id": index, "count": index} for index in range(100)],
+    )
+    decoded_ids = []
+    original_loads = table_backends._json_loads
+
+    def tracked_loads(value):
+        document = original_loads(value)
+        decoded_ids.append(document["_id"])
+        return document
+
+    monkeypatch.setattr(table_backends, "_json_loads", tracked_loads)
+
+    assert backend.update_many(
+        "items",
+        {"_id": 99},
+        {"$inc": {"count": 1}},
+        multi=False,
+    ) == [99]
+    assert decoded_ids == [99]
+
+    decoded_ids.clear()
+    assert (
+        backend.update_many(
+            "items",
+            {"_id": "missing"},
+            {"$set": {"seen": True}},
+            multi=False,
+        )
+        == []
+    )
+    assert decoded_ids == []
+
+
+def test_sqlite_indexed_update_decodes_only_bson_matching_candidates(
+    tmp_path,
+    monkeypatch,
+):
+    backend = SQLiteTableBackend(str(tmp_path / "targeted-index.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": "array-bool", "flag": [True]},
+            {"_id": "scalar-bool", "flag": True},
+            {"_id": "scalar-number", "flag": 1},
+            {"_id": "array-number", "flag": [1]},
+            {"_id": "other", "flag": False},
+        ],
+    )
+    backend.create_index("items", parse_index_spec("flag"))
+    decoded_ids = []
+    original_loads = table_backends._json_loads
+
+    def tracked_loads(value):
+        document = original_loads(value)
+        decoded_ids.append(document["_id"])
+        return document
+
+    monkeypatch.setattr(table_backends, "_json_loads", tracked_loads)
+
+    assert backend.update_many(
+        "items",
+        {"flag": True},
+        {"$set": {"matched": True}},
+    ) == ["array-bool", "scalar-bool"]
+    assert decoded_ids == ["scalar-bool", "array-bool"]
+
+
+def test_sqlite_indexed_update_one_keeps_natural_first_match(tmp_path):
+    backend = SQLiteTableBackend(str(tmp_path / "targeted-order.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": "array-first", "group": ["selected"], "state": "done"},
+            {"_id": "scalar-second", "group": "selected", "state": "pending"},
+        ],
+    )
+    backend.create_index("items", parse_index_spec("group"))
+
+    assert (
+        backend.update_many(
+            "items",
+            {"group": "selected"},
+            {"$set": {"state": "done"}},
+            multi=False,
+        )
+        == []
+    )
+    assert backend.find_one("items", {"_id": "scalar-second"})["state"] == "pending"
+
+
+def test_sqlite_targeted_update_falls_back_for_legacy_and_unsafe_candidates(
+    tmp_path,
+):
+    backend = SQLiteTableBackend(str(tmp_path / "targeted-fallbacks.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": "number", "value": 1},
+            {"_id": "object", "value": {"nested": 1}},
+        ],
+    )
+    backend.create_index("items", parse_index_spec("value"))
+
+    assert (
+        backend.update_many(
+            "items",
+            {"_id": {"missing": True}},
+            {"$set": {"seen": True}},
+            multi=False,
+        )
+        == []
+    )
+    assert (
+        backend.update_many(
+            "items",
+            {"value": float("nan")},
+            {"$set": {"seen": True}},
+            multi=False,
+        )
+        == []
+    )
+    assert (
+        backend.update_many(
+            "items",
+            {"value": 10**100},
+            {"$set": {"seen": True}},
+            multi=False,
+        )
+        == []
+    )
+    assert backend.update_many(
+        "items",
+        {"value": 1},
+        {"$set": {"seen": True}},
+    ) == ["number"]
+    assert backend.find_one("items", {"_id": "object"}).get("seen") is None
 
 
 def test_sqlite_bulk_update_validates_unique_post_image_atomically(tmp_path):

--- a/tests/test_sqlite_comparison_benchmark.py
+++ b/tests/test_sqlite_comparison_benchmark.py
@@ -1,0 +1,41 @@
+import importlib.util
+from pathlib import Path
+
+
+def _benchmark_module():
+    path = Path(__file__).parent / "benchmarks" / "bench_sqlite_comparison.py"
+    spec = importlib.util.spec_from_file_location("bench_sqlite_comparison", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sqlite_comparison_markdown_includes_point_update_schema():
+    benchmark = _benchmark_module()
+    available = benchmark._result(
+        "tinymongo-sqlite",
+        10,
+        2,
+        1.0,
+        [0.001, 0.003],
+        [0.004, 0.006],
+        0.5,
+        4,
+        0.25,
+        2,
+    )
+    unavailable = {
+        "engine": "mongodb",
+        "available": False,
+        "reason": "not running",
+    }
+
+    markdown = benchmark.format_markdown([available, unavailable])
+    lines = markdown.splitlines()
+
+    assert "Point update avg ms" in lines[0]
+    assert "Point update p95 ms" in lines[0]
+    assert lines[2].count("|") == lines[0].count("|")
+    assert "| 5.000 | 6.000 |" in lines[2]
+    assert lines[3].count("unavailable") == 9
+    assert lines[3].count("|") == lines[0].count("|")

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -2988,67 +2988,13 @@ class SQLiteTableBackend(TableBackend):
                 return _MISSING
 
             self._ensure_type_index_on_connection(conn, collection, spec)
-            where, params = self.compiler.compile(filter_doc)
-            path = _sql_literal(_json_path(field))
-            if isinstance(expected, bool):
-                scalar_types = ("true" if expected else "false",)
-            elif isinstance(expected, str):
-                scalar_types = ("text",)
-            else:
-                scalar_types = ("integer", "real")
-            scalar_sql = (
-                "SELECT data FROM {table}{where} "
-                "AND json_type(data, {path}) IN ({types})"
-            ).format(
-                table=_quote_identifier(collection),
-                where=where,
-                path=path,
-                types=", ".join(_sql_literal(kind) for kind in scalar_types),
-            )
-            type_expression = "json_type(data, {0})".format(path)
-            if isinstance(expected, bool):
-                member_predicate = "item.type = {0} AND item.value = ?".format(
-                    _sql_literal("true" if expected else "false")
-                )
-                member_params = [int(expected)]
-                candidate_predicate = (
-                    "{type_expression} = 'array' AND EXISTS ("
-                    "SELECT 1 FROM json_each(data, {path}) AS item "
-                    "WHERE {member_predicate})"
-                ).format(
-                    type_expression=type_expression,
-                    path=path,
-                    member_predicate=member_predicate,
-                )
-            elif isinstance(expected, str):
-                member_params = [expected]
-                candidate_predicate = (
-                    "{type_expression} = 'array' AND EXISTS ("
-                    "SELECT 1 FROM json_each(data, {path}) AS item "
-                    "WHERE item.type = 'text' AND item.value = ?)"
-                ).format(type_expression=type_expression, path=path)
-            else:
-                member_params = [expected]
-                candidate_predicate = (
-                    "({type_expression} = 'object' OR "
-                    "({type_expression} = 'array' AND EXISTS ("
-                    "SELECT 1 FROM json_each(data, {path}) AS item WHERE "
-                    "(item.type IN ('integer', 'real') AND item.value = ?) "
-                    "OR item.type = 'object')))"
-                ).format(type_expression=type_expression, path=path)
-            array_sql = (
-                "SELECT data FROM {table} WHERE {type_expression} "
-                "IN ('array', 'object') AND ({candidate_predicate})"
-            ).format(
-                table=_quote_identifier(collection),
-                type_expression=type_expression,
-                candidate_predicate=candidate_predicate,
-            )
             documents = []
             matched = 0
-            branches = (
-                (scalar_sql, params, False),
-                (array_sql, member_params, True),
+            branches = self._scalar_equality_query_branches(
+                collection,
+                filter_doc,
+                field,
+                expected,
             )
             for sql, sql_params, needs_postfilter in branches:
                 for row in conn.execute(sql, sql_params):
@@ -3076,6 +3022,174 @@ class SQLiteTableBackend(TableBackend):
             # those otherwise valid BSON numeric values.
             return None
         return None if result is _MISSING else result
+
+    def _scalar_equality_query_branches(
+        self,
+        collection,
+        filter_doc,
+        field,
+        expected,
+        select_columns="data",
+    ):
+        """Build exact scalar and conservative array equality candidates.
+
+        The scalar branch is exact after JSON type bracketing. The second
+        branch is a superset for array membership and encoded numeric objects,
+        so callers must apply the shared Python matcher when its final flag is
+        true. Keeping this SQL in one place lets reads and writes use the same
+        native expression indexes without changing MongoDB equality semantics.
+        """
+
+        where, params = self.compiler.compile(filter_doc)
+        path = _sql_literal(_json_path(field))
+        if isinstance(expected, bool):
+            scalar_types = ("true" if expected else "false",)
+        elif isinstance(expected, str):
+            scalar_types = ("text",)
+        else:
+            scalar_types = ("integer", "real")
+        scalar_sql = (
+            "SELECT {columns} FROM {table}{where} "
+            "AND json_type(data, {path}) IN ({types})"
+        ).format(
+            columns=select_columns,
+            table=_quote_identifier(collection),
+            where=where,
+            path=path,
+            types=", ".join(_sql_literal(kind) for kind in scalar_types),
+        )
+        type_expression = "json_type(data, {0})".format(path)
+        if isinstance(expected, bool):
+            member_predicate = "item.type = {0} AND item.value = ?".format(
+                _sql_literal("true" if expected else "false")
+            )
+            member_params = [int(expected)]
+            candidate_predicate = (
+                "{type_expression} = 'array' AND EXISTS ("
+                "SELECT 1 FROM json_each(data, {path}) AS item "
+                "WHERE {member_predicate})"
+            ).format(
+                type_expression=type_expression,
+                path=path,
+                member_predicate=member_predicate,
+            )
+        elif isinstance(expected, str):
+            member_params = [expected]
+            candidate_predicate = (
+                "{type_expression} = 'array' AND EXISTS ("
+                "SELECT 1 FROM json_each(data, {path}) AS item "
+                "WHERE item.type = 'text' AND item.value = ?)"
+            ).format(type_expression=type_expression, path=path)
+        else:
+            member_params = [expected]
+            candidate_predicate = (
+                "({type_expression} = 'object' OR "
+                "({type_expression} = 'array' AND EXISTS ("
+                "SELECT 1 FROM json_each(data, {path}) AS item WHERE "
+                "(item.type IN ('integer', 'real') AND item.value = ?) "
+                "OR item.type = 'object')))"
+            ).format(type_expression=type_expression, path=path)
+        array_sql = (
+            "SELECT {columns} FROM {table} WHERE {type_expression} "
+            "IN ('array', 'object') AND ({candidate_predicate})"
+        ).format(
+            columns=select_columns,
+            table=_quote_identifier(collection),
+            type_expression=type_expression,
+            candidate_predicate=candidate_predicate,
+        )
+        return (
+            (scalar_sql, params, False),
+            (array_sql, member_params, True),
+        )
+
+    def _update_candidate_rows_on_connection(
+        self,
+        conn,
+        collection,
+        filter_doc,
+        query_index_spec=None,
+    ):
+        """Load a naturally ordered superset for a non-unique update.
+
+        Direct ``_id`` predicates use the primary key. A top-level scalar
+        equality with a declared index uses the same scalar/array candidate
+        union as indexed reads. Unindexed and richer BSON predicates retain
+        the complete scan fallback. Every returned row is still checked by
+        :func:`matches_filter` before it can be changed.
+        """
+
+        table = _quote_identifier(collection)
+        direct_id = _direct_id_equality(filter_doc)
+        if direct_id is not _MISSING:
+            candidates = _physical_id_candidates(direct_id)
+            rows = conn.execute(
+                "SELECT rowid, _id, data FROM {0} WHERE _id IN ({1}) "
+                "ORDER BY rowid".format(
+                    table,
+                    ", ".join("?" for _ in candidates),
+                ),
+                candidates,
+            ).fetchall()
+            decoded = [
+                (
+                    natural_order,
+                    row_id,
+                    _restore_legacy_document_id(
+                        row_id,
+                        _json_loads(data),
+                        requested_id=direct_id,
+                    ),
+                )
+                for natural_order, row_id, data in rows
+            ]
+            if any(
+                matches_filter(document, filter_doc)
+                for _order, _id, document in decoded
+            ):
+                return decoded
+            if not _requires_legacy_id_scan(direct_id):
+                return decoded
+
+        equality = _simple_scalar_equality(filter_doc)
+        if query_index_spec is not None and equality is not None:
+            field, expected = equality
+            if isinstance(expected, float) and math.isnan(expected):
+                pass
+            else:
+                rows_by_id = {}
+                try:
+                    branches = self._scalar_equality_query_branches(
+                        collection,
+                        filter_doc,
+                        field,
+                        expected,
+                        select_columns="rowid, _id, data",
+                    )
+                    for sql, params, needs_postfilter in branches:
+                        for natural_order, row_id, data in conn.execute(sql, params):
+                            document = _json_loads(data)
+                            if needs_postfilter and not matches_filter(
+                                document,
+                                filter_doc,
+                            ):
+                                continue
+                            rows_by_id[row_id] = (
+                                natural_order,
+                                row_id,
+                                document,
+                            )
+                except OverflowError:
+                    pass
+                else:
+                    return sorted(rows_by_id.values(), key=lambda row: row[0])
+
+        return [
+            (natural_order, row_id, _json_loads(data))
+            for natural_order, row_id, data in conn.execute(
+                "SELECT rowid, _id, data FROM {0} ORDER BY rowid".format(table)
+            )
+        ]
 
     def _all_docs_unfiltered(self, collection):
         rows = self._run_collection_read(
@@ -3149,20 +3263,49 @@ class SQLiteTableBackend(TableBackend):
 
         self.create_collection(collection)
         specs = self.get_index_specs(collection)
+        unique_specs = [spec for spec in specs if spec.unique]
+        equality = _simple_scalar_equality(filter_doc)
+        query_index_spec = None
+        if equality is not None and "." not in equality[0]:
+            query_index_spec = next(
+                (spec for spec in specs if spec.field == equality[0]),
+                None,
+            )
         table = _quote_identifier(collection)
         conn = self._connect()
         try:
+            # Creating a companion array-candidate index commits SQLite schema
+            # work, so reconcile it before opening the update transaction.
+            if query_index_spec is not None and not unique_specs:
+                self._ensure_type_index_on_connection(
+                    conn,
+                    collection,
+                    query_index_spec,
+                )
             # Acquire SQLite's writer reservation before selecting candidates.
             # Together with TinyMongo's cross-process write lock this keeps the
             # validated post-image and the committed rows in the same atomic
             # read-check-write unit.
             conn.execute("BEGIN IMMEDIATE")
-            rows = conn.execute("SELECT _id, data FROM {0}".format(table)).fetchall()
-            originals = [(row_id, _json_loads(data)) for row_id, data in rows]
+            if unique_specs:
+                rows = conn.execute(
+                    "SELECT rowid, _id, data FROM {0} ORDER BY rowid".format(table)
+                ).fetchall()
+                originals = [
+                    (natural_order, row_id, _json_loads(data))
+                    for natural_order, row_id, data in rows
+                ]
+            else:
+                originals = self._update_candidate_rows_on_connection(
+                    conn,
+                    collection,
+                    filter_doc,
+                    query_index_spec=query_index_spec,
+                )
 
             matches = [
                 (row_id, document)
-                for row_id, document in originals
+                for _natural_order, row_id, document in originals
                 if matches_filter(document, filter_doc)
             ]
             if not multi:
@@ -3189,11 +3332,12 @@ class SQLiteTableBackend(TableBackend):
                 conn.rollback()
                 return [], 0, 0
 
-            post_image = [
-                replacement_by_row_id.get(row_id, document)
-                for row_id, document in originals
-            ]
-            validate_unique_documents(post_image, specs)
+            if unique_specs:
+                post_image = [
+                    replacement_by_row_id.get(row_id, document)
+                    for _natural_order, row_id, document in originals
+                ]
+                validate_unique_documents(post_image, specs)
 
             if replacements:
                 conn.executemany(


### PR DESCRIPTION
## Summary

- route exact SQLite `_id` updates through the native primary-key candidates instead of decoding the full collection
- reuse declared non-unique indexes for top-level bool/int/float/string equality updates, including conservative array/object candidates followed by exact BSON matching
- preserve natural row order so `update_one()` keeps first-match and first-no-op behavior
- extend the SQLite/raw SQLite/MongoDB benchmark with durable point updates and document the measured results
- update the roadmap, README, benchmark guide, and changelog

## Why

SQLite's `_update_many_transaction()` previously ran an unconditional full-table `SELECT`, BSON-decoded every document, filtered in Python, and built a complete post-image for every update. That happened even for an ordinary `update_one({"_id": ...})` call or an equality query backed by a declared index.

The existing single-transaction bulk-update work removed repeated commits, but candidate discovery remained O(collection size). This change removes that scan where SQLite can identify a safe candidate superset.

## Safety and compatibility

Candidate selection remains inside the existing `BEGIN IMMEDIATE` read-check-write transaction and the cross-process TinyMongo write lock.

- every candidate is checked with the shared BSON matcher before modification
- scalar and array/object candidates are deduplicated and sorted by SQLite `rowid` before applying `multi=False`
- exact `_id` lookups retain typed and released legacy physical-key candidates
- missing legacy container and datetime IDs retain the compatibility scan
- NaN, oversized integers, dotted fields, rich BSON predicates, and unindexed filters retain the complete scan
- any user-created unique index keeps complete post-image validation, including overlapping multikey-token and fail-closed legacy-catalog behavior
- native SQLite integrity failures still map to `DuplicateKeyError`

## Performance

The same updated benchmark driver ran against base commit `8d627af` and this branch with 10,000 documents, 200 deterministic durable point updates, Python 3.9.6, and SQLite WAL/`synchronous=NORMAL`.

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| `_id` point update average | 98.653 ms | 4.330 ms | 22.8x faster |
| `_id` point update p95 | 124.121 ms | 4.965 ms | 25.0x faster |
| Indexed 1,000-document update | 0.228 s | 0.144 s | 1.58x faster |
| Indexed update throughput | 4,395 docs/s | 6,968 docs/s | 1.59x higher |

Decode instrumentation changed from all 10,000 stored documents per point update to one document for a hit and zero for an ordinary miss. Raw SQLite remains documented as a lower bound because it does not provide TinyMongo's BSON, MongoDB query, validation, or update semantics.

## Validation

- full suite: 3,698 passed, 1 skipped, 531 deselected
- focused SQLite update and benchmark-schema tests: 14 passed
- branch coverage: 100% across `tinymongo/*`
- `ruff check .`
- `black --check .`
- `mypy --ignore-missing-imports tinymongo`
- controlled 10,000-document TinyMongo SQLite/raw SQLite before-and-after benchmark
- independent correctness review found no blocking transaction, uniqueness, legacy-ID, BSON, ordering, or concurrency issue

Related to #79 and #136; neither umbrella issue is closed by this focused performance change.
