### PR TITLE
Accelerate indexed SQLite complex reads

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -226,7 +226,17 @@ The normalized unique-token ledger remains a possible later optimization for
 bulk inserts into collections with user-created unique indexes. TM-040's
 measured no-index application path no longer needs that larger migration.
 
-#### SQLite candidate-selective updates
+#### SQLite candidate-selective reads and updates
+
+- [x] Reuse declared top-level SQLite expression indexes as conservative
+  candidate sources for complex positive `$and` reads with scalar equality or
+  `$in` anchors. Push safe numeric ranges and `$mod` into SQLite, then retain
+  the shared BSON matcher as final authority for arrays, extended BSON values,
+  large numbers, projections, counts, and cursor bounds.
+- [x] Add a reproducible 10,000-document complex-read comparison. The local
+  warmed run improved TinyMongo SQLite from about 6.4 to 73.9 queries/second
+  while returning the same 215 decoded rows as raw SQLite and MongoDB; raw
+  SQLite reached 361.2 and MongoDB reached 136.0 queries/second.
 
 - [x] Route exact `_id` updates through SQLite's primary key inside the existing
   `BEGIN IMMEDIATE` transaction instead of BSON-decoding the complete

--- a/tests/benchmarks/bench_sqlite_complex_reads.py
+++ b/tests/benchmarks/bench_sqlite_complex_reads.py
@@ -1,0 +1,501 @@
+"""Compare warmed point and complex reads across three storage engines.
+
+This is a local benchmark, not a pytest test.  TinyMongo SQLite, raw SQLite,
+and MongoDB receive the same logical documents and the same single-field
+``group`` index.  Every timed operation fully materializes and validates its
+documents, so the measurements include each engine's normal result decoding.
+
+The complex filter deliberately combines ``$and``, ``$in``, a numeric range,
+and ``$mod``.  Raw SQLite expresses those predicates in SQL; TinyMongo and
+MongoDB receive the equivalent MongoDB filter.  Raw SQLite is a useful lower
+bound, but it does not provide TinyMongo's MongoDB-compatible BSON semantics.
+MongoDB runs in a uniquely named temporary database that is dropped afterward.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import os
+import platform
+import random
+import sqlite3
+import statistics
+import sys
+import tempfile
+import time
+import uuid
+
+import tinymongo as tm
+
+
+ENGINES = ("tinymongo-sqlite", "raw-sqlite", "mongodb")
+COMPLEX_GROUPS = ("g1", "g3", "g7")
+COMPLEX_LOWER_BOUND = 2500
+COMPLEX_UPPER_BOUND = 7500
+COMPLEX_MODULUS = 7
+COMPLEX_REMAINDER = 0
+COMPLEX_FILTER = {
+    "$and": [
+        {"group": {"$in": list(COMPLEX_GROUPS)}},
+        {
+            "i": {
+                "$gte": COMPLEX_LOWER_BOUND,
+                "$lt": COMPLEX_UPPER_BOUND,
+            }
+        },
+        {"i": {"$mod": [COMPLEX_MODULUS, COMPLEX_REMAINDER]}},
+    ]
+}
+_SQLITE_SYNCHRONOUS_NAMES = {0: "OFF", 1: "NORMAL", 2: "FULL", 3: "EXTRA"}
+
+
+def _docs(count):
+    return [
+        {
+            "_id": "doc-{0}".format(index),
+            "i": index,
+            "group": "g{0}".format(index % 10),
+            "payload": "value-{0}".format(index),
+        }
+        for index in range(count)
+    ]
+
+
+def _point_targets(documents, queries):
+    """Return the same deterministic, non-sequential targets for every engine."""
+
+    generator = random.Random(1974)
+    return ["doc-{0}".format(generator.randrange(documents)) for _ in range(queries)]
+
+
+def _complex_expected(documents):
+    return [
+        document
+        for document in documents
+        if document["group"] in COMPLEX_GROUPS
+        and COMPLEX_LOWER_BOUND <= document["i"] < COMPLEX_UPPER_BOUND
+        and document["i"] % COMPLEX_MODULUS == COMPLEX_REMAINDER
+    ]
+
+
+def _percentile(values, percentile):
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    index = int(round((percentile / 100.0) * (len(ordered) - 1)))
+    return ordered[index]
+
+
+def _metric(latencies, rows):
+    seconds = sum(latencies)
+    queries = len(latencies)
+    return {
+        "queries": queries,
+        "rows": rows,
+        "rows_per_query": rows / queries if queries else 0.0,
+        "seconds": seconds,
+        "queries_per_second": queries / seconds if seconds else 0.0,
+        "rows_per_second": rows / seconds if seconds else 0.0,
+        "average_ms": statistics.mean(latencies) * 1000 if latencies else 0.0,
+        "median_ms": statistics.median(latencies) * 1000 if latencies else 0.0,
+        "p95_ms": _percentile(latencies, 95) * 1000,
+    }
+
+
+def _sqlite_settings(conn):
+    journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    synchronous = conn.execute("PRAGMA synchronous").fetchone()[0]
+    return {
+        "journal_mode": str(journal_mode).upper(),
+        "synchronous": _SQLITE_SYNCHRONOUS_NAMES.get(synchronous, str(synchronous)),
+    }
+
+
+def _validate_one(found, expected, engine):
+    if found is None:
+        raise AssertionError(
+            "{0} point lookup missed {1}".format(engine, expected["_id"])
+        )
+    if found != expected:
+        raise AssertionError(
+            "{0} point lookup returned the wrong document for {1}".format(
+                engine,
+                expected["_id"],
+            )
+        )
+
+
+def _validate_many(found, expected_by_id, engine):
+    if len(found) != len(expected_by_id):
+        raise AssertionError(
+            "{0} complex query returned {1} rows, expected {2}".format(
+                engine,
+                len(found),
+                len(expected_by_id),
+            )
+        )
+    found_by_id = {}
+    for document in found:
+        document_id = document.get("_id")
+        if document_id in found_by_id:
+            raise AssertionError(
+                "{0} complex query returned duplicate _id {1}".format(
+                    engine,
+                    document_id,
+                )
+            )
+        found_by_id[document_id] = document
+    if found_by_id != expected_by_id:
+        missing = sorted(set(expected_by_id) - set(found_by_id))[:5]
+        extra = sorted(set(found_by_id) - set(expected_by_id))[:5]
+        raise AssertionError(
+            "{0} complex query returned different documents; missing={1}, "
+            "extra={2}".format(engine, missing, extra)
+        )
+
+
+def _measure_reads(
+    engine,
+    read_one,
+    read_complex,
+    documents,
+    queries,
+    warmups,
+):
+    docs_by_id = {document["_id"]: document for document in documents}
+    expected_complex = _complex_expected(documents)
+    expected_complex_by_id = {
+        document["_id"]: document for document in expected_complex
+    }
+    targets = _point_targets(len(documents), queries)
+
+    for _ in range(warmups):
+        for target in targets:
+            _validate_one(read_one(target), docs_by_id[target], engine)
+        _validate_many(read_complex(), expected_complex_by_id, engine)
+
+    point_latencies = []
+    for target in targets:
+        started = time.perf_counter()
+        found = read_one(target)
+        point_latencies.append(time.perf_counter() - started)
+        _validate_one(found, docs_by_id[target], engine)
+
+    complex_latencies = []
+    complex_rows = 0
+    for _ in range(queries):
+        started = time.perf_counter()
+        found = read_complex()
+        complex_latencies.append(time.perf_counter() - started)
+        _validate_many(found, expected_complex_by_id, engine)
+        complex_rows += len(found)
+
+    return {
+        "engine": engine,
+        "available": True,
+        "documents": len(documents),
+        "warmups": warmups,
+        "point": _metric(point_latencies, len(point_latencies)),
+        "complex": _metric(complex_latencies, complex_rows),
+        "complex_rows_per_query": len(expected_complex),
+    }
+
+
+def _run_tinymongo_sqlite(documents, queries, warmups, work_root):
+    db_dir = tempfile.mkdtemp(prefix="tinymongo-complex-read-", dir=work_root)
+    client = tm.TinyMongoClient(db_dir, backend="sqlite")
+    try:
+        collection = client.read_benchmark.records
+        docs = _docs(documents)
+        result = collection.insert_many(docs)
+        if len(result.inserted_ids) != documents:
+            raise AssertionError("TinyMongo inserted the wrong number of documents")
+        collection.create_index("group")
+
+        settings_conn = collection.parent.engine._connect()
+        try:
+            settings = _sqlite_settings(settings_conn)
+        finally:
+            settings_conn.close()
+
+        benchmark_result = _measure_reads(
+            "tinymongo-sqlite",
+            lambda target: collection.find_one({"_id": target}),
+            lambda: list(collection.find(COMPLEX_FILTER)),
+            docs,
+            queries,
+            warmups,
+        )
+        benchmark_result["indexes"] = ["group"]
+        benchmark_result["sqlite_settings"] = settings
+        return benchmark_result
+    finally:
+        client.close()
+
+
+def _run_raw_sqlite(documents, queries, warmups, work_root):
+    descriptor, path = tempfile.mkstemp(
+        prefix="raw-complex-read-",
+        suffix=".sqlite",
+        dir=work_root,
+    )
+    os.close(descriptor)
+    conn = sqlite3.connect(path, timeout=30)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE records (_id TEXT PRIMARY KEY, data TEXT NOT NULL)")
+        docs = _docs(documents)
+        conn.executemany(
+            "INSERT INTO records (_id, data) VALUES (?, ?)",
+            [
+                (
+                    document["_id"],
+                    json.dumps(
+                        document,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                )
+                for document in docs
+            ],
+        )
+        conn.execute(
+            "CREATE INDEX records_group " "ON records (json_extract(data, '$.group'))"
+        )
+        conn.commit()
+
+        complex_sql = (
+            "SELECT data FROM records "
+            "WHERE json_extract(data, '$.group') IN (?, ?, ?) "
+            "AND json_extract(data, '$.i') >= ? "
+            "AND json_extract(data, '$.i') < ? "
+            "AND CAST(json_extract(data, '$.i') AS INTEGER) % ? = ?"
+        )
+        complex_parameters = COMPLEX_GROUPS + (
+            COMPLEX_LOWER_BOUND,
+            COMPLEX_UPPER_BOUND,
+            COMPLEX_MODULUS,
+            COMPLEX_REMAINDER,
+        )
+        query_plan = conn.execute(
+            "EXPLAIN QUERY PLAN " + complex_sql,
+            complex_parameters,
+        ).fetchall()
+        if not any("records_group" in str(row[-1]) for row in query_plan):
+            raise AssertionError("raw SQLite did not use the group index")
+
+        def read_one(target):
+            row = conn.execute(
+                "SELECT data FROM records WHERE _id = ?",
+                (target,),
+            ).fetchone()
+            return None if row is None else json.loads(row[0])
+
+        def read_complex():
+            rows = conn.execute(complex_sql, complex_parameters).fetchall()
+            return [json.loads(row[0]) for row in rows]
+
+        benchmark_result = _measure_reads(
+            "raw-sqlite",
+            read_one,
+            read_complex,
+            docs,
+            queries,
+            warmups,
+        )
+        benchmark_result["indexes"] = ["group"]
+        benchmark_result["sqlite_settings"] = _sqlite_settings(conn)
+        benchmark_result["complex_query_plan"] = [str(row[-1]) for row in query_plan]
+        return benchmark_result
+    finally:
+        conn.close()
+
+
+def _run_mongodb(documents, queries, warmups, mongo_uri):
+    if not mongo_uri:
+        return {
+            "engine": "mongodb",
+            "available": False,
+            "reason": "set TINYMONGO_MONGODB_URI or pass --mongo-uri",
+        }
+    try:
+        import pymongo
+        from pymongo.write_concern import WriteConcern
+    except ImportError:
+        return {
+            "engine": "mongodb",
+            "available": False,
+            "reason": "install the pymongo benchmark dependency",
+        }
+
+    client = pymongo.MongoClient(mongo_uri, serverSelectionTimeoutMS=3000)
+    try:
+        client.admin.command("ping")
+    except Exception as exc:
+        client.close()
+        return {
+            "engine": "mongodb",
+            "available": False,
+            "reason": "MongoDB is unavailable: {0}".format(exc),
+        }
+
+    database_name = "tinymongo_read_perf_{0}_{1}".format(
+        os.getpid(),
+        uuid.uuid4().hex[:10],
+    )
+    write_concern = WriteConcern(w=1, j=True)
+    database = client.get_database(database_name, write_concern=write_concern)
+    collection = database.records
+    docs = _docs(documents)
+    try:
+        insert_result = collection.insert_many(docs)
+        if not insert_result.acknowledged:
+            raise AssertionError("MongoDB did not acknowledge the insert batch")
+        if len(insert_result.inserted_ids) != documents:
+            raise AssertionError("MongoDB inserted the wrong number of documents")
+        collection.create_index("group")
+
+        benchmark_result = _measure_reads(
+            "mongodb",
+            lambda target: collection.find_one({"_id": target}),
+            lambda: list(collection.find(COMPLEX_FILTER)),
+            docs,
+            queries,
+            warmups,
+        )
+        benchmark_result["indexes"] = ["group"]
+        benchmark_result["write_concern"] = write_concern.document
+        return benchmark_result
+    finally:
+        try:
+            client.drop_database(database_name)
+        finally:
+            client.close()
+
+
+def _format_read_table(results, metric_name, description):
+    rows = [
+        "### {0}".format(description),
+        "",
+        "| Engine | Queries | Rows/query | Queries/s | Rows/s | "
+        "Average ms | Median ms | p95 ms |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        if not result.get("available"):
+            rows.append(
+                "| {0} | unavailable | unavailable | unavailable | unavailable | "
+                "unavailable | unavailable | unavailable |".format(result["engine"])
+            )
+            continue
+        metric = result[metric_name]
+        rows.append(
+            "| {0} | {queries:,} | {rows_per_query:,.0f} | "
+            "{queries_per_second:,.1f} | {rows_per_second:,.0f} | "
+            "{average_ms:.3f} | {median_ms:.3f} | {p95_ms:.3f} |".format(
+                result["engine"], **metric
+            )
+        )
+    return rows
+
+
+def format_markdown(results):
+    rows = _format_read_table(
+        results,
+        "point",
+        "Simple `_id` lookup (one fully decoded document per query)",
+    )
+    rows.extend(
+        [
+            "",
+            "The complex query is `$and(group $in, i range, i $mod)` and every "
+            "engine fully decodes and validates the same result documents.",
+            "",
+        ]
+    )
+    rows.extend(
+        _format_read_table(
+            results,
+            "complex",
+            "Complex read (identical fully decoded result set per query)",
+        )
+    )
+    unavailable = [result for result in results if not result.get("available")]
+    if unavailable:
+        rows.extend(["", "Unavailable engines:"])
+        for result in unavailable:
+            rows.append("- {0}: {1}".format(result["engine"], result["reason"]))
+    return "\n".join(rows)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--docs", type=int, default=10000)
+    parser.add_argument("--queries", type=int, default=200)
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--engine", action="append", choices=ENGINES)
+    parser.add_argument("--work-root")
+    parser.add_argument("--mongo-uri", default=os.getenv("TINYMONGO_MONGODB_URI"))
+    parser.add_argument("--json-output")
+    parser.add_argument("--markdown-output")
+    args = parser.parse_args(argv)
+    if args.docs <= 0 or args.queries <= 0:
+        parser.error("--docs and --queries must both be positive")
+    if args.warmups < 0:
+        parser.error("--warmups must not be negative")
+
+    work_root = args.work_root or tempfile.mkdtemp(
+        prefix="tinymongo-complex-read-compare-"
+    )
+    os.makedirs(work_root, exist_ok=True)
+    requested = args.engine or list(ENGINES)
+    runners = {
+        "tinymongo-sqlite": lambda: _run_tinymongo_sqlite(
+            args.docs,
+            args.queries,
+            args.warmups,
+            work_root,
+        ),
+        "raw-sqlite": lambda: _run_raw_sqlite(
+            args.docs,
+            args.queries,
+            args.warmups,
+            work_root,
+        ),
+        "mongodb": lambda: _run_mongodb(
+            args.docs,
+            args.queries,
+            args.warmups,
+            args.mongo_uri,
+        ),
+    }
+    results = [runners[engine]() for engine in requested]
+    payload = {
+        "documents": args.docs,
+        "queries": args.queries,
+        "warmups": args.warmups,
+        "work_root": work_root,
+        "indexes": ["group"],
+        "complex_filter": COMPLEX_FILTER,
+        "environment": {
+            "platform": platform.platform(),
+            "python": sys.version,
+        },
+        "results": results,
+    }
+    markdown = format_markdown(results)
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    if args.markdown_output:
+        with open(args.markdown_output, "w", encoding="utf-8") as handle:
+            handle.write(markdown)
+            handle.write("\n")
+    print(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sqlite_complex_read_candidates.py
+++ b/tests/test_sqlite_complex_read_candidates.py
@@ -1,0 +1,659 @@
+"""Contracts for conservative SQLite complex-read candidate selection."""
+
+import sqlite3
+
+import pytest
+
+import tinymongo as tm
+from tinymongo import table_backends
+from tinymongo.errors import DuplicateKeyError
+from tinymongo.indexes import parse_index_spec
+
+
+BENCHMARK_QUERY = {
+    "$and": [
+        {"group": {"$in": ["g1", "g3", "g7"]}},
+        {"i": {"$gte": 40, "$lt": 360}},
+        {"i": {"$mod": [7, 0]}},
+    ]
+}
+
+
+def _collection(tmp_path, name="items"):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    return client, client.app[name]
+
+
+def _track_decodes(monkeypatch):
+    decoded_payloads = []
+    original_loads = table_backends._json_loads
+
+    def tracked_loads(value):
+        decoded_payloads.append(value)
+        return original_loads(value)
+
+    monkeypatch.setattr(table_backends, "_json_loads", tracked_loads)
+    return decoded_payloads
+
+
+def _matching_ids(documents, query):
+    return [
+        document["_id"]
+        for document in documents
+        if table_backends.matches_filter(document, query)
+    ]
+
+
+def _add_benchmark_indexes(collection):
+    collection.create_index("group", name="group_lookup")
+    collection.create_index("i", name="i_lookup")
+
+
+def test_sqlite_complex_and_in_range_mod_decodes_only_final_scalar_candidates(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "complex_candidates")
+    documents = [
+        {
+            "_id": index,
+            "group": "g{0}".format(index % 10),
+            "i": index,
+            "payload": "x" * 1_000,
+        }
+        for index in range(400)
+    ]
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+    expected_ids = _matching_ids(documents, BENCHMARK_QUERY)
+    decodes = _track_decodes(monkeypatch)
+
+    try:
+        found = list(collection.find(BENCHMARK_QUERY))
+
+        assert [document["_id"] for document in found] == expected_ids
+        assert len(decodes) == len(expected_ids)
+        assert len(decodes) < len(documents) // 10
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_preserve_array_member_matches(tmp_path):
+    client, collection = _collection(tmp_path, "complex_arrays")
+    documents = [
+        {"_id": "scalar", "group": "g1", "i": 56},
+        {"_id": "array-group", "group": ["other", "g3"], "i": 63},
+        {"_id": "array-number", "group": "g7", "i": [-1, 70, 500]},
+        {"_id": "wrong-group", "group": ["g2", "g4"], "i": 77},
+        {"_id": "wrong-mod", "group": "g1", "i": [57, 58]},
+    ]
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+
+    try:
+        assert {row["_id"] for row in collection.find(BENCHMARK_QUERY)} == {
+            "scalar",
+            "array-group",
+            "array-number",
+        }
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_keep_mixed_scalar_types_distinct(tmp_path):
+    client, collection = _collection(tmp_path, "complex_mixed_types")
+    documents = [
+        {"_id": "bool", "group": True, "i": 7},
+        {"_id": "number", "group": 1, "i": 7},
+        {"_id": "string", "group": "1", "i": 7},
+        {"_id": "bool-array", "group": [False, True], "i": 7},
+        {"_id": "number-array", "group": [0, 1], "i": 7},
+        {"_id": "string-array", "group": ["0", "1"], "i": 7},
+        {"_id": "miss", "group": False, "i": 7},
+    ]
+    query = {
+        "$and": [
+            {"group": {"$in": [True, 1, "1"]}},
+            {"i": {"$mod": [7, 0]}},
+        ]
+    }
+    collection.insert_many(documents)
+    collection.create_index("group")
+
+    try:
+        assert [row["_id"] for row in collection.find(query)] == [
+            "bool",
+            "number",
+            "string",
+            "bool-array",
+            "number-array",
+            "string-array",
+        ]
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_preserve_safe_and_int64_numeric_boundaries(
+    tmp_path,
+):
+    client, collection = _collection(tmp_path, "complex_numeric_boundaries")
+    safe = table_backends._SQLITE_SAFE_QUERY_NUMBER
+    int64_min = -(2**63)
+    documents = [
+        {"_id": "below-safe", "group": "g1", "i": -safe - 1},
+        {"_id": "safe-match", "group": "g1", "i": -safe},
+        {"_id": "safe-neighbor", "group": "g1", "i": -safe + 1},
+        {"_id": "safe-array", "group": "g1", "i": [-safe - 1, -safe]},
+        {"_id": "int64-match", "group": "g1", "i": int64_min},
+        {"_id": "int64-neighbor", "group": "g1", "i": int64_min + 1},
+        {"_id": "wrong-group", "group": "g2", "i": -safe},
+    ]
+    safe_query = {
+        "$and": [
+            {"group": {"$in": ["g1"]}},
+            {"i": {"$gte": -safe, "$lte": safe}},
+            {"i": {"$mod": [7, -3]}},
+        ]
+    }
+    int64_remainder = table_backends._truncating_remainder(int64_min, 7)
+    int64_query = {
+        "$and": [
+            {"group": {"$in": ["g1"]}},
+            {"i": {"$gte": int64_min, "$lte": int64_min + 1}},
+            {"i": {"$mod": [7, int64_remainder]}},
+        ]
+    }
+    collection.insert_many(documents)
+    collection.create_index("group")
+
+    try:
+        assert [row["_id"] for row in collection.find(safe_query)] == [
+            "safe-match",
+            "safe-array",
+        ]
+        assert [row["_id"] for row in collection.find(int64_query)] == ["int64-match"]
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_restore_natural_order_before_bounds(tmp_path):
+    client, collection = _collection(tmp_path, "complex_candidate_order")
+    documents = [
+        {"_id": "scalar-first", "group": "g1", "i": 7},
+        {"_id": "array-first", "group": ["g1"], "i": 14},
+        {"_id": "scalar-miss", "group": "g2", "i": 21},
+        {"_id": "array-second", "group": ["other", "g1"], "i": 28},
+        {"_id": "scalar-second", "group": "g1", "i": 35},
+    ]
+    query = {
+        "$and": [
+            {"group": {"$in": ["g1"]}},
+            {"i": {"$mod": [7, 0]}},
+        ]
+    }
+    collection.insert_many(documents)
+    collection.create_index("group")
+
+    try:
+        assert [row["_id"] for row in collection.find(query).skip(1).limit(2)] == [
+            "array-first",
+            "array-second",
+        ]
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_preserve_embedded_object_in_matches(tmp_path):
+    client, collection = _collection(tmp_path, "complex_objects")
+    documents = [
+        {"_id": "match", "group": {"name": "g1", "rank": 1}, "i": 14},
+        {"_id": "different-object", "group": {"name": "g1"}, "i": 14},
+        {"_id": "outside-range", "group": {"name": "g1", "rank": 1}, "i": -1},
+    ]
+    query = {
+        "$and": [
+            {"group": {"$in": [{"name": "g1", "rank": 1}]}},
+            {"i": {"$gte": 0, "$lt": 100}},
+        ]
+    }
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+
+    try:
+        assert [row["_id"] for row in collection.find(query)] == ["match"]
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_preserve_decimal128_numeric_matches(tmp_path):
+    bson = pytest.importorskip("bson")
+    client, collection = _collection(tmp_path, "complex_decimals")
+    documents = [
+        {"_id": "decimal-match", "group": "g1", "i": bson.Decimal128("56")},
+        {"_id": "decimal-mod-miss", "group": "g1", "i": bson.Decimal128("57")},
+        {"_id": "ordinary-match", "group": "g3", "i": 63},
+    ]
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+
+    try:
+        assert {row["_id"] for row in collection.find(BENCHMARK_QUERY)} == {
+            "decimal-match",
+            "ordinary-match",
+        }
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_preserve_large_integer_matches(tmp_path):
+    client, collection = _collection(tmp_path, "complex_large_numbers")
+    huge = 2**100
+    documents = [
+        {"_id": "match", "group": "g1", "i": huge},
+        {"_id": "nearby", "group": "g1", "i": huge + 10},
+        {"_id": "wrong-group", "group": "g2", "i": huge},
+    ]
+    query = {
+        "$and": [
+            {"group": {"$in": ["g1"]}},
+            {"i": {"$gte": huge - 1, "$lte": huge + 1}},
+        ]
+    }
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+
+    try:
+        assert [row["_id"] for row in collection.find(query)] == ["match"]
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_unsupported_or_branch_falls_back_without_false_negatives(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "complex_unsupported")
+    documents = [
+        {"_id": 1, "group": "g1", "score": 1, "label": "inside"},
+        {"_id": 2, "group": "g1", "score": 2, "label": "inside"},
+        {"_id": 3, "group": "g2", "score": 3, "label": "outside-match"},
+        {"_id": 4, "group": "g2", "score": 4, "label": "outside-miss"},
+    ]
+    query = {
+        "$or": [
+            {
+                "$and": [
+                    {"group": {"$in": ["g1"]}},
+                    {"score": {"$ne": 2}},
+                ]
+            },
+            {"label": {"$regex": "^outside-match$"}},
+        ]
+    }
+    collection.insert_many(documents)
+    collection.create_index("group")
+    decodes = _track_decodes(monkeypatch)
+
+    try:
+        assert [row["_id"] for row in collection.find(query)] == [1, 3]
+        assert len(decodes) == len(documents)
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_negative_only_filter_uses_safe_full_scan(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "complex_negative")
+    documents = [
+        {"_id": 1, "group": "g1"},
+        {"_id": 2, "group": "g2"},
+        {"_id": 3},
+    ]
+    collection.insert_many(documents)
+    collection.create_index("group")
+    decodes = _track_decodes(monkeypatch)
+
+    try:
+        assert [row["_id"] for row in collection.find({"group": {"$nin": ["g1"]}})] == [
+            2,
+            3,
+        ]
+        assert len(decodes) == len(documents)
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_keep_bounds_projection_and_count_semantics(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "complex_consumers")
+    documents = [
+        {
+            "_id": index,
+            "group": "g{0}".format(index % 10),
+            "i": index,
+            "label": "item-{0}".format(index),
+            "payload": "x" * 1_000,
+        }
+        for index in range(400)
+    ]
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+    expected_ids = _matching_ids(documents, BENCHMARK_QUERY)
+    decodes = _track_decodes(monkeypatch)
+
+    try:
+        bounded = list(collection.find(BENCHMARK_QUERY).skip(2).limit(3))
+        assert [row["_id"] for row in bounded] == expected_ids[2:5]
+        assert len(decodes) <= 5
+
+        decodes.clear()
+        projected = list(
+            collection.find(BENCHMARK_QUERY, {"label": 1, "_id": 0}).skip(1).limit(2)
+        )
+        assert projected == [
+            {"label": "item-{0}".format(index)} for index in expected_ids[1:3]
+        ]
+        assert len(decodes) <= 3
+
+        decodes.clear()
+        assert collection.count_documents(BENCHMARK_QUERY) == len(expected_ids)
+        assert len(decodes) <= len(expected_ids)
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_query_without_declared_indexes_remains_complete(tmp_path):
+    client, collection = _collection(tmp_path, "complex_no_index")
+    documents = [
+        {"_id": index, "group": "g{0}".format(index % 10), "i": index}
+        for index in range(400)
+    ]
+    collection.insert_many(documents)
+    expected_ids = _matching_ids(documents, BENCHMARK_QUERY)
+
+    try:
+        assert [row["_id"] for row in collection.find(BENCHMARK_QUERY)] == (
+            expected_ids
+        )
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_query_recovers_dropped_native_index_storage(tmp_path):
+    client, collection = _collection(tmp_path, "complex_dropped_index")
+    documents = [
+        {"_id": index, "group": "g{0}".format(index % 10), "i": index}
+        for index in range(100)
+    ]
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+    backend = collection.parent.engine
+    specs = [
+        parse_index_spec("group", name="group_lookup"),
+        parse_index_spec("i", name="i_lookup"),
+    ]
+
+    # Warm the query metadata and the native companion-index cache first.
+    assert list(collection.find(BENCHMARK_QUERY))
+    connection = sqlite3.connect(backend.path)
+    try:
+        for spec in specs:
+            physical = backend._physical_index_name(collection.name, spec)
+            connection.execute(
+                "DROP INDEX IF EXISTS {0}".format(
+                    table_backends._quote_identifier(physical)
+                )
+            )
+            connection.execute(
+                "DROP INDEX IF EXISTS {0}".format(
+                    table_backends._quote_identifier(physical + "_types")
+                )
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+    try:
+        assert [row["_id"] for row in collection.find(BENCHMARK_QUERY)] == (
+            _matching_ids(documents, BENCHMARK_QUERY)
+        )
+
+        connection = sqlite3.connect(backend.path)
+        try:
+            rebuilt = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'index'"
+                )
+            }
+        finally:
+            connection.close()
+        anchor_spec = next(spec for spec in specs if spec.field == "group")
+        physical = backend._physical_index_name(collection.name, anchor_spec)
+        assert physical in rebuilt
+        assert physical + "_types" in rebuilt
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_query_handles_missing_index_catalog_as_no_index(tmp_path):
+    client, collection = _collection(tmp_path, "complex_missing_catalog")
+    documents = [
+        {"_id": index, "group": "g{0}".format(index % 10), "i": index}
+        for index in range(100)
+    ]
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+    backend = collection.parent.engine
+
+    # Populate the schema-versioned query cache before another writer removes
+    # the catalog. The next read must invalidate the cache and scan safely.
+    assert list(collection.find(BENCHMARK_QUERY))
+    connection = sqlite3.connect(backend.path)
+    try:
+        connection.execute(
+            "DROP TABLE {0}".format(
+                table_backends._quote_identifier(backend.index_catalog_table)
+            )
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    try:
+        assert [row["_id"] for row in collection.find(BENCHMARK_QUERY)] == (
+            _matching_ids(documents, BENCHMARK_QUERY)
+        )
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_query_propagates_index_catalog_failures(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "complex_catalog_failure")
+    collection.insert_many(
+        [
+            {"_id": 1, "group": "g1", "i": 56},
+            {"_id": 2, "group": "g2", "i": 63},
+        ]
+    )
+    _add_benchmark_indexes(collection)
+    backend = collection.parent.engine
+
+    def fail_catalog(_connection, _collection_name):
+        raise DuplicateKeyError("unsafe index migration")
+
+    monkeypatch.setattr(
+        backend,
+        "_get_query_index_specs_on_connection",
+        fail_catalog,
+    )
+    try:
+        with pytest.raises(DuplicateKeyError, match="unsafe index migration"):
+            list(collection.find(BENCHMARK_QUERY))
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_query_falls_back_when_total_parameters_are_too_large(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "complex_parameter_limit")
+    documents = [
+        {"_id": "first", "group": 1, "i": 7},
+        {"_id": "second", "group": 899, "i": 14},
+        {"_id": "outside", "group": 900, "i": 21},
+    ]
+    collection.insert_many(documents)
+    collection.create_index("group")
+    query = {
+        "$and": [
+            {"group": {"$in": list(range(900))}},
+            {"i": {"$gte": 0}},
+        ]
+    }
+    decodes = _track_decodes(monkeypatch)
+
+    try:
+        assert [row["_id"] for row in collection.find(query)] == [
+            "first",
+            "second",
+        ]
+        assert len(decodes) == len(documents)
+    finally:
+        client.close()
+
+
+def test_sqlite_native_filter_does_not_consult_complex_candidate_planner(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "native_filter")
+    collection.insert_many(
+        [
+            {"_id": 1, "group": "g1"},
+            {"_id": 2},
+        ]
+    )
+    backend = collection.parent.engine
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("complex candidate planner should not run")
+
+    monkeypatch.setattr(
+        backend,
+        "_find_complex_index_candidates",
+        fail_if_called,
+    )
+    try:
+        assert [
+            row["_id"] for row in collection.find({"group": {"$exists": True}})
+        ] == [1]
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidate_helper_boundaries(tmp_path):
+    client, collection = _collection(tmp_path, "candidate_boundaries")
+    backend = collection.parent.engine
+
+    try:
+        assert table_backends._positive_filter_conjuncts("not-a-filter") == []
+        assert backend._sqlite_candidate_scalar(True) == ("boolean", 1)
+        assert backend._sqlite_candidate_scalar(1.5) == ("number", 1.5)
+        assert backend._sqlite_candidate_scalar(float("inf")) is None
+        assert backend._sqlite_index_candidate_values({"$eq": True}) == (True,)
+        assert backend._sqlite_index_candidate_values({"$in": []}) == ()
+        assert backend._sqlite_index_candidate_values({"$in": list(range(901))}) is None
+
+        empty_sql, empty_params = backend._sqlite_index_candidate_id_query(
+            collection.name,
+            "group",
+            (),
+        )
+        assert "WHERE 0" in empty_sql
+        assert empty_params == []
+
+        grouped_sql, grouped_params = backend._sqlite_index_candidate_id_query(
+            collection.name,
+            "group",
+            (True, True, 1.5, "g1"),
+        )
+        assert "'true', 'false'" in grouped_sql
+        assert grouped_params == [1, 1.5, "g1"]
+
+        assert backend._sqlite_range_candidate_operand(1.5) == 1.5
+        assert backend._sqlite_range_candidate_operand(float("inf")) is None
+        assert backend._sqlite_range_candidate_operand("1.5") is None
+
+        clauses, params = backend._sqlite_candidate_residual_where(
+            [
+                ("_id", {"$gt": 0}),
+                ("nested.value", {"$lt": 10}),
+                ("plain", 1),
+                ("unsafe_range", {"$gt": float("inf")}),
+                ("huge_mod", {"$mod": [2**54, 0]}),
+                ("ignored", {"$exists": True}),
+            ]
+        )
+        assert clauses == []
+        assert params == []
+
+        collection.create_index("group")
+        connection = backend._connect()
+        try:
+            candidate = backend._sqlite_complex_candidate_query(
+                connection,
+                collection.name,
+                {
+                    "$and": [
+                        {"_id": {"$ne": "not-present"}},
+                        {"group": {"$in": ["g1"]}},
+                    ]
+                },
+            )
+        finally:
+            connection.close()
+        assert candidate is not None
+    finally:
+        client.close()
+
+
+def test_sqlite_complex_candidates_cover_direct_backend_and_overflow_fallback(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path, "candidate_backend_paths")
+    documents = [
+        {"_id": index, "group": "g{0}".format(index % 10), "i": index}
+        for index in range(100)
+    ]
+    collection.insert_many(documents)
+    _add_benchmark_indexes(collection)
+    backend = collection.parent.engine
+
+    try:
+        assert [
+            row["_id"] for row in backend.find(collection.name, BENCHMARK_QUERY)
+        ] == (_matching_ids(documents, BENCHMARK_QUERY))
+
+        def overflow(*_args, **_kwargs):
+            raise OverflowError("SQLite integer conversion overflow")
+
+        monkeypatch.setattr(backend, "_run_collection_read", overflow)
+        assert (
+            backend._find_complex_index_candidates(
+                collection.name,
+                BENCHMARK_QUERY,
+            )
+            is table_backends._MISSING
+        )
+    finally:
+        client.close()

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -138,6 +138,7 @@ _BSON_QUERY_TYPE_ALIASES = frozenset(
 _SIGNED_INT64_MIN = -(2**63)
 _SIGNED_INT64_MAX = 2**63 - 1
 _SIGNED_INT32_MAX = 2**31 - 1
+_SQLITE_SAFE_QUERY_NUMBER = 2**53 - 1
 
 
 class _PreparedSQLiteInsert(object):
@@ -707,6 +708,27 @@ def _simple_scalar_equality(filter_doc):
     ):
         return None
     return field, expected
+
+
+def _positive_filter_conjuncts(filter_doc):
+    """Return field predicates that are positive siblings in an implicit AND.
+
+    Logical OR/NOR branches cannot independently narrow their parent without a
+    complete candidate plan for every arm.  An explicit ``$and`` is different:
+    every child is required, so any safely plannable field below it remains a
+    valid candidate constraint even when its siblings require Python matching.
+    """
+
+    if not isinstance(filter_doc, Mapping):
+        return []
+    conjuncts = []
+    for field, expected in filter_doc.items():
+        if field == "$and" and isinstance(expected, (list, tuple)):
+            for item in expected:
+                conjuncts.extend(_positive_filter_conjuncts(item))
+        elif isinstance(field, str) and not field.startswith("$"):
+            conjuncts.append((field, expected))
+    return conjuncts
 
 
 def _direct_id_equality(filter_doc):
@@ -2786,6 +2808,9 @@ class SQLiteTableBackend(TableBackend):
         if indexed is not None:
             return indexed
         if requires_python_filter(filter_doc):
+            candidates = self._find_complex_index_candidates(collection, filter_doc)
+            if candidates is not _MISSING:
+                return candidates
             return [
                 doc
                 for doc in self._all_docs_unfiltered(collection)
@@ -2872,6 +2897,14 @@ class SQLiteTableBackend(TableBackend):
         if indexed is not None:
             return indexed
         if requires_python_filter(filter_doc):
+            candidates = self._find_complex_index_candidates(
+                collection,
+                filter_doc,
+                skip=skip,
+                limit=limit,
+            )
+            if candidates is not _MISSING:
+                return candidates
             return self._scan_bounded(collection, filter_doc, skip, limit)
         try:
             if _filter_references_id(filter_doc):
@@ -2906,6 +2939,13 @@ class SQLiteTableBackend(TableBackend):
         if indexed is not None:
             return len(indexed)
         if requires_python_filter(filter_doc):
+            candidates = self._find_complex_index_candidates(
+                collection,
+                filter_doc,
+                count_only=True,
+            )
+            if candidates is not _MISSING:
+                return candidates
             return self._count_filtered_scan(collection, filter_doc)
         try:
             if _filter_references_id(filter_doc):
@@ -3004,8 +3044,16 @@ class SQLiteTableBackend(TableBackend):
         )
         if indexed is not None:
             return indexed
-
         if requires_python_filter(filter_doc):
+            candidates = self._find_complex_index_candidates(
+                collection,
+                filter_doc,
+                projection=projection,
+                skip=skip,
+                limit=limit,
+            )
+            if candidates is not _MISSING:
+                return candidates
             return self._scan_projected(
                 collection,
                 projection,
@@ -3233,6 +3281,290 @@ class SQLiteTableBackend(TableBackend):
                     )
                 conn.commit()
                 self._ready_type_indexes.add(key)
+
+    @staticmethod
+    def _sqlite_candidate_scalar(value):
+        """Return one SQLite-bindable ordinary scalar, or ``None``.
+
+        Candidate planning deliberately starts with exact built-in values.
+        BSON subclasses and extended values keep the established Python scan
+        unless another positive predicate can safely bound their candidates.
+        """
+
+        if type(value) is bool:
+            return "boolean", int(value)
+        if type(value) is int:
+            if _SIGNED_INT64_MIN <= value <= _SIGNED_INT64_MAX:
+                return "number", value
+            return None
+        if type(value) is float:
+            return ("number", value) if math.isfinite(value) else None
+        if type(value) is str:
+            return "string", value
+        return None
+
+    def _sqlite_index_candidate_values(self, expected):
+        """Extract scalar equality alternatives suitable for one index anchor."""
+
+        if isinstance(expected, Mapping):
+            if "$eq" in expected:
+                values = (expected["$eq"],)
+            elif "$in" in expected and isinstance(expected["$in"], (list, tuple)):
+                values = tuple(expected["$in"])
+            else:
+                return None
+        else:
+            values = (expected,)
+
+        if not values:
+            return ()
+        if len(values) > _SQLITE_CONFLICT_QUERY_SIZE:
+            return None
+        if any(self._sqlite_candidate_scalar(value) is None for value in values):
+            return None
+        return values
+
+    def _sqlite_index_candidate_id_query(self, collection, field, values):
+        """Build an indexed union that yields a conservative physical-ID set."""
+
+        table = _quote_identifier(collection)
+        if not values:
+            return (
+                "SELECT rowid AS candidate_rowid FROM {0} WHERE 0".format(table),
+                [],
+            )
+
+        path = _sql_literal(_json_path(field))
+        expression = "json_extract(data, {0})".format(path)
+        type_expression = "json_type(data, {0})".format(path)
+        branches = []
+        params = []
+        grouped = {"boolean": [], "number": [], "string": []}
+        seen = set()
+        for value in values:
+            family, sql_value = self._sqlite_candidate_scalar(value)
+            identity = bson_identity_key(value)
+            key = (family, identity)
+            if key in seen:
+                continue
+            seen.add(key)
+            grouped[family].append(sql_value)
+
+        for family, sql_values in grouped.items():
+            if not sql_values:
+                continue
+            if family == "boolean":
+                type_clause = "{0} IN ('true', 'false')".format(type_expression)
+            elif family == "number":
+                type_clause = "{0} IN ('integer', 'real')".format(type_expression)
+            else:
+                type_clause = "{0} = 'text'".format(type_expression)
+            placeholders = ", ".join("?" for _ in sql_values)
+            branches.append(
+                "SELECT rowid AS candidate_rowid FROM {table} "
+                "WHERE {expression} IN ({placeholders}) AND {type_clause}".format(
+                    table=table,
+                    expression=expression,
+                    placeholders=placeholders,
+                    type_clause=type_clause,
+                )
+            )
+            params.extend(sql_values)
+
+        # MongoDB scalar equality also matches array members, while extended
+        # BSON scalars are stored as JSON objects.  The companion partial index
+        # makes this broad ambiguity branch inexpensive and the exact matcher
+        # removes its false positives after decoding.
+        branches.append(
+            "SELECT rowid AS candidate_rowid FROM {table} WHERE {type_expression} "
+            "IN ('array', 'object')".format(
+                table=table,
+                type_expression=type_expression,
+            )
+        )
+        # The scalar families and the container branch are type-disjoint, and
+        # values inside each family were de-duplicated above. UNION ALL avoids
+        # SQLite's temporary de-duplication B-tree without duplicating rows.
+        return " UNION ALL ".join(branches), params
+
+    @staticmethod
+    def _sqlite_range_candidate_operand(value):
+        if type(value) is int:
+            return value if abs(value) <= _SQLITE_SAFE_QUERY_NUMBER else None
+        if type(value) is float:
+            if math.isfinite(value) and abs(value) <= _SQLITE_SAFE_QUERY_NUMBER:
+                return value
+        return None
+
+    @staticmethod
+    def _sqlite_numeric_candidate_clause(field, predicates, params):
+        """Return a type-bracketed numeric superset for field predicates."""
+
+        path = _sql_literal(_json_path(field))
+        expression = "json_extract(source.data, {0})".format(path)
+        type_expression = "json_type(source.data, {0})".format(path)
+        safe_range = "{0} BETWEEN {1} AND {2}".format(
+            expression,
+            -_SQLITE_SAFE_QUERY_NUMBER,
+            _SQLITE_SAFE_QUERY_NUMBER,
+        )
+        predicate = " AND ".join(
+            item.format(expression=expression) for item in predicates
+        )
+        clause = (
+            "((({kind} IN ('integer', 'real') AND {safe_range}) AND {predicate}) "
+            "OR ({kind} IN ('integer', 'real') AND NOT ({safe_range})) "
+            "OR {kind} IN ('array', 'object'))"
+        ).format(
+            kind=type_expression,
+            safe_range=safe_range,
+            predicate=predicate,
+        )
+        return clause, params
+
+    def _sqlite_candidate_residual_where(self, conjuncts):
+        """Compile safe positive numeric constraints and leave all others residual."""
+
+        predicates_by_field = {}
+        comparisons = {
+            "$gt": ">",
+            "$gte": ">=",
+            "$lt": "<",
+            "$lte": "<=",
+        }
+        for field, expected in conjuncts:
+            if (
+                not isinstance(field, str)
+                or field == "_id"
+                or "." in field
+                or not isinstance(expected, Mapping)
+            ):
+                continue
+            for operator, operand in expected.items():
+                predicate = None
+                predicate_params = []
+                if operator in comparisons:
+                    sql_operand = self._sqlite_range_candidate_operand(operand)
+                    if sql_operand is not None:
+                        predicate = "{expression} " + comparisons[operator] + " ?"
+                        predicate_params = [sql_operand]
+                elif operator == "$mod":
+                    divisor, remainder = _normalize_mod_operand(operand)
+                    if max(abs(divisor), abs(remainder)) <= _SQLITE_SAFE_QUERY_NUMBER:
+                        predicate = "CAST({expression} AS INTEGER) % ? = ?"
+                        predicate_params = [divisor, remainder]
+                if predicate is not None:
+                    field_plan = predicates_by_field.setdefault(field, ([], []))
+                    field_plan[0].append(predicate)
+                    field_plan[1].extend(predicate_params)
+
+        clauses = []
+        params = []
+        for field, (predicates, predicate_params) in predicates_by_field.items():
+            clause, clause_params = self._sqlite_numeric_candidate_clause(
+                field,
+                predicates,
+                predicate_params,
+            )
+            clauses.append(clause)
+            params.extend(clause_params)
+        return clauses, params
+
+    def _sqlite_complex_candidate_query(self, conn, collection, filter_doc):
+        """Return SQL selecting a conservative complex-query candidate set."""
+
+        conjuncts = _positive_filter_conjuncts(filter_doc)
+        specs = self._get_query_index_specs_on_connection(conn, collection)
+        by_field = {spec.field: spec for spec in specs}
+        anchor = None
+        for field, expected in conjuncts:
+            if isinstance(field, str) and field != "_id" and "." not in field:
+                values = self._sqlite_index_candidate_values(expected)
+                spec = by_field.get(field)
+                if values is not None and spec is not None:
+                    self._ensure_type_index_on_connection(conn, collection, spec)
+                    anchor = self._sqlite_index_candidate_id_query(
+                        collection,
+                        field,
+                        values,
+                    )
+                    break
+        if anchor is None:
+            return None
+
+        candidate_sql, candidate_params = anchor
+        residual_clauses, residual_params = self._sqlite_candidate_residual_where(
+            conjuncts
+        )
+        where = ""
+        if residual_clauses:
+            where = " WHERE " + " AND ".join(residual_clauses)
+        table = _quote_identifier(collection)
+        sql = (
+            "WITH candidate_ids AS ({candidates}) "
+            "SELECT source.data FROM {table} AS source "
+            "JOIN candidate_ids ON candidate_ids.candidate_rowid = source.rowid"
+            "{where} ORDER BY source.rowid"
+        ).format(
+            candidates=candidate_sql,
+            table=table,
+            where=where,
+        )
+        params = candidate_params + residual_params
+        if len(params) > _SQLITE_CONFLICT_QUERY_SIZE:
+            # Older SQLite builds commonly cap statements at 999 variables.
+            # Stay below that portable boundary and leave headroom for future
+            # planner predicates instead of turning a large query into an
+            # OperationalError at execution time.
+            return None
+        return sql, params
+
+    def _find_complex_index_candidates(
+        self,
+        collection,
+        filter_doc,
+        projection=None,
+        skip=0,
+        limit=0,
+        count_only=False,
+    ):
+        """Decode only indexed SQL candidates, then apply exact Mongo matching."""
+
+        def indexed_read(conn):
+            candidate = self._sqlite_complex_candidate_query(
+                conn,
+                collection,
+                filter_doc,
+            )
+            if candidate is None:
+                return _MISSING
+            sql, params = candidate
+            documents = []
+            matched = 0
+            count = 0
+            for row in conn.execute(sql, params):
+                document = _json_loads(row[0])
+                if not matches_filter(document, filter_doc):
+                    continue
+                if matched < skip:
+                    matched += 1
+                    continue
+                if count_only:
+                    count += 1
+                else:
+                    documents.append(
+                        project_document(document, projection)
+                        if projection is not None
+                        else document
+                    )
+                if limit and (count if count_only else len(documents)) >= limit:
+                    break
+            return count if count_only else documents
+
+        try:
+            return self._run_collection_read(collection, indexed_read)
+        except OverflowError:
+            return _MISSING
 
     def _find_indexed_scalar_with_array_union(
         self,


### PR DESCRIPTION
## Summary

This adds a conservative candidate-selection path for complex reads on the TinyMongo SQLite backend.

TinyMongo now reuses declared top-level SQLite expression indexes to narrow positive `$and` queries that have a scalar equality or `$in` anchor. Safe numeric range and `$mod` predicates are also applied in SQLite before BSON decoding. The shared Python BSON matcher remains the final authority, so candidate selection cannot change the MongoDB-facing result.

No collection-table columns or new storage format are introduced. Existing TinyMongo index metadata and expression indexes are reused, with missing scalar/type companion indexes reconciled lazily.

## Why

Complex Mongo-style predicates previously fell back to decoding and testing every document in a SQLite collection, even when the application had already declared a useful index. Large payloads made that substantially slower than the underlying database needed to be.

This change treats SQLite filtering as a conservative pre-query: it reduces the rows transferred and decoded while preserving the established matcher for exact MongoDB semantics.

## Implementation details

- Flattens only positive implicit/explicit `$and` predicates; it never narrows through `$or`, `$nor`, or negative-only expressions.
- Uses type-disjoint indexed branches for bool, number, string, and ambiguous array/object candidates.
- Preserves MongoDB scalar equality against array members by including container candidates for exact post-filtering.
- Pushes safe top-level numeric `$gt`/`$gte`/`$lt`/`$lte` and `$mod` predicates into SQLite.
- Keeps arrays, objects, Decimal128, nonfinite numbers, values outside the safe numeric range, unsupported operators, and dotted fields on conservative paths.
- Applies exact matching before projection, skip, limit, or counting.
- Orders candidates by physical row ID so natural-order cursor behavior is unchanged.
- Caps the complete parameter set below SQLite's portable bind-variable boundary.
- Rebuilds missing physical/type expression indexes from durable catalog metadata when needed.

## Performance

Reproducible warmed comparison:

- 10,000 identical documents
- 200 complex queries after 3 warmups
- one declared `group` index
- identical `$and(group $in, i range, i $mod)` filter
- all engines fully decoded and validated the same 215 rows per query

| Engine | Complex queries/sec | Average latency |
| --- | ---: | ---: |
| TinyMongo SQLite before | ~6.4 | ~156 ms |
| TinyMongo SQLite with this change | 73.9 | 13.538 ms |
| MongoDB | 136.0 | 7.354 ms |
| Raw SQLite | 361.2 | 2.768 ms |

The TinyMongo path is approximately 11.5x faster than the prior full-scan fallback. MongoDB used acknowledged journaled writes (`w=1, j=true`) during setup; writes were not part of the timed read loop.

The new benchmark is available at `tests/benchmarks/bench_sqlite_complex_reads.py`.

## Compatibility coverage

Focused tests cover:

- mixed bool/number/string `$in` values
- arrays and embedded objects
- Decimal128 and huge integers
- numeric boundaries around ±2^53 and signed int64
- negative modulo behavior
- unsupported and negative-only fallback queries
- natural ordering with interleaved scalar/container candidates
- projection, count, skip, and limit
- missing catalogs and externally removed native indexes
- SQLite parameter limits and overflow fallback
- concurrent-safe index reconciliation

## Validation

- `3763 passed, 1 skipped, 531 deselected`
- 100% statement and branch coverage across `tinymongo/*`
- 314 shared SQLite/MongoDB sync and async contract checks passed, with 2 expected MongoDB skips
- `ruff check .`
- `black --check .`
- `mypy --ignore-missing-imports tinymongo`

The roadmap records the completed candidate-selective read work and the measured comparison.
