### PR TITLE
Accelerate SQLite bulk inserts

### DIFF
--- a/tests/test_bson_codec_fast_path.py
+++ b/tests/test_bson_codec_fast_path.py
@@ -1,0 +1,155 @@
+"""Regression coverage for the exact-built-in BSON codec fast path."""
+
+import math
+
+import pytest
+
+from tinymongo import bson_codec, bson_types
+from tinymongo.errors import InvalidDocument
+
+
+def test_exact_json_builtins_do_not_consult_bson_registry(monkeypatch):
+    def unexpected_registry_lookup(value):
+        raise AssertionError(
+            "exact built-in {0!r} reached the BSON registry".format(type(value))
+        )
+
+    monkeypatch.setattr(bson_types, "bson_type_spec", unexpected_registry_lookup)
+    document = {
+        "null": None,
+        "boolean": True,
+        "integer": 42,
+        "double": 3.5,
+        "text": "ordinary",
+        "array": [1, "two", False],
+        "tuple": (3, None),
+        "nested": {"value": 4},
+        "nonfinite": float("inf"),
+    }
+
+    encoded = bson_codec.encode_value(document)
+
+    assert encoded == {
+        "null": None,
+        "boolean": True,
+        "integer": 42,
+        "double": 3.5,
+        "text": "ordinary",
+        "array": [1, "two", False],
+        "tuple": [3, None],
+        "nested": {"value": 4},
+        "nonfinite": {
+            "__tinymongo_type_v1__": "float",
+            "value": "infinity",
+        },
+    }
+
+
+def test_builtin_subclasses_still_consult_bson_registry(monkeypatch):
+    class Text(str):
+        pass
+
+    class Number(int):
+        pass
+
+    class Double(float):
+        pass
+
+    class Document(dict):
+        pass
+
+    class Array(list):
+        pass
+
+    original = bson_types.bson_type_spec
+    seen = []
+
+    def recording_registry_lookup(value):
+        seen.append(type(value))
+        return original(value)
+
+    monkeypatch.setattr(bson_types, "bson_type_spec", recording_registry_lookup)
+    value = Document(
+        {
+            "text": Text("subclass"),
+            "number": Number(7),
+            "double": Double(2.5),
+            "array": Array([Text("nested")]),
+        }
+    )
+
+    encoded = bson_codec.encode_value(value)
+
+    assert encoded == {
+        "text": "subclass",
+        "number": 7,
+        "double": 2.5,
+        "array": ["nested"],
+    }
+    assert {Document, Text, Number, Double, Array}.issubset(set(seen))
+
+
+def test_pymongo_native_subclasses_keep_their_bson_tags():
+    bson = pytest.importorskip("bson")
+    script = bson.Code("return answer;", {"answer": 42})
+    binary = bson.Binary(bytes(range(16)), subtype=4)
+
+    encoded = bson_codec.encode_value({"script": script, "binary": binary})
+    restored = bson_codec.decode_value(encoded)
+
+    assert encoded["script"]["__tinymongo_type_v1__"] == "code"
+    assert encoded["binary"]["__tinymongo_type_v1__"] == "binary"
+    assert type(restored["script"]) is bson.Code
+    assert restored["script"] == script
+    assert type(restored["binary"]) is bson.Binary
+    assert restored["binary"] == binary
+    assert restored["binary"].subtype == 4
+
+
+def test_fast_path_preserves_invalid_document_context_and_root():
+    document = {"outer": [{"unsupported": {1, 2}}]}
+
+    with pytest.raises(InvalidDocument) as caught:
+        bson_codec.dumps(document, document_context="batch document 8")
+
+    assert caught.value.document is document
+    assert "batch document 8" in str(caught.value)
+    assert "$['outer'][0]['unsupported']" in str(caught.value)
+
+
+def test_document_context_can_be_built_only_when_validation_fails():
+    context_calls = []
+
+    def context():
+        context_calls.append(True)
+        return "lazy batch document"
+
+    assert bson_codec.loads(
+        bson_codec.dumps({"value": 1}, document_context=context)
+    ) == {"value": 1}
+    assert context_calls == []
+
+    with pytest.raises(InvalidDocument) as caught:
+        bson_codec.dumps({"value": object()}, document_context=context)
+
+    assert context_calls == [True]
+    assert "lazy batch document" in str(caught.value)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_fast_path_keeps_nonfinite_float_round_trips(value):
+    restored = bson_codec.loads(bson_codec.dumps({"value": value}))["value"]
+
+    if math.isnan(value):
+        assert math.isnan(restored)
+    else:
+        assert restored == value
+
+
+def test_nonfinite_float_subclass_uses_the_bson_aware_fallback():
+    class Double(float):
+        pass
+
+    restored = bson_codec.loads(bson_codec.dumps({"value": Double("inf")}))["value"]
+
+    assert restored == float("inf")

--- a/tests/test_bulk_insert_planning.py
+++ b/tests/test_bulk_insert_planning.py
@@ -211,6 +211,83 @@ def test_engine_insert_many_uses_optional_conflict_candidate_hook():
     assert engine.candidate_calls == [("items", documents, [])]
 
 
+def test_engine_insert_many_candidate_hook_can_request_a_full_scan():
+    class Engine:
+        def find_insert_conflict_candidates(self, _collection, _documents, _specs):
+            return None
+
+        def find(self, _collection, _filter):
+            return []
+
+        def get_index_specs(self, _collection):
+            return []
+
+        def insert_many(self, _collection, documents, **_kwargs):
+            return list(range(len(documents)))
+
+    collection = SimpleNamespace(
+        full_name="app.items",
+        tablename="items",
+        parent=SimpleNamespace(engine=Engine()),
+    )
+    documents = [{"_id": "new"}]
+
+    results, accepted, errors = core._execute_engine_insert_many(
+        collection,
+        documents,
+        ordered=True,
+        bypass_document_validation=False,
+    )
+
+    assert results == [0]
+    assert accepted == documents
+    assert errors == []
+
+
+def test_sqlite_prepared_insert_internal_fallbacks(tmp_path):
+    backend = table_backends.SQLiteTableBackend(str(tmp_path / "prepared.sqlite"))
+    try:
+        with pytest.raises(ValueError, match="encoded documents must align"):
+            backend._prepare_insert_many(
+                [{"_id": "one"}],
+                encoded_documents=[],
+            )
+
+        prepared = backend._prepare_insert_many(
+            [{"_id": "one"}],
+            previous=[],
+        )
+        assert [item.document for item in prepared] == [{"_id": "one"}]
+
+        backend.insert_many_prevalidated("items", [{"_id": "existing"}])
+        assert (
+            backend.find_insert_conflict_candidates(
+                "items",
+                [{"_id": "new"}],
+                [],
+            )
+            == []
+        )
+        assert backend.find_insert_conflict_candidates(
+            "items",
+            [{"_id": "existing"}],
+            [],
+        ) == [{"_id": "existing"}]
+        assert (
+            backend.find_insert_conflict_candidates(
+                "items",
+                [{"_id": "new"}],
+                [IndexSpec("email", unique=True)],
+            )
+            is None
+        )
+        backend.create_collection("empty")
+        assert backend._commit_insert_rows("empty", []) == []
+        assert "empty" not in backend._known_nonempty_collections
+    finally:
+        backend.close()
+
+
 def test_sqlite_public_bulk_insert_queries_only_incoming_id_candidates(
     tmp_path,
     monkeypatch,

--- a/tests/test_insert_many_semantics.py
+++ b/tests/test_insert_many_semantics.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 
 import tinymongo
+import tinymongo.bson_codec as bson_codec
 import tinymongo.table_backends as table_backends
 from tinymongo.asyncio import AsyncTinyMongoClient
 from tinymongo.errors import BulkWriteError, DuplicateKeyError, InvalidDocument
@@ -152,10 +153,26 @@ def test_sqlite_targeted_preflight_replans_a_native_id_race(
     collection = client.app.native_race
     backend = collection.parent.engine
     collection.insert_one({"_id": "seed"})
-    original_insert_rows = backend._insert_rows
+    raced_key = table_backends._physical_id_key("raced")
+    raced_payload = table_backends._json_dumps({"_id": "raced"})
+    original_commit_insert_rows = backend._commit_insert_rows
+    original_dumps = bson_codec.dumps
+    original_physical_id_key = table_backends._physical_id_key
     attempts = 0
+    document_encodes = 0
+    physical_id_keys = 0
 
-    def racing_insert_rows(collection_name, documents):
+    def counting_dumps(value, *args, **kwargs):
+        nonlocal document_encodes
+        document_encodes += 1
+        return original_dumps(value, *args, **kwargs)
+
+    def counting_physical_id_key(value):
+        nonlocal physical_id_keys
+        physical_id_keys += 1
+        return original_physical_id_key(value)
+
+    def racing_commit_insert_rows(collection_name, rows):
         nonlocal attempts
         attempts += 1
         if attempts == 1:
@@ -164,27 +181,35 @@ def test_sqlite_targeted_preflight_replans_a_native_id_race(
                 conn.execute(
                     'INSERT INTO "native_race" (_id, data) VALUES (?, ?)',
                     (
-                        table_backends._physical_id_key("raced"),
-                        table_backends._json_dumps({"_id": "raced"}),
+                        raced_key,
+                        raced_payload,
                     ),
                 )
                 conn.commit()
             finally:
                 conn.close()
-            return original_insert_rows(collection_name, documents)
-        return original_insert_rows(collection_name, documents)
+            return original_commit_insert_rows(collection_name, rows)
+        return original_commit_insert_rows(collection_name, rows)
 
     def unexpected_full_scan(*_args, **_kwargs):
         raise AssertionError("the native-race retry should repeat the PK probe")
 
-    monkeypatch.setattr(backend, "_insert_rows", racing_insert_rows)
+    monkeypatch.setattr(backend, "_commit_insert_rows", racing_commit_insert_rows)
     monkeypatch.setattr(backend, "find", unexpected_full_scan)
+    monkeypatch.setattr(bson_codec, "dumps", counting_dumps)
+    monkeypatch.setattr(
+        table_backends,
+        "_physical_id_key",
+        counting_physical_id_key,
+    )
     documents = [{"_id": "first"}, {"_id": "raced"}, {"_id": "last"}]
     try:
         with pytest.raises(BulkWriteError) as caught:
             collection.insert_many(documents, ordered=ordered)
 
         assert attempts == 2
+        assert document_encodes == len(documents)
+        assert physical_id_keys == len(documents)
         assert caught.value.details["nInserted"] == expected_inserted
         assert [error["index"] for error in caught.value.details["writeErrors"]] == [1]
         conn = backend._connect()
@@ -193,6 +218,88 @@ def test_sqlite_targeted_preflight_replans_a_native_id_race(
         finally:
             conn.close()
         assert stored == expected_count
+    finally:
+        client.close()
+
+
+def test_sqlite_bulk_insert_encodes_and_keys_each_document_once(
+    tmp_path,
+    monkeypatch,
+):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.prepared_once
+    backend = collection.parent.engine
+    backend.create_collection(collection.name)
+    original_dumps = bson_codec.dumps
+    original_physical_id_key = table_backends._physical_id_key
+    document_encodes = 0
+    physical_id_keys = 0
+
+    def counting_dumps(value, *args, **kwargs):
+        nonlocal document_encodes
+        document_encodes += 1
+        return original_dumps(value, *args, **kwargs)
+
+    def counting_physical_id_key(value):
+        nonlocal physical_id_keys
+        physical_id_keys += 1
+        return original_physical_id_key(value)
+
+    monkeypatch.setattr(bson_codec, "dumps", counting_dumps)
+    monkeypatch.setattr(
+        table_backends,
+        "_physical_id_key",
+        counting_physical_id_key,
+    )
+    documents = [
+        {"_id": "prepared-{0}".format(index), "value": index} for index in range(8)
+    ]
+    try:
+        result = collection.insert_many(documents)
+
+        assert result.inserted_ids == [document["_id"] for document in documents]
+        assert document_encodes == len(documents)
+        assert physical_id_keys == len(documents)
+    finally:
+        client.close()
+
+
+def test_sqlite_prepared_rows_align_after_mixed_duplicate_rejections(tmp_path):
+    client = _client(tmp_path, "sqlite")
+    collection = client.app.prepared_alignment
+    collection.create_index("email", unique=True)
+    collection.insert_many(
+        [
+            {"_id": "id-owner", "email": "id-owner@example.com"},
+            {"_id": "email-owner", "email": "taken@example.com"},
+        ]
+    )
+    documents = [
+        {"_id": "accepted-first", "email": "batch@example.com"},
+        {"_id": "id-owner", "email": "unused@example.com"},
+        {"_id": "email-conflict", "email": "taken@example.com"},
+        {"_id": "batch-conflict", "email": "batch@example.com"},
+        {"_id": "accepted-last", "email": "last@example.com"},
+    ]
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many(documents, ordered=False)
+
+        details = caught.value.details
+        assert details["nInserted"] == 2
+        assert [error["index"] for error in details["writeErrors"]] == [1, 2, 3]
+        assert [error["op"] for error in details["writeErrors"]] == documents[1:4]
+        assert all(
+            error["op"] is documents[error["index"]] for error in details["writeErrors"]
+        )
+        assert {
+            document["_id"]: document["email"] for document in collection.find({})
+        } == {
+            "id-owner": "id-owner@example.com",
+            "email-owner": "taken@example.com",
+            "accepted-first": "batch@example.com",
+            "accepted-last": "last@example.com",
+        }
     finally:
         client.close()
 
@@ -230,8 +337,12 @@ def test_insert_many_applies_ordering_to_unique_index_failures(
 
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("ordered", [True, False])
+@pytest.mark.parametrize("bypass_document_validation", [False, True])
 def test_insert_many_serialization_preflight_is_all_or_nothing(
-    tmp_path, backend, ordered
+    tmp_path,
+    backend,
+    ordered,
+    bypass_document_validation,
 ):
     client = _client(tmp_path, backend)
     collection = client.app.items
@@ -242,7 +353,11 @@ def test_insert_many_serialization_preflight_is_all_or_nothing(
     ]
 
     with pytest.raises(InvalidDocument) as caught:
-        collection.insert_many(documents, ordered=ordered)
+        collection.insert_many(
+            documents,
+            ordered=ordered,
+            bypass_document_validation=bypass_document_validation,
+        )
 
     message = str(caught.value)
     assert caught.value.document is documents[1]

--- a/tests/test_sqlite_optimistic_inserts.py
+++ b/tests/test_sqlite_optimistic_inserts.py
@@ -1,0 +1,501 @@
+"""Contracts for SQLite's empty-collection optimistic insert path."""
+
+from collections import UserDict
+import importlib
+
+import pytest
+
+import tinymongo as tm
+import tinymongo.table_backends as table_backends
+from tinymongo.errors import BulkWriteError
+from tinymongo.indexes import IndexSpec
+
+
+core = importlib.import_module("tinymongo.tinymongo")
+
+
+def _collection(tmp_path, name="items"):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    collection = client.app[name]
+    collection.parent.engine.create_collection(collection.name)
+    return client, collection
+
+
+def _raw_documents(backend, collection):
+    conn = backend._connect()
+    try:
+        return [
+            table_backends._json_loads(row[0])
+            for row in conn.execute(
+                "SELECT data FROM {0} ORDER BY data".format(
+                    table_backends._quote_identifier(collection)
+                )
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def test_sqlite_empty_clean_batch_skips_conflict_planning(tmp_path, monkeypatch):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    original_connect = backend._connect
+    statements = []
+
+    def tracked_connect():
+        conn = original_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    def unexpected_planner(*_args, **_kwargs):
+        raise AssertionError("an empty clean batch should skip shared planning")
+
+    def unexpected_candidates(*_args, **_kwargs):
+        raise AssertionError("an empty clean batch should skip candidate reads")
+
+    monkeypatch.setattr(backend, "_connect", tracked_connect)
+    monkeypatch.setattr(core, "_plan_insert_many", unexpected_planner)
+    monkeypatch.setattr(
+        backend,
+        "_find_prepared_insert_conflict_candidates",
+        unexpected_candidates,
+    )
+    monkeypatch.setattr(backend, "find", unexpected_candidates)
+    documents = [{"_id": "one", "value": 1}, {"_id": "two", "value": 2}]
+    try:
+        result = collection.insert_many(documents)
+
+        assert result.inserted_ids == ["one", "two"]
+        begin = statements.index("BEGIN IMMEDIATE")
+        empty_probe = next(
+            index
+            for index, statement in enumerate(statements)
+            if statement.startswith('SELECT 1 FROM "items" LIMIT 1')
+        )
+        first_insert = next(
+            index
+            for index, statement in enumerate(statements)
+            if statement.startswith('INSERT INTO "items"')
+        )
+        commit = statements.index("COMMIT")
+        assert begin < empty_probe < first_insert < commit
+        assert not any(
+            statement.startswith('SELECT data FROM "items"') for statement in statements
+        )
+        assert _raw_documents(backend, collection.name) == documents
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("ordered", "expected_inserted", "expected_ids"),
+    [
+        (True, 2, {"first", "second"}),
+        (False, 3, {"first", "second", "last"}),
+    ],
+)
+def test_sqlite_empty_duplicate_rolls_back_before_planning(
+    tmp_path,
+    monkeypatch,
+    ordered,
+    expected_inserted,
+    expected_ids,
+):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    original_candidates = backend._find_prepared_insert_conflict_candidates
+    original_connect = backend._connect
+    original_insert_rows = backend._insert_rows_on_connection
+    fallback_counts = []
+    insert_attempts = 0
+
+    def checked_candidates(*args, **kwargs):
+        conn = original_connect()
+        try:
+            fallback_counts.append(
+                conn.execute('SELECT COUNT(*) FROM "items"').fetchone()[0]
+            )
+        finally:
+            conn.close()
+        return original_candidates(*args, **kwargs)
+
+    def counting_insert_rows(*args, **kwargs):
+        nonlocal insert_attempts
+        insert_attempts += 1
+        return original_insert_rows(*args, **kwargs)
+
+    monkeypatch.setattr(
+        backend,
+        "_find_prepared_insert_conflict_candidates",
+        checked_candidates,
+    )
+    monkeypatch.setattr(
+        backend,
+        "_insert_rows_on_connection",
+        counting_insert_rows,
+    )
+    documents = [
+        {"_id": "first"},
+        {"_id": "second"},
+        {"_id": "first"},
+        {"_id": "last"},
+    ]
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many(documents, ordered=ordered)
+
+        assert fallback_counts == [0]
+        assert insert_attempts == 2
+        assert caught.value.details["nInserted"] == expected_inserted
+        assert [error["index"] for error in caught.value.details["writeErrors"]] == [2]
+        assert caught.value.details["writeErrors"][0]["op"] is documents[2]
+        assert {document["_id"] for document in collection.find({})} == expected_ids
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("unique", "planner_expected"),
+    [(True, True), (False, False)],
+)
+def test_sqlite_index_gate_keeps_only_unique_indexes_on_the_planner(
+    tmp_path,
+    monkeypatch,
+    unique,
+    planner_expected,
+):
+    client, collection = _collection(tmp_path)
+    collection.create_index("email", unique=unique)
+    original_planner = core._plan_insert_many
+    planner_calls = 0
+
+    def tracked_planner(*args, **kwargs):
+        nonlocal planner_calls
+        planner_calls += 1
+        return original_planner(*args, **kwargs)
+
+    monkeypatch.setattr(core, "_plan_insert_many", tracked_planner)
+    try:
+        collection.insert_many(
+            [
+                {"_id": "one", "email": "one@example.com"},
+                {"_id": "two", "email": "two@example.com"},
+            ]
+        )
+
+        assert bool(planner_calls) is planner_expected
+    finally:
+        client.close()
+
+
+def test_sqlite_zero_timestamp_and_custom_mapping_skip_optimistic_path(
+    tmp_path,
+    monkeypatch,
+):
+    Timestamp = pytest.importorskip("bson").Timestamp
+    client, timestamp_collection = _collection(tmp_path, "timestamps")
+    custom_collection = client.app.custom_mappings
+    custom_collection.parent.engine.create_collection(custom_collection.name)
+    backend = timestamp_collection.parent.engine
+    zero = Timestamp(0, 0)
+
+    def unexpected_optimistic_insert(*_args, **_kwargs):
+        raise AssertionError("this batch requires shared planning")
+
+    monkeypatch.setattr(
+        backend,
+        "_try_empty_collection_insert_many",
+        unexpected_optimistic_insert,
+    )
+    monkeypatch.setattr(core.time_module, "time", lambda: 1000)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_SECONDS", 0)
+    monkeypatch.setattr(core, "_SERVER_TIMESTAMP_INCREMENT", 0)
+    timestamp_documents = [
+        {"_id": "one", "stamp": zero},
+        {"_id": "two", "stamp": zero},
+    ]
+    custom_document = UserDict({"_id": "custom", "value": 1})
+    try:
+        timestamp_collection.insert_many(timestamp_documents)
+        custom_collection.insert_many([custom_document])
+
+        assert [document["stamp"] for document in timestamp_documents] == [zero, zero]
+        assert timestamp_collection.find_one({"_id": "one"})["stamp"] == Timestamp(
+            1000, 1
+        )
+        assert timestamp_collection.find_one({"_id": "two"})["stamp"] == Timestamp(
+            1000, 2
+        )
+        assert custom_collection.find_one({"_id": "custom"}) == {
+            "_id": "custom",
+            "value": 1,
+        }
+    finally:
+        client.close()
+
+
+def test_sqlite_nonempty_legacy_row_gates_optimistic_write(tmp_path, monkeypatch):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    conn = backend._connect()
+    try:
+        conn.execute(
+            'INSERT INTO "items" (_id, data) VALUES (?, ?)',
+            ("same", table_backends._json_dumps({"_id": "same"})),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    original_insert_rows = backend._insert_rows_on_connection
+    insert_attempts = 0
+
+    def counting_insert_rows(*args, **kwargs):
+        nonlocal insert_attempts
+        insert_attempts += 1
+        return original_insert_rows(*args, **kwargs)
+
+    monkeypatch.setattr(
+        backend,
+        "_insert_rows_on_connection",
+        counting_insert_rows,
+    )
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many([{"_id": "same"}])
+
+        assert insert_attempts == 0
+        assert caught.value.details["nInserted"] == 0
+        assert caught.value.details["writeErrors"][0]["index"] == 0
+        assert len(_raw_documents(backend, collection.name)) == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_known_nonempty_collection_skips_repeated_empty_probes(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    original_connect = backend._connect
+    conn = original_connect()
+    try:
+        conn.execute(
+            'INSERT INTO "items" (_id, data) VALUES (?, ?)',
+            (
+                table_backends._physical_id_key("seed"),
+                table_backends._json_dumps({"_id": "seed"}),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    statements = []
+
+    def tracked_connect():
+        tracked = original_connect()
+        tracked.set_trace_callback(statements.append)
+        return tracked
+
+    monkeypatch.setattr(backend, "_connect", tracked_connect)
+    try:
+        collection.insert_many([{"_id": "first"}])
+        collection.insert_many([{"_id": "second"}])
+
+        assert (
+            sum(
+                statement.startswith('SELECT 1 FROM "items" LIMIT 1')
+                for statement in statements
+            )
+            == 1
+        )
+    finally:
+        client.close()
+
+
+def test_sqlite_unexpected_optimistic_error_rolls_back_and_propagates(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    original_insert_rows = backend._insert_rows_on_connection
+
+    def partial_insert_then_error(conn, collection_name, rows):
+        original_insert_rows(conn, collection_name, rows[:1])
+        raise RuntimeError("injected optimistic failure")
+
+    monkeypatch.setattr(
+        backend,
+        "_insert_rows_on_connection",
+        partial_insert_then_error,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="injected optimistic failure"):
+            collection.insert_many([{"_id": "one"}, {"_id": "two"}])
+
+        assert _raw_documents(backend, collection.name) == []
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    "table_sql",
+    [
+        'CREATE TABLE "items" (_id TEXT, data TEXT NOT NULL)',
+        'CREATE TABLE "items" '
+        "(_id TEXT PRIMARY KEY ON CONFLICT IGNORE, data TEXT NOT NULL)",
+        'CREATE TABLE "items" '
+        "(_id TEXT PRIMARY KEY ON CONFLICT REPLACE, data TEXT NOT NULL)",
+    ],
+)
+def test_sqlite_custom_table_conflict_rules_gate_optimistic_path(
+    tmp_path,
+    monkeypatch,
+    table_sql,
+):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    backend.drop_collection(collection.name)
+    conn = backend._connect()
+    try:
+        conn.execute(table_sql)
+        conn.commit()
+    finally:
+        conn.close()
+    backend._ready_collections.add(collection.name)
+    original_planner = core._plan_insert_many
+    planner_calls = 0
+
+    def tracked_planner(*args, **kwargs):
+        nonlocal planner_calls
+        planner_calls += 1
+        return original_planner(*args, **kwargs)
+
+    monkeypatch.setattr(core, "_plan_insert_many", tracked_planner)
+    documents = [{"_id": "duplicate"}, {"_id": "duplicate"}]
+    try:
+        with pytest.raises(BulkWriteError) as caught:
+            collection.insert_many(documents)
+
+        assert planner_calls == 1
+        assert caught.value.details["nInserted"] == 1
+        assert caught.value.details["writeErrors"][0]["index"] == 1
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    "schema_sql",
+    [
+        'CREATE TRIGGER "items_noop" AFTER INSERT ON "items" ' "BEGIN SELECT 1; END",
+        'CREATE UNIQUE INDEX "items_external_email" ON "items" '
+        "(json_extract(data, '$.email'))",
+    ],
+)
+def test_sqlite_external_schema_features_gate_optimistic_path(
+    tmp_path,
+    monkeypatch,
+    schema_sql,
+):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    conn = backend._connect()
+    try:
+        conn.execute(schema_sql)
+        conn.commit()
+    finally:
+        conn.close()
+    original_planner = core._plan_insert_many
+    planner_calls = 0
+
+    def tracked_planner(*args, **kwargs):
+        nonlocal planner_calls
+        planner_calls += 1
+        return original_planner(*args, **kwargs)
+
+    monkeypatch.setattr(core, "_plan_insert_many", tracked_planner)
+    try:
+        result = collection.insert_many(
+            [
+                {"_id": "one", "email": "one@example.com"},
+                {"_id": "two", "email": "two@example.com"},
+            ]
+        )
+
+        assert result.inserted_ids == ["one", "two"]
+        assert planner_calls == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_optimistic_path_fails_closed_if_catalog_read_ends_transaction(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    original_specs = backend._get_index_specs_on_connection
+    original_planner = core._plan_insert_many
+    spec_calls = 0
+    planner_calls = 0
+
+    def committing_specs(conn, collection_name):
+        nonlocal spec_calls
+        spec_calls += 1
+        specs = original_specs(conn, collection_name)
+        if spec_calls == 2:
+            conn.commit()
+        return specs
+
+    def tracked_planner(*args, **kwargs):
+        nonlocal planner_calls
+        planner_calls += 1
+        return original_planner(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "_get_index_specs_on_connection", committing_specs)
+    monkeypatch.setattr(core, "_plan_insert_many", tracked_planner)
+    try:
+        result = collection.insert_many([{"_id": "one"}])
+
+        assert result.inserted_ids == ["one"]
+        assert planner_calls == 1
+    finally:
+        client.close()
+
+
+def test_sqlite_optimistic_path_rechecks_unique_specs_inside_transaction(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    backend = collection.parent.engine
+    original_specs = backend._get_index_specs_on_connection
+    original_planner = core._plan_insert_many
+    spec_calls = 0
+    planner_calls = 0
+
+    def changing_specs(conn, collection_name):
+        nonlocal spec_calls
+        spec_calls += 1
+        if spec_calls == 1:
+            return []
+        if spec_calls == 2:
+            return [IndexSpec("email", unique=True)]
+        return original_specs(conn, collection_name)
+
+    def tracked_planner(*args, **kwargs):
+        nonlocal planner_calls
+        planner_calls += 1
+        return original_planner(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "_get_index_specs_on_connection", changing_specs)
+    monkeypatch.setattr(core, "_plan_insert_many", tracked_planner)
+    try:
+        result = collection.insert_many([{"_id": "one"}])
+
+        assert result.inserted_ids == ["one"]
+        assert planner_calls == 1
+    finally:
+        client.close()

--- a/tests/test_typed_physical_ids.py
+++ b/tests/test_typed_physical_ids.py
@@ -1,6 +1,8 @@
 """Focused contracts for BSON-aware SQL and Parquet physical `_id` keys."""
 
 from datetime import datetime, timedelta, timezone
+import hashlib
+import json
 
 import pytest
 
@@ -100,6 +102,21 @@ def test_physical_id_keys_follow_registered_bson_identity():
     assert _physical_id_key(float("inf")) != _physical_id_key(float("-inf"))
     assert _physical_id_key(float("nan")) == _physical_id_key(float("nan"))
     assert _physical_id_key([1, True]) == _physical_id_key((1, True))
+
+
+@pytest.mark.parametrize(
+    "value",
+    ("", 'quote-"', "line\nbreak", "nul-\0", "snowman-\N{SNOWMAN}"),
+)
+def test_exact_string_physical_id_fast_path_matches_canonical_format(value):
+    canonical = json.dumps(
+        _canonical_id_value(value),
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    expected = "__tinymongo_id_v2__:" + hashlib.sha256(canonical).hexdigest()
+
+    assert _physical_id_key(value) == expected
 
 
 def test_physical_id_fallback_and_malformed_legacy_rows(monkeypatch):

--- a/tinymongo/bson_codec.py
+++ b/tinymongo/bson_codec.py
@@ -64,6 +64,7 @@ _REGEX_BSON = "bson"
 _REGEX_TEXT = "string"
 _REGEX_BYTES = "bytes"
 _ROOT_UNSET = object()
+_BUILTIN_TREE_FALLBACK = object()
 
 
 def bson_available():
@@ -141,10 +142,71 @@ def _bounded_repr(value, limit=160):
     return rendered[: limit - 3] + "..."
 
 
+def _context_suffix(context):
+    if callable(context):
+        context = context()
+    return " for {0}".format(context) if context else ""
+
+
+def _encode_builtin_tree(value):
+    """Encode an exact-built-in tree or request the full BSON-aware path.
+
+    Most persisted documents contain only ordinary Python JSON values. Walking
+    those trees here avoids constructing an error path and consulting the BSON
+    registry for every leaf. Encountering any subclass, BSON value, unsupported
+    object, or reserved tag-shaped mapping restarts through ``encode_value`` so
+    validation errors and subclass precedence remain unchanged.
+    """
+
+    value_type = type(value)
+    if value is None or value_type is bool or value_type is int or value_type is str:
+        return value
+    if value_type is float:
+        return value if math.isfinite(value) else _encode_nonfinite_float(value)
+    if value_type is dict:
+        if set(value) == {_TYPE_MARKER, _VALUE_MARKER}:
+            return _BUILTIN_TREE_FALLBACK
+        encoded = {}
+        for key, item in value.items():
+            encoded_item = _encode_builtin_tree(item)
+            if encoded_item is _BUILTIN_TREE_FALLBACK:
+                return _BUILTIN_TREE_FALLBACK
+            encoded[str(key)] = encoded_item
+        return encoded
+    if value_type is list or value_type is tuple:
+        encoded = []
+        for item in value:
+            encoded_item = _encode_builtin_tree(item)
+            if encoded_item is _BUILTIN_TREE_FALLBACK:
+                return _BUILTIN_TREE_FALLBACK
+            encoded.append(encoded_item)
+        return encoded
+    return _BUILTIN_TREE_FALLBACK
+
+
 def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
     """Recursively convert supported non-JSON values into tagged JSON data."""
     if _root is _ROOT_UNSET:
         _root = value
+
+    # Ordinary JSON values make up the overwhelming majority of stored
+    # documents. Keep exact built-ins off the BSON registry path: checking the
+    # complete optional BSON type hierarchy for every string, integer, and
+    # container is both unnecessary and expensive. Exact-type checks are
+    # deliberate here. PyMongo types such as ``Code`` and ``Binary`` subclass
+    # native Python types and must continue through the registry below.
+    value_type = type(value)
+    if value is None or value_type is bool or value_type is int or value_type is str:
+        return value
+    if value_type is float:
+        if math.isfinite(value):
+            return value
+        return _encode_nonfinite_float(value)
+    if value_type is dict:
+        return _encode_mapping(value, _path, _root, _context)
+    if value_type is list or value_type is tuple:
+        return _encode_sequence(value, _path, _root, _context)
+
     spec = bson_types.bson_type_spec(value)
     storage_tag = spec.storage_tag if spec is not None else None
     if storage_tag == "objectid":
@@ -196,7 +258,7 @@ def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
                 _VALUE_MARKER: _encode_regex(value),
             }
         except (UnicodeDecodeError, ValueError) as error:
-            context = " for {0}".format(_context) if _context else ""
+            context = _context_suffix(_context)
             raise InvalidDocument(
                 "Invalid document{0} at {1!r}: cannot encode regular "
                 "expression {2}: {3}".format(
@@ -208,56 +270,15 @@ def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
                 document=_root,
             ) from error
     if isinstance(value, float) and not math.isfinite(value):
-        if math.isnan(value):
-            payload = "nan"
-        elif value < 0:
-            payload = "-infinity"
-        else:
-            payload = "infinity"
-        return {_TYPE_MARKER: _NONFINITE_FLOAT, _VALUE_MARKER: payload}
+        return _encode_nonfinite_float(value)
     if isinstance(value, Mapping):
-        # A user mapping can legitimately have the same two keys as one of our
-        # scalar tags. Wrap that exact shape so it cannot be silently decoded as
-        # a datetime/ObjectId when it crosses a persistence boundary.
-        if set(value) == {_TYPE_MARKER, _VALUE_MARKER}:
-            return {
-                _TYPE_MARKER: _ESCAPED_MAPPING,
-                _VALUE_MARKER: [
-                    [
-                        str(key),
-                        encode_value(
-                            item,
-                            _path=_nested_path(_path, key),
-                            _root=_root,
-                            _context=_context,
-                        ),
-                    ]
-                    for key, item in value.items()
-                ],
-            }
-        return {
-            str(key): encode_value(
-                item,
-                _path=_nested_path(_path, key),
-                _root=_root,
-                _context=_context,
-            )
-            for key, item in value.items()
-        }
+        return _encode_mapping(value, _path, _root, _context)
     if isinstance(value, (list, tuple)):
-        return [
-            encode_value(
-                item,
-                _path=_nested_path(_path, index),
-                _root=_root,
-                _context=_context,
-            )
-            for index, item in enumerate(value)
-        ]
+        return _encode_sequence(value, _path, _root, _context)
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
 
-    context = " for {0}".format(_context) if _context else ""
+    context = _context_suffix(_context)
     raise InvalidDocument(
         "Invalid document{0} at {1!r}: cannot encode object {2}, "
         "of type {3!r}".format(
@@ -268,6 +289,59 @@ def encode_value(value, _path="$", _root=_ROOT_UNSET, _context=None):
         ),
         document=_root,
     )
+
+
+def _encode_nonfinite_float(value):
+    if math.isnan(value):
+        payload = "nan"
+    elif value < 0:
+        payload = "-infinity"
+    else:
+        payload = "infinity"
+    return {_TYPE_MARKER: _NONFINITE_FLOAT, _VALUE_MARKER: payload}
+
+
+def _encode_mapping(value, path, root, context):
+    # A user mapping can legitimately have the same two keys as one of our
+    # scalar tags. Wrap that exact shape so it cannot be silently decoded as a
+    # datetime/ObjectId when it crosses a persistence boundary.
+    if set(value) == {_TYPE_MARKER, _VALUE_MARKER}:
+        return {
+            _TYPE_MARKER: _ESCAPED_MAPPING,
+            _VALUE_MARKER: [
+                [
+                    str(key),
+                    encode_value(
+                        item,
+                        _path=_nested_path(path, key),
+                        _root=root,
+                        _context=context,
+                    ),
+                ]
+                for key, item in value.items()
+            ],
+        }
+    return {
+        str(key): encode_value(
+            item,
+            _path=_nested_path(path, key),
+            _root=root,
+            _context=context,
+        )
+        for key, item in value.items()
+    }
+
+
+def _encode_sequence(value, path, root, context):
+    return [
+        encode_value(
+            item,
+            _path=_nested_path(path, index),
+            _root=root,
+            _context=context,
+        )
+        for index, item in enumerate(value)
+    ]
 
 
 def _encode_binary(value, subtype):
@@ -514,7 +588,10 @@ def decode_value(value):
 def dumps(value, document_context=None, **kwargs):
     """Serialize a TinyMongo value as JSON with BSON-compatible tagging."""
     kwargs.setdefault("allow_nan", False)
-    return json.dumps(encode_value(value, _context=document_context), **kwargs)
+    encoded = _encode_builtin_tree(value)
+    if encoded is _BUILTIN_TREE_FALLBACK:
+        encoded = encode_value(value, _context=document_context)
+    return json.dumps(encoded, **kwargs)
 
 
 def loads(value):

--- a/tinymongo/bson_types.py
+++ b/tinymongo/bson_types.py
@@ -732,6 +732,18 @@ def bson_identity_key(value):
     MongoDB-style numeric equality while booleans remain a separate family.
     """
 
+    value_type = type(value)
+    if value is None:
+        return "null", None
+    if value_type is str:
+        return "string", value
+    if value_type is bool:
+        return "boolean", value
+    if value_type is int or value_type is float:
+        return "number", _number_identity_key(value)
+    if value_type is bytes or value_type is bytearray:
+        return "binary", _binary_identity_key(value)
+
     spec = bson_type_spec(value)
     if spec is None:
         return None

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -140,6 +140,49 @@ _SIGNED_INT64_MAX = 2**63 - 1
 _SIGNED_INT32_MAX = 2**31 - 1
 
 
+class _PreparedSQLiteInsert(object):
+    """One validated SQLite row shared by preflight and final insertion."""
+
+    __slots__ = (
+        "document",
+        "payload",
+        "physical_id",
+        "_physical_id_candidates",
+        "_requires_legacy_scan",
+    )
+
+    def __init__(
+        self,
+        document,
+        payload,
+        physical_id,
+        physical_id_candidates=None,
+        requires_legacy_scan=None,
+    ):
+        self.document = document
+        self.payload = payload
+        self.physical_id = physical_id
+        self._physical_id_candidates = physical_id_candidates
+        self._requires_legacy_scan = requires_legacy_scan
+
+    @property
+    def physical_id_candidates(self):
+        if self._physical_id_candidates is None:
+            self._physical_id_candidates = _physical_id_candidates(
+                self.document["_id"],
+                current=self.physical_id,
+            )
+        return self._physical_id_candidates
+
+    @property
+    def requires_legacy_scan(self):
+        if self._requires_legacy_scan is None:
+            self._requires_legacy_scan = _requires_legacy_insert_scan(
+                self.document["_id"]
+            )
+        return self._requires_legacy_scan
+
+
 def _large_numeric_ratio(key):
     """Return an exact ratio that is unsafe for bounded int-to-text runtimes."""
 
@@ -235,18 +278,34 @@ def _canonical_id_value(value):
 
 def _physical_id_key(value):
     """Return the compact typed key stored in SQL and Parquet `_id` columns."""
-    canonical = json.dumps(
-        _canonical_id_value(value),
-        ensure_ascii=True,
-        separators=(",", ":"),
-    ).encode("ascii")
+
+    if type(value) is str:
+        # ``Code`` subclasses ``str`` and must retain its BSON identity, hence
+        # the deliberate exact-type check. This is byte-for-byte equivalent to
+        # the general registry/canonicalization path without its repeated JSON
+        # encode/decode cycle.
+        canonical = (
+            b'["registered-scalar",["string",'
+            + json.dumps(value, ensure_ascii=True).encode("ascii")
+            + b"]]"
+        )
+    else:
+        canonical = json.dumps(
+            _canonical_id_value(value),
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ).encode("ascii")
     return _PHYSICAL_ID_PREFIX + hashlib.sha256(canonical).hexdigest()
 
 
-def _physical_id_candidates(value):
+def _physical_id_candidates(value, current=None):
     """Return the v2 key followed by compatible legacy stringified keys."""
 
-    current = _physical_id_key(value)
+    if current is None:
+        current = _physical_id_key(value)
+    if type(value) is str:
+        return tuple(dict.fromkeys((current, value)))
+
     legacy = [_legacy_stringified_id(value)]
     old_typed = _legacy_large_ratio_physical_id_key(value)
     if old_typed is not None:
@@ -272,6 +331,8 @@ def _physical_id_candidates(value):
 def _requires_legacy_id_scan(value):
     """Return whether equivalent legacy IDs can have unpredictable strings."""
 
+    if type(value) in (str, bool, int, float, bytes, bytearray) or value is None:
+        return False
     if isinstance(value, (Mapping, list, tuple)):
         return True
     identity = bson_identity_key(value)
@@ -281,6 +342,8 @@ def _requires_legacy_id_scan(value):
 def _requires_legacy_insert_scan(value):
     """Return whether an insert preflight cannot enumerate every legacy key."""
 
+    if type(value) in (str, bool, int, float, bytes, bytearray) or value is None:
+        return False
     # Decimal128 support arrived after typed physical IDs. An incoming decimal
     # can still equal an int/float row written by a released pre-typed codec,
     # whose string key may not preserve the decimal's scale.
@@ -2023,6 +2086,7 @@ class SQLiteTableBackend(TableBackend):
         self._ready_collections = set()
         self._ready_type_indexes = set()
         self._query_index_cache = {}
+        self._known_nonempty_collections = set()
 
     def _physical_index_name(self, collection, spec):
         identity = "{0}\x00{1}\x00{2}".format(
@@ -2082,6 +2146,7 @@ class SQLiteTableBackend(TableBackend):
                 key for key in self._ready_type_indexes if key[0] != collection
             }
             self._query_index_cache.pop(collection, None)
+            self._known_nonempty_collections.discard(collection)
 
     def _run_collection_read(self, collection, operation):
         """Run one connection-scoped read, recovering once from an external drop."""
@@ -2371,6 +2436,60 @@ class SQLiteTableBackend(TableBackend):
         _validate_physical_ids(existing_docs, docs)
         return self._insert_rows(collection, docs)
 
+    def _prepare_insert_many(
+        self,
+        documents,
+        encoded_documents=None,
+        previous=None,
+    ):
+        """Prepare SQLite payloads and typed IDs once for an insert batch.
+
+        ``previous`` is positionally aligned with ``documents`` and is only
+        used after the shared planner has replaced a document with a
+        top-level server-timestamp copy. The planner never changes ``_id``, so
+        those rows need a new payload but can retain their physical key and
+        legacy candidate set.
+        """
+
+        if encoded_documents is not None and len(encoded_documents) != len(documents):
+            raise ValueError("encoded documents must align with documents")
+        if previous is not None and len(previous) != len(documents):
+            previous = None
+
+        prepared = []
+        for index, document in enumerate(documents):
+            prior = previous[index] if previous is not None else None
+            if prior is not None and prior.document is document:
+                prepared.append(prior)
+                continue
+
+            payload = (
+                encoded_documents[index]
+                if encoded_documents is not None
+                else _json_dumps(document)
+            )
+            if prior is not None:
+                prepared.append(
+                    _PreparedSQLiteInsert(
+                        document,
+                        payload,
+                        prior.physical_id,
+                        prior._physical_id_candidates,
+                        prior._requires_legacy_scan,
+                    )
+                )
+                continue
+
+            physical_id = _physical_id_key(document["_id"])
+            prepared.append(
+                _PreparedSQLiteInsert(
+                    document,
+                    payload,
+                    physical_id,
+                )
+            )
+        return prepared
+
     def find_insert_conflict_candidates(self, collection, documents, specs):
         """Load SQLite rows whose primary keys can conflict with a batch.
 
@@ -2391,6 +2510,134 @@ class SQLiteTableBackend(TableBackend):
                 for candidate in _physical_id_candidates(document["_id"])
             )
         )
+        return self._load_insert_conflict_candidates(collection, candidates)
+
+    def _find_prepared_insert_conflict_candidates(
+        self,
+        collection,
+        prepared_documents,
+        specs,
+    ):
+        """Load conflicts using physical IDs already prepared for insertion."""
+
+        if any(spec.unique for spec in specs) or any(
+            prepared.requires_legacy_scan for prepared in prepared_documents
+        ):
+            return None
+        candidates = tuple(
+            dict.fromkeys(
+                candidate
+                for prepared in prepared_documents
+                for candidate in prepared.physical_id_candidates
+            )
+        )
+        return self._load_insert_conflict_candidates(collection, candidates)
+
+    @_write_locked
+    def _try_empty_collection_insert_many(
+        self,
+        collection,
+        prepared_documents,
+        bypass_document_validation=False,
+    ):
+        """Insert a simple batch atomically when its collection is empty.
+
+        Empty storage proves that no current or legacy physical ID can already
+        conflict. Batches with durable unique indexes retain the shared planner
+        because a legacy catalog may intentionally lack its native constraint.
+        Any within-batch native conflict rolls the entire attempt back before
+        collection-level planning produces MongoDB-compatible partial results.
+        """
+
+        with self._sqlite_state_lock:
+            if collection in self._known_nonempty_collections:
+                return None
+
+        self.create_collection(collection)
+        conn = self._connect()
+        try:
+            # Bring any stale index catalog forward before beginning the
+            # optimistic transaction because that one-time migration commits.
+            specs = self._get_index_specs_on_connection(conn, collection)
+            if any(spec.unique for spec in specs):
+                return None
+
+            conn.execute("BEGIN IMMEDIATE")
+            # Re-read under SQLite's write reservation so an external schema
+            # writer cannot add a unique constraint between the safety check
+            # and the batch insert.
+            specs = self._get_index_specs_on_connection(conn, collection)
+            if not conn.in_transaction:
+                return None
+            if any(spec.unique for spec in specs):
+                conn.rollback()
+                return None
+            table = _quote_identifier(collection)
+
+            # TinyMongo does not create triggers, and its only unique SQLite
+            # index outside the primary key is represented in ``specs`` above.
+            # Fail closed around externally customized schemas. In particular,
+            # a missing PK or ``ON CONFLICT IGNORE/REPLACE`` could make a batch
+            # with duplicate IDs appear to succeed, while a trigger could skip
+            # a row or perform an irreversible speculative side effect.
+            expected_table_sql = (
+                "CREATE TABLE {0} "
+                "(_id TEXT PRIMARY KEY, data TEXT NOT NULL)".format(table)
+            )
+            table_sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (collection,),
+            ).fetchone()
+            has_trigger = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'trigger' "
+                "AND tbl_name = ? LIMIT 1",
+                (collection,),
+            ).fetchone()
+            has_external_unique_index = any(
+                row[2] and row[3] != "pk"
+                for row in conn.execute(
+                    "PRAGMA index_list({0})".format(table)
+                ).fetchall()
+            )
+            if (
+                table_sql is None
+                or table_sql[0] != expected_table_sql
+                or has_trigger is not None
+                or has_external_unique_index
+            ):
+                conn.rollback()
+                return None
+
+            if (
+                conn.execute("SELECT 1 FROM {0} LIMIT 1".format(table)).fetchone()
+                is not None
+            ):
+                conn.rollback()
+                with self._sqlite_state_lock:
+                    self._known_nonempty_collections.add(collection)
+                return None
+
+            rows = [
+                (prepared.physical_id, prepared.payload)
+                for prepared in prepared_documents
+            ]
+            try:
+                results = self._insert_rows_on_connection(conn, collection, rows)
+                conn.commit()
+            except sqlite3.IntegrityError:
+                conn.rollback()
+                return None
+            with self._sqlite_state_lock:
+                self._known_nonempty_collections.add(collection)
+            return results
+        finally:
+            if conn.in_transaction:
+                conn.rollback()
+            conn.close()
+
+    def _load_insert_conflict_candidates(self, collection, candidates):
+        """Decode rows matching one already canonicalized candidate set."""
+
         if not candidates:  # pragma: no cover - public batches are non-empty
             return []
 
@@ -2431,22 +2678,51 @@ class SQLiteTableBackend(TableBackend):
         self.create_collection(collection)
         return self._insert_rows(collection, docs)
 
+    @_write_locked
+    def _insert_many_prepared(
+        self,
+        collection,
+        prepared_documents,
+        bypass_document_validation=False,
+    ):
+        """Commit rows whose validation, encoding, and IDs are complete."""
+
+        self.create_collection(collection)
+        rows = [
+            (prepared.physical_id, prepared.payload) for prepared in prepared_documents
+        ]
+        return self._commit_insert_rows(collection, rows)
+
     def _insert_rows(self, collection, docs):
         """Serialize and commit one already validated SQLite insert batch."""
 
         rows = [(_physical_id_key(doc["_id"]), _json_dumps(doc)) for doc in docs]
+        return self._commit_insert_rows(collection, rows)
+
+    def _commit_insert_rows(self, collection, rows):
+        """Commit one sequence of physical SQLite rows."""
+
         conn = self._connect()
         try:
-            sql = "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
-                _quote_identifier(collection)
-            )
-            conn.executemany(sql, rows)
+            results = self._insert_rows_on_connection(conn, collection, rows)
             conn.commit()
-            return list(range(len(rows)))
+            if rows:
+                with self._sqlite_state_lock:
+                    self._known_nonempty_collections.add(collection)
+            return results
         except sqlite3.IntegrityError as exc:
             raise DuplicateKeyError(str(exc))
         finally:
             conn.close()
+
+    def _insert_rows_on_connection(self, conn, collection, rows):
+        """Execute physical rows without choosing transaction boundaries."""
+
+        sql = "INSERT INTO {0} (_id, data) VALUES (?, ?)".format(
+            _quote_identifier(collection)
+        )
+        conn.executemany(sql, rows)
+        return list(range(len(rows)))
 
     def _find_direct_id(self, collection, filter_doc, projection=None):
         """Resolve one exact ``_id`` predicate through SQLite's primary key."""

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -168,6 +168,29 @@ def _stamp_top_level_server_timestamps(document):
     return document if stamped is None else stamped
 
 
+def _can_try_optimistic_insert_many(documents):
+    """Return whether a batch can bypass planning if SQLite is empty.
+
+    Custom mapping classes retain the general planner because their iteration
+    and copy behavior can be observable. Direct all-zero timestamps must also
+    reach the planner in order so its logical clock and caller-copy guarantees
+    remain unchanged.
+    """
+
+    for document in documents:
+        if type(document) is not dict:
+            return False
+        if _TIMESTAMP is not None and any(
+            key != "_id"
+            and isinstance(value, _TIMESTAMP)
+            and value.time == 0
+            and value.inc == 0
+            for key, value in document.items()
+        ):
+            return False
+    return True
+
+
 def _get_nested(doc, path, default=_MISSING):
     current = doc
     for key in path.split("."):
@@ -295,6 +318,7 @@ def _plan_insert_many(
     specs,
     ordered,
     original_documents=None,
+    accepted_indexes=None,
 ):
     """Split a batch into inserts and duplicate-key write errors."""
     if original_documents is None:
@@ -365,6 +389,8 @@ def _plan_insert_many(
                 break
         else:
             accepted.append(document)
+            if accepted_indexes is not None:
+                accepted_indexes.append(index)
             if identity is None:
                 fallback_ids.append(value)
             else:
@@ -383,6 +409,7 @@ def _execute_engine_insert_many(
     ordered,
     bypass_document_validation,
     original_documents=None,
+    encoded_documents=None,
 ):
     """Plan and execute a table-backend batch, retrying native races."""
 
@@ -392,18 +419,49 @@ def _execute_engine_insert_many(
     last_error = None
     accepted = []
     write_errors = []
+    prepare_documents = getattr(engine, "_prepare_insert_many", None)
+    prepared_documents = None
+    if callable(prepare_documents):
+        prepared_documents = prepare_documents(
+            documents,
+            encoded_documents=encoded_documents,
+        )
+
+    try_empty_insert = getattr(engine, "_try_empty_collection_insert_many", None)
+    if (
+        prepared_documents is not None
+        and callable(try_empty_insert)
+        and _can_try_optimistic_insert_many(documents)
+    ):
+        optimistic_results = try_empty_insert(
+            collection.tablename,
+            prepared_documents,
+            bypass_document_validation=bypass_document_validation is True,
+        )
+        if optimistic_results is not None:
+            return list(optimistic_results), list(documents), []
 
     # Remote SQL constraints are the final cross-process authority. If another
     # writer commits after our preflight, the native insert fails atomically;
     # re-read and re-plan so the public error still identifies the original
     # operation and preserves ordered/unordered semantics.
     for _attempt in range(3):
-        find_candidates = getattr(
+        find_prepared_candidates = getattr(
             engine,
-            "find_insert_conflict_candidates",
+            "_find_prepared_insert_conflict_candidates",
             None,
         )
-        if not callable(find_candidates):
+        find_candidates = getattr(engine, "find_insert_conflict_candidates", None)
+        if prepared_documents is not None and callable(find_prepared_candidates):
+            specs = engine.get_index_specs(collection.tablename)
+            existing_documents = find_prepared_candidates(
+                collection.tablename,
+                prepared_documents,
+                specs,
+            )
+            if existing_documents is None:
+                existing_documents = engine.find(collection.tablename, {})
+        elif not callable(find_candidates):
             existing_documents = engine.find(collection.tablename, {})
             specs = engine.get_index_specs(collection.tablename)
         else:
@@ -415,6 +473,7 @@ def _execute_engine_insert_many(
             )
             if existing_documents is None:
                 existing_documents = engine.find(collection.tablename, {})
+        accepted_indexes = []
         accepted, write_errors = _plan_insert_many(
             collection,
             documents,
@@ -422,20 +481,43 @@ def _execute_engine_insert_many(
             specs,
             ordered,
             original_documents=original_documents,
+            accepted_indexes=accepted_indexes,
         )
         if not accepted:
             return [], accepted, write_errors
+
+        accepted_prepared = None
+        if prepared_documents is not None:
+            # The planner replaces documents containing a top-level
+            # Timestamp(0, 0) with their stamped copies. Reconcile only those
+            # slots while reusing every ordinary document's validated payload
+            # and physical key, including across a native-constraint retry.
+            prepared_documents = prepare_documents(
+                documents,
+                previous=prepared_documents,
+            )
+            accepted_prepared = [
+                prepared_documents[index] for index in accepted_indexes
+            ]
         try:
-            insert_prevalidated = getattr(
-                engine,
-                "insert_many_prevalidated",
-                engine.insert_many,
-            )
-            results = insert_prevalidated(
-                collection.tablename,
-                accepted,
-                bypass_document_validation=bypass_document_validation is True,
-            )
+            insert_prepared = getattr(engine, "_insert_many_prepared", None)
+            if accepted_prepared is not None and callable(insert_prepared):
+                results = insert_prepared(
+                    collection.tablename,
+                    accepted_prepared,
+                    bypass_document_validation=bypass_document_validation is True,
+                )
+            else:
+                insert_prevalidated = getattr(
+                    engine,
+                    "insert_many_prevalidated",
+                    engine.insert_many,
+                )
+                results = insert_prevalidated(
+                    collection.tablename,
+                    accepted,
+                    bypass_document_validation=bypass_document_validation is True,
+                )
         except DuplicateKeyError as error:
             last_error = error
             continue
@@ -2108,15 +2190,19 @@ class TinyMongoCollection(object):
 
         from .bson_codec import dumps as encode_storage_payload
 
-        context = "collection {0!r}".format(self.full_name)
-        if index is not None:
-            context += ", document index {0}".format(index)
-        if "_id" in document:
-            context += ", document _id={0!r}".format(document["_id"])
-        encode_storage_payload(
+        def document_context():
+            context = "collection {0!r}".format(self.full_name)
+            if index is not None:
+                context += ", document index {0}".format(index)
+            if "_id" in document:
+                context += ", document _id={0!r}".format(document["_id"])
+            return context
+
+        return encode_storage_payload(
             document,
-            document_context=context,
+            document_context=document_context,
             ensure_ascii=False,
+            separators=(",", ":"),
         )
 
     @property
@@ -2732,10 +2818,25 @@ class TinyMongoCollection(object):
         # changing storage. PyMongo can split very large inputs across multiple
         # wire batches, so TinyMongo intentionally provides a stronger
         # whole-list guarantee here.
-        for index, doc in enumerate(stored_docs):
-            self._validate_storage_document(doc, index=index)
-
         engine = self.parent.engine
+        prepared_hook_names = (
+            "_prepare_insert_many",
+            "_find_prepared_insert_conflict_candidates",
+            "_insert_many_prepared",
+        )
+        retain_encoded_documents = engine is not None and all(
+            callable(getattr(engine, name, None)) for name in prepared_hook_names
+        )
+        if retain_encoded_documents:
+            encoded_documents = [
+                self._validate_storage_document(doc, index=index)
+                for index, doc in enumerate(stored_docs)
+            ]
+        else:
+            encoded_documents = None
+            for index, doc in enumerate(stored_docs):
+                self._validate_storage_document(doc, index=index)
+
         if engine is not None:
             results, accepted, write_errors = _execute_engine_insert_many(
                 self,
@@ -2743,6 +2844,7 @@ class TinyMongoCollection(object):
                 ordered,
                 bypass_document_validation,
                 original_documents=docs,
+                encoded_documents=encoded_documents,
             )
             if write_errors:
                 raise BulkWriteError(_bulk_write_details(len(accepted), write_errors))


### PR DESCRIPTION
## Summary

This PR speeds up SQLite-backed bulk inserts without changing the MongoDB-compatible behavior exposed by TinyMongo.

- Adds exact-built-in BSON encoding and identity-key fast paths while preserving subclass handling for types such as `Code` and `Binary`.
- Prepares each SQLite insert once, reusing its serialized payload and typed physical `_id` across candidate checks, retries, and commits.
- Adds an optimistic initial-load path for empty, canonical SQLite tables.
- Avoids repeatedly probing collections already known to be nonempty.
- Expands coverage around ordered/unordered failures, retries, timestamps, typed IDs, custom mappings, schema changes, triggers, and unique indexes.

## Why

Profiling showed that most bulk-insert time was spent above SQLite: repeated BSON checks, JSON serialization, identity-key construction, and candidate planning. The new prepared-row path removes that duplicate work. For a brand-new compatible table, the optimistic path also skips the general conflict planner after proving under a write transaction that the table is empty and safe.

## Contract and safety boundaries

The optimistic path is deliberately narrow:

- It accepts only exact built-in document shapes that have already passed BSON validation.
- It is disabled for top-level zero timestamps that require server-time stamping.
- It begins an immediate transaction and rechecks the index catalog, schema, and emptiness inside that transaction.
- It is disabled for unique catalog specs, triggers, external unique indexes, legacy/custom table definitions, and noncanonical primary-key behavior.
- Any SQLite integrity failure, including commit-time failure, rolls back and falls back to the existing Mongo-compatible planner.
- Nonempty collections retain the prepared general path, including ordered and unordered error semantics.

## Local benchmark

Median local throughput for 10,000-document batches:

| Engine/path | Inserts/sec |
| --- | ---: |
| TinyMongo SQLite on `master` | 13,123 |
| TinyMongo SQLite, nonempty prepared path | 63,486 |
| TinyMongo SQLite, initial empty-table path | 70,250 |
| MongoDB (`w=1, j=true`) | 108,890 |
| Direct SQLite | 258,821 |

The initial-load path is about **5.35x faster** than the previous TinyMongo SQLite baseline and about **19% faster** than the prepared-only stage. MongoDB results were noisier across runs; its comparison explicitly used acknowledged, journaled writes. Direct SQLite is an implementation ceiling rather than a contract-equivalent comparison.

## Validation

- Full suite: `3744 passed, 1 skipped, 531 deselected`
- Coverage: `100%` across 8,314 statements and 3,524 branches
- `ruff check .`
- `black --check .`
- `git diff --check`
