### PR TITLE
Add compound, sparse, and partial index support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- Ascending compound, sparse, and partial indexes now preserve their complete
+  definitions across durable backends and enforce matching unique-key
+  membership. Embedded compound indexes support one flat multikey field,
+  parallel arrays fail atomically, and remote SQL keeps unsupported multikey
+  unique values fail-closed.
 - Beanie 2.1 can initialize through the async client without application
   shims. TinyMongo now answers the discovery-safe `ping` and `buildInfo`
   database commands, accepts Beanie's `authorizedCollections` and `nameOnly`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,14 @@
   indexes, Decimal128 IDs, and non-enumerable legacy IDs retain the conservative
   full-scan fallback for released legacy-store formats.
 - SQLite `update_one()` and `update_many()` now select exact `_id` rows through
-  the primary key and declared non-unique index candidates for top-level
+  the primary key and declared index candidates for top-level
   bool/int/float/string equality inside the existing atomic transaction. Exact
-  BSON post-filtering and natural first-match order are preserved, while
-  unique-index and uncertain legacy cases retain the complete validation scan.
+  BSON post-filtering and natural first-match order are preserved.
+- **TM-043:** SQLite modifier updates with unique indexes now compare exact
+  before/after token sets for only the selected documents. Updates that leave
+  compound, sparse, partial, and multikey entries unchanged avoid a complete
+  collection decode; actual entry changes retain atomic full post-image
+  validation.
 
 ### Fixed
 - **TM-037:** Direct, non-`_id` `Timestamp(0, 0)` values now receive a

--- a/README.md
+++ b/README.md
@@ -543,6 +543,17 @@ Collections expose durable indexes and unique constraints:
 
 ```python
 collection.create_index("email", unique=True, name="login_email")
+collection.create_index(
+    [("tenant_id", 1), ("email", 1)],
+    unique=True,
+    name="tenant_email",
+)
+collection.create_index("nickname", sparse=True)
+collection.create_index(
+    "email",
+    unique=True,
+    partialFilterExpression={"active": True},
+)
 collection.find({"email": "person@example.com"})
 collection.list_indexes()
 collection.drop_index("login_email")
@@ -556,24 +567,35 @@ namespace exists. Duplicate `_id` and unique-index violations raise
 `DuplicateKeyError` with MongoDB-compatible code `11000`.
 
 Plural `create_indexes()` accepts duck-typed PyMongo `IndexModel` batches
-without importing PyMongo in TinyMongo's core. Unique indexes are enforced.
-Performance-only declarations degrade safely and emit
-`TinyMongoUnsupportedWarning`: descending and hashed declarations use
-ascending equality indexes, and compound declarations use their ascending
-leading-field prefix. Sparse membership is not honored and TTL expiration is
-not performed; both are reported explicitly. A semantically unsafe unique
-declaration is rejected before any batch entry is created.
+without importing PyMongo in TinyMongo's core. Ascending compound, sparse, and
+partial indexes retain their complete definitions in durable catalogs and can
+enforce uniqueness. Sparse indexes omit documents whose indexed fields are all
+missing but include explicit `null`; partial indexes include only documents
+matching their filter. Supported partial filters use literals, `$eq`,
+`$exists: true`, `$gt`, `$gte`, `$in`, `$lt`, `$lte`, `$type`, `$and`, and
+`$or`. Sparse and partial options cannot be combined on one index.
+
+Performance-only declarations still degrade safely and emit
+`TinyMongoUnsupportedWarning`: descending and hashed keys use ascending
+equality indexes, `background` is ignored, text indexes are skipped because
+`$text` queries are unsupported, and TTL indexes do not expire documents. A
+unique hashed, text, or TTL declaration is rejected before any batch entry is
+created because weakening it would compromise integrity.
 
 Unique indexes support JSON scalar values, Decimal128, UUID/Binary, regex, and
-flat arrays on embedded backends; missing and `null` share one unique key.
-Object values, ObjectId, datetime, nested arrays, non-finite numbers, and array
-traversal inside a dotted index path are not supported for unique indexes yet.
+flat arrays on embedded backends. Ordinary indexes treat missing and `null` as
+one unique key, while sparse and partial membership follows the rules above.
+Embedded compound unique indexes support one flat array field and reject
+parallel arrays. Object values, ObjectId, datetime, nested arrays, non-finite
+numbers, and array traversal inside a dotted index path are not supported for
+unique indexes yet.
 Remote SQL stores a versioned canonical token digest beside each unique-indexed
 value and protects it with a native constraint. This preserves exact int/float
 numeric identity across processes, including very large integers and doubles,
-while keeping booleans distinct from numbers. Remote SQL still rejects array,
-Decimal128, UUID/Binary, and regex values under unique indexes because those
-tokens cannot yet guarantee MongoDB multikey or BSON identity.
+while keeping booleans distinct from numbers. Remote SQL still rejects all
+array/multikey, Decimal128, UUID/Binary, and regex values under unique indexes
+because those tokens cannot yet guarantee cross-process MongoDB multikey or
+BSON identity.
 
 SQL, DuckDB, and Parquet storage uses typed physical `_id` keys for new rows.
 Existing databases with older stringified keys remain readable and mutable.
@@ -975,9 +997,9 @@ await beanie.init_beanie(
 
 The compatibility layer supplies Beanie's `buildInfo` discovery command,
 collection-listing hints, and PyMongo-shaped update and delete reply documents.
-Single-field indexes continue to work. Compound, sparse, and partial unique
-indexes remain a tracked integrity feature and fail loudly instead of being
-silently weakened.
+Single-field, ascending compound, sparse, and partial unique indexes work
+through the same durable index layer. Unsupported key types and unique-value
+combinations retain the fail-closed behavior described above.
 
 The tested subset covers document creation, repeated saves, queries, updates,
 deletes, counts, and collection drops. Aggregation beyond the documented core

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,8 +223,9 @@ with the follow-up audit of his
   18.90 seconds to 3.94 seconds and removed a 5.35x first-to-last slowdown.
 
 The normalized unique-token ledger remains a possible later optimization for
-bulk inserts into collections with user-created unique indexes. TM-040's
-measured no-index application path no longer needs that larger migration.
+bulk inserts and updates that actually change entries in user-created unique
+indexes. TM-040's measured no-index application path and TM-043's unchanged-key
+update path no longer need that larger migration.
 
 #### SQLite candidate-selective reads and updates
 
@@ -245,9 +246,16 @@ measured no-index application path no longer needs that larger migration.
 - [x] Reuse declared non-unique indexes for top-level bool/int/float/string
   equality to restrict `update_one()` and `update_many()` to scalar plus
   array/object candidates, then apply the exact shared BSON matcher in natural
-  row order. NaN, oversized integers, rich BSON predicates, dotted fields, and
-  collections with user-created unique indexes deliberately retain the
-  conservative full scan.
+  row order. NaN, oversized integers, rich BSON predicates, and dotted fields
+  deliberately retain the conservative candidate scan.
+- [x] **TM-043:** Let modifier updates use those same targeted candidates when
+  user-created unique indexes exist. Compare every changed document's exact
+  before/after unique token sets, including compound, sparse, partial, and
+  multikey membership; skip the complete post-image scan when all sets are
+  unchanged, while retaining atomic full validation whenever an entry really
+  changes. A local 40,000-document point-update check measured about 4.7 ms
+  with a unique index versus 4.2 ms without one, removing the earlier
+  collection-size-dependent penalty.
 - [x] Extend the SQLite/raw SQLite/MongoDB comparison benchmark with durable
   `_id` point updates. In the controlled 10,000-document local comparison, the
   TinyMongo point-update average fell from 98.653 ms to 4.330 ms (22.8x), and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -430,9 +430,11 @@ Exit criteria:
   - [x] Retain MongoEngine's and Beanie's native ObjectId primary-key behavior;
     document `generate_id()` as an explicit string-ID choice rather than a
     required workaround.
-  - [ ] Implement integrity-preserving compound, sparse, and partial unique
-    indexes across durable catalogs and supported backends. Keep unsupported
-    combinations fail-closed until their full semantics can be enforced.
+  - [x] Implement integrity-preserving ascending compound, sparse, and partial
+    unique indexes across durable catalogs and supported backends. Preserve
+    ordered keys and membership options across restarts, use native constraints
+    where available, and keep remote multikey values and other unsupported
+    unique combinations fail-closed.
 - [ ] [#81: MongoDB document and key validation](https://github.com/schapman1974/tinymongo/issues/81)
   - [ ] Encode and catalog local database and Parquet collection filenames so
     logical names stay beneath the storage root and remain portable and

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -38,6 +38,22 @@ cover the ordinary no-unique-index path; collections with user-created unique
 indexes deliberately retain complete Python validation until an exact
 multikey-token ledger is justified.
 
+### Unique-index modifier updates (TM-043)
+
+Unique indexes previously forced every SQLite modifier update through a full
+collection decode, even for an exact `_id` filter and an update to an unrelated
+field. The targeted path now compares the selected documents' before/after
+unique token sets and performs full post-image validation only if an index
+entry changes. A local 40,000-document smoke benchmark measured median point
+updates of about 4.22 ms without a secondary index, 4.48 ms with a non-unique
+index, and 4.68 ms with a unique index. Absolute timings vary by host, but the
+former roughly 44x unique-index penalty was absent.
+
+This optimization applies to modifier updates whose unique entries remain the
+same. An update that changes a unique key or changes sparse/partial membership
+still deliberately validates the full post-image so multikey overlap and
+cross-document conflicts remain atomic.
+
 ### SQLite, raw SQLite, and MongoDB comparison
 
 The focused comparison uses the same 10,000 JSON-shaped documents and performs:

--- a/tests/contracts/test_talkpython_contract.py
+++ b/tests/contracts/test_talkpython_contract.py
@@ -310,15 +310,11 @@ def test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique(
     else:
         with pytest.warns(TinyMongoUnsupportedWarning) as captured:
             created = collection.create_indexes(models)
-        assert len(captured) == 5
+        assert len(captured) == 4
         warning_messages = [str(item.message) for item in captured]
         assert any("newest_show" in message for message in warning_messages)
         assert any("published_show_priority" in message for message in warning_messages)
-        assert any(
-            "existing index 'is_published'" in message for message in warning_messages
-        )
         assert any("api_key_lookup" in message for message in warning_messages)
-        assert any("optional_slug" in message for message in warning_messages)
         assert any("expire_geo_lookup" in message for message in warning_messages)
     collection.insert_one({"_id": 1, "email": "mike@example.com"})
     duplicate = observe(
@@ -332,9 +328,8 @@ def test_create_indexes_accepts_the_real_mixed_batch_and_enforces_unique(
         "optional_slug",
         "email_unique",
         "expire_geo_lookup",
+        "published_show_priority",
     }
-    if contract_target.name == "mongodb":
-        expected_created.add("published_show_priority")
     assert set(created) == expected_created
     assert duplicate.error == "duplicate_key"
 

--- a/tests/test_advanced_indexes.py
+++ b/tests/test_advanced_indexes.py
@@ -1,0 +1,703 @@
+"""Semantic contracts for compound, sparse, and partial indexes."""
+
+import sqlite3
+from uuid import uuid4
+
+import pytest
+
+import tinymongo
+from tinymongo import table_backends
+from tinymongo.errors import DuplicateKeyError, TinyMongoNotSupportedError
+from tinymongo.indexes import IndexSpec
+from tinymongo.storage_backends import clear_memory_namespace
+
+
+SEMANTIC_BACKENDS = [
+    pytest.param("memory", id="memory"),
+    pytest.param("tinydb", id="json"),
+    pytest.param("sqlite", id="sqlite"),
+]
+
+
+class AdvancedIndexBackend:
+    """Open fresh clients against one durable test namespace."""
+
+    def __init__(self, backend, address):
+        self.backend = backend
+        self.address = address
+        self.clients = []
+
+    def open(self):
+        client = tinymongo.TinyMongoClient(self.address, backend=self.backend)
+        self.clients.append(client)
+        return client
+
+    def close(self, client):
+        client.close()
+
+    def close_all(self):
+        for client in reversed(self.clients):
+            client.close()
+        if self.backend == "memory":
+            clear_memory_namespace(self.address)
+
+
+@pytest.fixture(params=SEMANTIC_BACKENDS)
+def advanced_index_backend(request, tmp_path):
+    backend = request.param
+    address = (
+        "memory://advanced-index-{0}".format(uuid4().hex)
+        if backend == "memory"
+        else str(tmp_path / backend)
+    )
+    target = AdvancedIndexBackend(backend, address)
+    try:
+        yield target
+    finally:
+        target.close_all()
+
+
+def _indexes_by_name(collection):
+    return {index["name"]: index for index in collection.list_indexes()}
+
+
+def test_advanced_index_metadata_round_trips_through_public_apis_and_restart(
+    advanced_index_backend,
+):
+    first = advanced_index_backend.open()
+    items = first.app.items
+
+    assert items.create_indexes(
+        [
+            {
+                "key": [("tenant", 1), ("email", 1)],
+                "name": "tenant_email",
+                "unique": True,
+            },
+            {"key": [("alias", 1)], "name": "alias_sparse", "sparse": True},
+            {
+                "key": [("sku", 1)],
+                "name": "active_sku",
+                "unique": True,
+                "partialFilterExpression": {"active": True},
+            },
+        ]
+    ) == ["tenant_email", "alias_sparse", "active_sku"]
+
+    expected = {
+        "_id_": {"name": "_id_", "key": [("_id", 1)]},
+        "tenant_email": {
+            "name": "tenant_email",
+            "key": [("tenant", 1), ("email", 1)],
+            "unique": True,
+        },
+        "alias_sparse": {
+            "name": "alias_sparse",
+            "key": [("alias", 1)],
+            "sparse": True,
+        },
+        "active_sku": {
+            "name": "active_sku",
+            "key": [("sku", 1)],
+            "unique": True,
+            "partialFilterExpression": {"active": True},
+        },
+    }
+    assert _indexes_by_name(items) == expected
+    assert items.index_information() == {
+        name: {key: value for key, value in metadata.items() if key != "name"}
+        for name, metadata in expected.items()
+    }
+
+    # Public metadata must be a defensive copy, including the partial filter.
+    exposed = _indexes_by_name(items)
+    exposed["tenant_email"]["key"].append(("mutated", 1))
+    exposed["active_sku"]["partialFilterExpression"]["active"] = False
+    assert _indexes_by_name(items) == expected
+
+    advanced_index_backend.close(first)
+    reopened = advanced_index_backend.open()
+    items = reopened.app.items
+    assert _indexes_by_name(items) == expected
+
+    items.insert_one(
+        {"_id": 1, "tenant": "one", "email": "same", "sku": "sku", "active": True}
+    )
+    with pytest.raises(DuplicateKeyError):
+        items.insert_one(
+            {
+                "_id": 2,
+                "tenant": "one",
+                "email": "same",
+                "sku": "other",
+                "active": False,
+            }
+        )
+    with pytest.raises(DuplicateKeyError):
+        items.insert_one(
+            {
+                "_id": 3,
+                "tenant": "two",
+                "email": "other",
+                "sku": "sku",
+                "active": True,
+            }
+        )
+
+
+def test_unique_compound_index_enforces_insert_update_and_upsert_atomically(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    users = client.app.users
+    users.create_index(
+        [("tenant", 1), ("username", 1)],
+        name="tenant_username",
+        unique=True,
+    )
+    users.insert_many(
+        [
+            {"_id": 1, "tenant": "north", "username": "ada"},
+            {"_id": 2, "tenant": "south", "username": "ada"},
+            {"_id": 3, "tenant": "north", "username": "grace"},
+        ]
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        users.insert_one({"_id": 4, "tenant": "north", "username": "ada"})
+    with pytest.raises(DuplicateKeyError):
+        users.update_one({"_id": 3}, {"$set": {"username": "ada"}})
+    with pytest.raises(DuplicateKeyError):
+        users.update_one(
+            {"_id": 5},
+            {"$set": {"tenant": "north", "username": "ada"}},
+            upsert=True,
+        )
+
+    assert users.find_one({"_id": 3}) == {
+        "_id": 3,
+        "tenant": "north",
+        "username": "grace",
+    }
+    assert users.find_one({"_id": 5}) is None
+
+    result = users.update_one(
+        {"_id": 6},
+        {"$set": {"tenant": "north", "username": "linus"}},
+        upsert=True,
+    )
+    assert result.upserted_id == 6
+    assert users.find_one({"_id": 6})["username"] == "linus"
+
+
+def test_compound_unique_keys_preserve_ordered_tuples_and_missing_values(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    values = client.app.values
+    values.create_index([("left", 1), ("right", 1)], unique=True)
+
+    values.insert_many(
+        [
+            {"_id": 1, "left": "a", "right": "b"},
+            {"_id": 2, "left": "b", "right": "a"},
+            {"_id": 3, "left": "a"},
+            {"_id": 4, "left": "b"},
+            {"_id": 5, "right": "a"},
+            {"_id": 6},
+        ]
+    )
+
+    duplicate_documents = [
+        {"_id": 7, "left": "a", "right": "b"},
+        {"_id": 8, "left": "a", "right": None},
+        {"_id": 9, "left": None, "right": "a"},
+        {"_id": 10, "left": None, "right": None},
+    ]
+    for document in duplicate_documents:
+        with pytest.raises(DuplicateKeyError):
+            values.insert_one(document)
+
+    assert values.count_documents({}) == 6
+
+
+def test_unique_compound_index_supports_one_flat_multikey_component(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    items = client.app.items
+    items.create_index(
+        [("owner.id", 1), ("labels", 1)],
+        name="owner_labels",
+        unique=True,
+    )
+
+    # Repeated values inside one document create one entry, not a conflict
+    # with that same document. The owner remains part of every compound tuple.
+    items.insert_one(
+        {
+            "_id": 1,
+            "owner": {"id": "north"},
+            "labels": ["red", "blue", "red"],
+        }
+    )
+    items.insert_one({"_id": 2, "owner": {"id": "south"}, "labels": ["blue"]})
+    items.insert_one({"_id": 3, "owner": {"id": "north"}, "labels": ["green"]})
+
+    with pytest.raises(DuplicateKeyError):
+        items.insert_one(
+            {
+                "_id": 4,
+                "owner": {"id": "north"},
+                "labels": ["yellow", "blue"],
+            }
+        )
+
+    assert items.find_one({"_id": 4}) is None
+    assert items.count_documents({}) == 3
+
+
+def test_compound_parallel_arrays_fail_clearly_and_atomically(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    items = client.app.items
+    items.create_index(
+        [("regions", 1), ("labels", 1)],
+        name="region_labels",
+        unique=True,
+    )
+
+    with pytest.raises(
+        TinyMongoNotSupportedError,
+        match="cannot index parallel array fields: regions, labels",
+    ):
+        items.insert_one({"_id": 1, "regions": ["east", "west"], "labels": ["a", "b"]})
+    assert items.find_one({"_id": 1}) is None
+
+    items.insert_one({"_id": 2, "regions": "east", "labels": "a"})
+    with pytest.raises(TinyMongoNotSupportedError, match="parallel array fields"):
+        items.update_one(
+            {"_id": 2},
+            {"$set": {"regions": ["east", "west"], "labels": ["a", "b"]}},
+        )
+    assert items.find_one({"_id": 2}) == {
+        "_id": 2,
+        "regions": "east",
+        "labels": "a",
+    }
+
+
+def test_unique_sparse_index_skips_missing_but_indexes_explicit_null(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    users = client.app.users
+    users.create_index("email", name="email_sparse", unique=True, sparse=True)
+
+    users.insert_many([{"_id": 1}, {"_id": 2}, {"_id": 3, "email": None}])
+    with pytest.raises(DuplicateKeyError):
+        users.insert_one({"_id": 4, "email": None})
+    with pytest.raises(DuplicateKeyError):
+        users.update_one({"_id": 1}, {"$set": {"email": None}})
+
+    assert "email" not in users.find_one({"_id": 1})
+    users.update_one({"_id": 3}, {"$unset": {"email": ""}})
+    users.insert_one({"_id": 4, "email": None})
+    result = users.update_one({"_id": 5}, {"$set": {"other": True}}, upsert=True)
+    assert result.upserted_id == 5
+    assert users.count_documents({"email": {"$exists": False}}) == 4
+
+
+def test_sparse_compound_membership_uses_any_present_field_and_complete_tuple(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    values = client.app.values
+    values.create_index(
+        [("left", 1), ("right", 1)],
+        name="sparse_pair",
+        sparse=True,
+        unique=True,
+    )
+
+    # Fully missing documents are absent from the sparse index.
+    values.insert_many([{"_id": 1}, {"_id": 2}])
+    values.insert_many(
+        [
+            {"_id": 3, "left": "a"},
+            {"_id": 4, "right": "a"},
+            {"_id": 5, "left": "a", "right": "a"},
+            {"_id": 6, "left": None, "right": None},
+        ]
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 7, "left": "a", "right": None})
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 8, "left": None, "right": "a"})
+    with pytest.raises(DuplicateKeyError):
+        values.insert_one({"_id": 9, "right": None})
+
+    assert values.count_documents({}) == 6
+
+
+def test_partial_unique_membership_transitions_on_update_and_upsert(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    users = client.app.users
+    users.create_index(
+        "email",
+        name="active_email",
+        unique=True,
+        partialFilterExpression={"active": True},
+    )
+    users.insert_many(
+        [
+            {"_id": 1, "email": "same", "active": True},
+            {"_id": 2, "email": "same", "active": False},
+            {"_id": 3, "email": "same"},
+        ]
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        users.update_one({"_id": 2}, {"$set": {"active": True}})
+    assert users.find_one({"_id": 2})["active"] is False
+
+    users.update_one({"_id": 1}, {"$set": {"active": False}})
+    users.update_one({"_id": 2}, {"$set": {"active": True}})
+    assert users.find_one({"_id": 2})["active"] is True
+
+    with pytest.raises(DuplicateKeyError):
+        users.update_one(
+            {"_id": 4},
+            {"$set": {"email": "same", "active": True}},
+            upsert=True,
+        )
+    assert users.find_one({"_id": 4}) is None
+
+    result = users.update_one(
+        {"_id": 5},
+        {"$set": {"email": "same", "active": False}},
+        upsert=True,
+    )
+    assert result.upserted_id == 5
+
+
+def test_partial_filter_supports_boolean_range_in_type_and_logical_predicates(
+    advanced_index_backend,
+):
+    client = advanced_index_backend.open()
+    items = client.app.items
+    expression = {
+        "$and": [
+            {"enabled": True},
+            {"score": {"$gte": 10, "$lt": 20}},
+            {"tier": {"$in": ["pro", "team"]}},
+            {"code": {"$exists": True, "$type": "string"}},
+        ]
+    }
+    items.create_index(
+        "slug",
+        name="eligible_slug",
+        unique=True,
+        partialFilterExpression=expression,
+    )
+
+    items.insert_many(
+        [
+            {
+                "_id": 1,
+                "slug": "same",
+                "enabled": True,
+                "score": 12,
+                "tier": "pro",
+                "code": "A",
+            },
+            {
+                "_id": 2,
+                "slug": "same",
+                "enabled": True,
+                "score": 9,
+                "tier": "pro",
+                "code": "B",
+            },
+            {
+                "_id": 3,
+                "slug": "same",
+                "enabled": True,
+                "score": 12,
+                "tier": "free",
+                "code": "C",
+            },
+            {
+                "_id": 4,
+                "slug": "same",
+                "enabled": True,
+                "score": 12,
+                "tier": "team",
+                "code": 4,
+            },
+        ]
+    )
+
+    with pytest.raises(DuplicateKeyError):
+        items.insert_one(
+            {
+                "_id": 5,
+                "slug": "same",
+                "enabled": True,
+                "score": 19,
+                "tier": "team",
+                "code": "E",
+            }
+        )
+    assert items.count_documents({}) == 4
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        ({"partialFilterExpression": []}, "must be a mapping"),
+        ({"partialFilterExpression": {}}, "non-empty mapping"),
+        (
+            {"partialFilterExpression": {"active": {"$exists": False}}},
+            "only \\$exists: true",
+        ),
+        (
+            {"partialFilterExpression": {"tier": {"$in": "pro"}}},
+            "requires an array",
+        ),
+        (
+            {"partialFilterExpression": {"age": {"$gte": 18, "unit": "years"}}},
+            "cannot mix operators",
+        ),
+        (
+            {"partialFilterExpression": {"email": {"$ne": None}}},
+            "Unsupported partialFilterExpression operator",
+        ),
+        (
+            {"partialFilterExpression": {"$nor": [{"active": True}]}},
+            "Unsupported partialFilterExpression operator",
+        ),
+        (
+            {
+                "sparse": True,
+                "partialFilterExpression": {"active": True},
+            },
+            "cannot be combined",
+        ),
+        ({"sparse": 1}, "must be a boolean"),
+        ({"unique": 1}, "must be a boolean"),
+        ({"collation": {"locale": "en"}}, "Unsupported index option"),
+    ],
+)
+def test_invalid_advanced_index_predicates_and_options_leave_no_metadata(
+    tmp_path, options, message
+):
+    client = tinymongo.TinyMongoClient(str(tmp_path / uuid4().hex), backend="sqlite")
+    items = client.app.items
+    try:
+        with pytest.raises(TinyMongoNotSupportedError, match=message):
+            items.create_index("value", **options)
+        assert items.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    "keys",
+    [
+        [("tenant", 1), ("tenant", 1)],
+        [("tenant", 1), ("email", -1)],
+        [("tenant", 1), ("", 1)],
+    ],
+)
+def test_invalid_compound_key_definitions_leave_no_metadata(tmp_path, keys):
+    client = tinymongo.TinyMongoClient(str(tmp_path / uuid4().hex), backend="sqlite")
+    items = client.app.items
+    try:
+        with pytest.raises(TinyMongoNotSupportedError):
+            items.create_index(keys)
+        assert items.list_indexes() == [{"name": "_id_", "key": [("_id", 1)]}]
+    finally:
+        client.close()
+
+
+def test_sqlite_materializes_compound_sparse_and_partial_native_indexes(tmp_path):
+    client = tinymongo.TinyMongoClient(
+        str(tmp_path / "native-indexes"), backend="sqlite"
+    )
+    items = client.app.items
+    items.create_index(
+        [("tenant", 1), ("email", 1)],
+        name="tenant_email",
+        unique=True,
+    )
+    items.create_index("alias", name="alias_sparse", sparse=True)
+    items.create_index(
+        "sku",
+        name="active_sku",
+        unique=True,
+        partialFilterExpression={"active": True},
+    )
+
+    engine = items.parent.engine
+    specs = {spec.name: spec for spec in engine.get_index_specs("items")}
+    physical = {
+        name: engine._physical_index_name("items", spec) for name, spec in specs.items()
+    }
+    conn = sqlite3.connect(engine.path)
+    try:
+        index_rows = {
+            row[1]: row for row in conn.execute('PRAGMA index_list("items")').fetchall()
+        }
+        assert index_rows[physical["tenant_email"]][2] == 1
+        assert index_rows[physical["tenant_email"]][4] == 0
+        assert index_rows[physical["alias_sparse"]][2] == 0
+        assert index_rows[physical["alias_sparse"]][4] == 1
+        assert index_rows[physical["active_sku"]][2] == 1
+        assert index_rows[physical["active_sku"]][4] == 1
+
+        # The unique base index stores one exact BSON-aware tuple token. Its
+        # companion lookup index stores the two native JSON expressions used
+        # for query candidate selection.
+        compound_constraint_parts = [
+            row
+            for row in conn.execute(
+                'PRAGMA index_xinfo("{0}")'.format(physical["tenant_email"])
+            ).fetchall()
+            if row[5]
+        ]
+        compound_lookup_parts = [
+            row
+            for row in conn.execute(
+                'PRAGMA index_xinfo("{0}_lookup")'.format(physical["tenant_email"])
+            ).fetchall()
+            if row[5]
+        ]
+        assert len(compound_constraint_parts) == 1
+        assert len(compound_lookup_parts) == 2
+
+        definitions = {
+            row[0]: row[1]
+            for row in conn.execute(
+                "SELECT name, sql FROM sqlite_master WHERE type = 'index'"
+            ).fetchall()
+        }
+        assert "tinymongo_index_token" in definitions[physical["tenant_email"]]
+        assert (
+            definitions[physical["tenant_email"] + "_lookup"].count("json_extract") == 2
+        )
+        assert " WHERE " in definitions[physical["alias_sparse"]]
+        assert "json_type" in definitions[physical["alias_sparse"]]
+        assert " WHERE " in definitions[physical["active_sku"]]
+        assert "tinymongo_index_member" in definitions[physical["active_sku"]]
+    finally:
+        conn.close()
+        client.close()
+
+
+def test_sqlite_compound_index_limits_decoding_before_exact_matching(
+    tmp_path, monkeypatch
+):
+    client = tinymongo.TinyMongoClient(
+        str(tmp_path / "compound-query"), backend="sqlite"
+    )
+    items = client.app.items
+    documents = [
+        {
+            "_id": number,
+            "tenant": "wanted" if number % 100 == 0 else "other",
+            "kind": "match" if number % 200 == 0 else "miss",
+            "payload": "x" * 500,
+        }
+        for number in range(1_000)
+    ]
+    items.insert_many(documents)
+    items.create_index([("tenant", 1), ("kind", 1)], name="tenant_kind")
+
+    decoded = []
+    original_loads = table_backends._json_loads
+
+    def track_loads(value):
+        decoded.append(value)
+        return original_loads(value)
+
+    monkeypatch.setattr(table_backends, "_json_loads", track_loads)
+    try:
+        found = list(items.find({"tenant": "wanted", "kind": "match"}))
+        assert [document["_id"] for document in found] == [0, 200, 400, 600, 800]
+        assert len(decoded) <= 10
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("name", "options", "member", "nonmember"),
+    [
+        (
+            "sparse_tags",
+            {"sparse": True},
+            {"tags": ["red", "red", "blue"]},
+            {},
+        ),
+        (
+            "active_tags",
+            {"partialFilterExpression": {"active": True}},
+            {"tags": ["red", "red", "blue"], "active": True},
+            {"tags": ["blue"], "active": False},
+        ),
+    ],
+    ids=["sparse", "partial"],
+)
+def test_sqlite_conditional_unique_single_field_multikey_indexes(
+    tmp_path, name, options, member, nonmember
+):
+    client = tinymongo.TinyMongoClient(
+        str(tmp_path / "conditional-multikey"), backend="sqlite"
+    )
+    items = client.app.items
+    items.create_index("tags", name=name, unique=True, **options)
+
+    first = {"_id": 1}
+    first.update(member)
+    excluded = {"_id": 2}
+    excluded.update(nonmember)
+    items.insert_one(first)
+    items.insert_one(excluded)
+
+    overlap = {"_id": 3, "tags": ["green", "blue"]}
+    if "partialFilterExpression" in options:
+        overlap["active"] = True
+    with pytest.raises(DuplicateKeyError):
+        items.insert_one(overlap)
+
+    disjoint = {"_id": 4, "tags": ["green", "yellow"]}
+    if "partialFilterExpression" in options:
+        disjoint["active"] = True
+    items.insert_one(disjoint)
+
+    assert items.find_one({"_id": 3}) is None
+    assert {document["_id"] for document in items.find({})} == {1, 2, 4}
+    client.close()
+
+
+def test_index_spec_metadata_v2_preserves_advanced_definition():
+    spec = IndexSpec(
+        keys=[("tenant", 1), ("email", 1)],
+        name="active_tenant_email",
+        unique=True,
+        partial_filter={"active": True},
+    )
+
+    assert IndexSpec.from_metadata(spec.to_metadata()) == spec
+    assert spec.to_metadata() == {
+        "v": 2,
+        "name": "active_tenant_email",
+        "key": [["tenant", 1], ["email", 1]],
+        "unique": True,
+        "sparse": False,
+        "partialFilterExpression": {"active": True},
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,7 +308,7 @@ def test_cli_export_import_preserves_embedded_document_field_order(tmp_path):
     restored_client.close()
 
 
-def test_copy_indexes_preserves_names_keys_and_uniqueness():
+def test_copy_indexes_preserves_names_keys_and_supported_options():
     class Source:
         def list_indexes(self):
             return [
@@ -317,8 +317,13 @@ def test_copy_indexes_preserves_names_keys_and_uniqueness():
                     "name": "email_unique",
                     "key": [("email", 1)],
                     "unique": True,
+                    "sparse": True,
                 },
-                {"name": "created_desc", "key": [("created", -1)]},
+                {
+                    "name": "created_desc",
+                    "key": [("created", -1)],
+                    "partialFilterExpression": {"archived": False},
+                },
             ]
 
     class Target:
@@ -334,9 +339,15 @@ def test_copy_indexes_preserves_names_keys_and_uniqueness():
     assert target.created == [
         (
             [("email", 1)],
-            {"name": "email_unique", "unique": True},
+            {"name": "email_unique", "unique": True, "sparse": True},
         ),
-        ([("created", -1)], {"name": "created_desc"}),
+        (
+            [("created", -1)],
+            {
+                "name": "created_desc",
+                "partialFilterExpression": {"archived": False},
+            },
+        ),
     ]
 
 

--- a/tests/test_durable_indexes.py
+++ b/tests/test_durable_indexes.py
@@ -394,6 +394,57 @@ def test_legacy_equivalent_index_catalog_keeps_named_retry_idempotent(tmp_path):
     assert users.create_index("email", name="second") == "second"
 
 
+def test_legacy_degraded_compound_catalog_is_promoted_on_batch_retry(tmp_path):
+    address = str(tmp_path / "legacy-compound")
+    client = tinymongo.TinyMongoClient(address)
+    users = client.app.users
+    legacy = users._index_document(IndexSpec("account", name="account_email"))
+    legacy["spec"] = {
+        "v": 1,
+        "name": "account_email",
+        "key": [["account", 1]],
+        "unique": False,
+    }
+    users.parent.tinydb.table(INDEX_CATALOG_TABLE).insert(legacy)
+    client.close()
+
+    client = tinymongo.TinyMongoClient(address)
+    try:
+        users = client.app.users
+        assert _indexes_by_name(users)["account_email"]["key"] == [("account", 1)]
+
+        assert users.create_indexes(
+            [
+                {
+                    "key": [("account", 1), ("email", 1)],
+                    "name": "account_email",
+                }
+            ]
+        ) == ["account_email"]
+
+        assert _indexes_by_name(users)["account_email"]["key"] == [
+            ("account", 1),
+            ("email", 1),
+        ]
+        catalog = users.parent.tinydb.table(INDEX_CATALOG_TABLE)
+        promoted = next(
+            document
+            for document in catalog.all()
+            if document["collection"] == "users"
+            and document["spec"]["name"] == "account_email"
+        )
+        assert promoted["spec"] == {
+            "v": 2,
+            "name": "account_email",
+            "key": [["account", 1], ["email", 1]],
+            "unique": False,
+            "sparse": False,
+            "partialFilterExpression": None,
+        }
+    finally:
+        client.close()
+
+
 def test_degraded_batch_reuses_equivalent_indexes_and_preserves_unique_options(
     durable_index_backend,
 ):
@@ -524,13 +575,11 @@ def test_unsupported_index_shapes_types_and_options_leave_no_metadata(
     client = durable_index_backend.open()
     users = client.app.users
     unsupported = [
-        ([("first", 1), ("last", 1)], {}),
         ([("email", -1)], {}),
         (123, {}),
         (object(), {}),
         ("email", {"unique": 1}),
         ("email", {"name": ""}),
-        ("email", {"sparse": True}),
         ("email", {"background": True}),
     ]
 

--- a/tests/test_index_helpers.py
+++ b/tests/test_index_helpers.py
@@ -8,7 +8,9 @@ from tinymongo.errors import DuplicateKeyError, TinyMongoNotSupportedError
 from tinymongo.indexes import (
     INDEX_METADATA_VERSION,
     IndexSpec,
+    document_matches_index,
     index_catalog_id,
+    index_entry_tokens,
     index_tokens,
     parse_index_spec,
     validate_unique_documents,
@@ -45,17 +47,72 @@ def test_parse_accepts_one_ascending_pair(key):
 
 
 def test_parse_normalizes_supported_options():
-    spec = parse_index_spec("email", unique=True, name="login_email")
+    spec = parse_index_spec(
+        [("tenant", 1), ("email", 1)],
+        unique=True,
+        name="tenant_login_email",
+        sparse=True,
+    )
 
+    assert spec.keys == (("tenant", 1), ("email", 1))
     assert spec.unique is True
-    assert spec.name == "login_email"
+    assert spec.sparse is True
+    assert spec.name == "tenant_login_email"
+
+
+def test_parse_accepts_an_ordered_mapping_for_compound_keys():
+    spec = parse_index_spec({"tenant": 1, "email": 1})
+
+    assert spec.keys == (("tenant", 1), ("email", 1))
+    assert spec.direction == 1
+    assert spec.fields == ("tenant", "email")
+
+
+def test_parse_normalizes_partial_filter_expression():
+    expression = {"active": True, "score": {"$gte": 10}}
+
+    spec = parse_index_spec("email", partialFilterExpression=expression)
+
+    assert spec.partial_filter == expression
+
+
+def test_partial_filter_accepts_nested_literal_documents():
+    expression = {"profile": {"status": "active"}}
+
+    assert (
+        parse_index_spec("email", partialFilterExpression=expression).partial_filter
+        == expression
+    )
+
+
+@pytest.mark.parametrize("operator", ["$and", "$or"])
+@pytest.mark.parametrize("children", [[], "not-an-array"])
+def test_partial_filter_logical_operators_require_nonempty_arrays(operator, children):
+    with pytest.raises(TinyMongoNotSupportedError, match="non-empty array"):
+        parse_index_spec("email", partialFilterExpression={operator: children})
+
+
+def test_index_spec_requires_exactly_one_key_input():
+    with pytest.raises(TypeError, match="either field or keys"):
+        IndexSpec("email", keys=[("tenant", 1), ("email", 1)])
+
+    with pytest.raises(TypeError, match="requires field or keys"):
+        IndexSpec()
+
+
+def test_index_spec_rejects_unknown_metadata_versions():
+    with pytest.raises(ValueError, match="Unsupported index metadata version"):
+        IndexSpec("email", metadata_version=99)
+
+
+def test_index_spec_comparison_with_an_unrelated_type_is_false():
+    assert (IndexSpec("email") == "email") is False
 
 
 @pytest.mark.parametrize(
     "key",
     [
         [],
-        [("first", 1), ("last", 1)],
         ("email", -1),
         ("email", "text"),
         ("email", "hashed"),
@@ -74,8 +131,6 @@ def test_parse_rejects_unsupported_keys(key):
     "option",
     [
         {"expireAfterSeconds": 10},
-        {"sparse": True},
-        {"partialFilterExpression": {"active": True}},
         {"collation": {"locale": "en"}},
         {"wildcardProjection": {"field": 1}},
         {"background": True},
@@ -119,8 +174,26 @@ def test_metadata_is_json_safe_and_round_trips():
         "name": "profile_login",
         "key": [["profile.email", 1]],
         "unique": True,
+        "sparse": False,
+        "partialFilterExpression": None,
     }
     assert IndexSpec.from_metadata(encoded) == spec
+
+
+def test_legacy_metadata_round_trips_with_default_v2_options():
+    legacy = {
+        "v": 1,
+        "name": "email_1",
+        "key": [["email", 1]],
+        "unique": False,
+    }
+
+    restored = IndexSpec.from_metadata(legacy)
+
+    assert restored == IndexSpec("email")
+    assert restored.metadata_version == 1
+    assert restored.sparse is False
+    assert restored.partial_filter is None
 
 
 @pytest.mark.parametrize(
@@ -324,3 +397,14 @@ def test_unique_validation_rejects_invalid_inputs():
         )
     with pytest.raises(TypeError, match="mappings"):
         index_tokens("not-a-document", "x")
+
+
+def test_index_membership_rejects_invalid_inputs():
+    spec = IndexSpec("email", sparse=True)
+
+    with pytest.raises(TypeError, match="documents must be mappings"):
+        document_matches_index("not-a-document", spec)
+    with pytest.raises(TypeError, match="requires an IndexSpec"):
+        document_matches_index({"email": "a@example.com"}, "email")
+    with pytest.raises(TypeError, match="require an IndexSpec"):
+        index_entry_tokens({"email": "a@example.com"}, "email")

--- a/tests/test_index_models.py
+++ b/tests/test_index_models.py
@@ -68,19 +68,22 @@ def test_existing_index_spec_passes_through_unchanged():
 
 def test_index_signature_uses_keys_and_unique_options_but_not_name():
     assert index_spec_signature(IndexSpec("email", name="first")) == (
-        "email",
-        1,
+        (("email", 1),),
         False,
+        False,
+        None,
     )
     assert index_spec_signature(IndexSpec("email", name="second")) == (
-        "email",
-        1,
+        (("email", 1),),
         False,
+        False,
+        None,
     )
     assert index_spec_signature(IndexSpec("email", name="unique", unique=True)) == (
-        "email",
-        1,
+        (("email", 1),),
         True,
+        False,
+        None,
     )
 
     with pytest.raises(TypeError, match="IndexSpec"):
@@ -122,7 +125,6 @@ def test_degraded_reuse_warning_rejects_invalid_or_inequivalent_inputs():
     [
         ({"key": {"created": -1}}, "descending", "treated as ascending"),
         ({"key": {"token": "hashed"}}, "hashed", "ascending equality"),
-        ({"key": {"email": 1}, "sparse": True}, "sparse", "not honored"),
         (
             {"key": {"created": 1}, "expireAfterSeconds": 0},
             "ttl",
@@ -146,6 +148,37 @@ def test_single_field_performance_declarations_create_a_degraded_index(
     assert message in plan.warning
 
 
+def test_sparse_model_preserves_membership_semantics_without_degradation():
+    plan = plan_index_model({"key": {"email": 1}, "sparse": True})
+
+    assert plan.spec == IndexSpec("email", sparse=True)
+    assert plan.degraded_features == ()
+    assert plan.outcome == "create"
+    assert plan.warning is None
+
+
+@pytest.mark.parametrize(
+    ("document", "message"),
+    [
+        (
+            {"key": {"email": 1}, "partialFilterExpression": "active"},
+            "must be a mapping",
+        ),
+        (
+            {
+                "key": {"email": 1},
+                "sparse": True,
+                "partialFilterExpression": {"active": True},
+            },
+            "cannot be combined",
+        ),
+    ],
+)
+def test_model_rejects_invalid_partial_index_option_combinations(document, message):
+    with pytest.raises(TinyMongoNotSupportedError, match=message):
+        plan_index_model(document)
+
+
 def test_false_performance_flags_require_no_degradation():
     plan = plan_index_model({"key": {"email": 1}, "sparse": False, "background": False})
 
@@ -165,7 +198,7 @@ def test_nonunique_text_index_is_accepted_as_a_warned_noop():
     assert plan.to_metadata()["effective_spec"] is None
 
 
-def test_nonunique_compound_model_degrades_to_an_ascending_leading_field():
+def test_nonunique_compound_model_preserves_keys_and_sparse_membership():
     plan = plan_index_model(
         DuckIndexModel(
             {
@@ -179,19 +212,19 @@ def test_nonunique_compound_model_degrades_to_an_ascending_leading_field():
     )
 
     assert plan.name == "account_recent"
-    assert plan.spec == IndexSpec(field="account_id", name="account_recent")
+    assert plan.spec == IndexSpec(
+        keys=(("account_id", 1), ("created", 1)),
+        name="account_recent",
+        sparse=True,
+    )
     assert plan.outcome == "create_degraded"
     assert plan.degraded_features == (
-        "compound",
         "descending",
-        "sparse",
         "ttl",
         "background",
     )
     assert "created with reduced behavior" in plan.warning
-    assert "ascending leading field" in plan.warning
     assert "descending direction" in plan.warning
-    assert "sparse membership" in plan.warning
     assert "TTL expiration" in plan.warning
     assert "background creation" in plan.warning
 
@@ -202,10 +235,12 @@ def test_nonunique_compound_model_degrades_to_an_ascending_leading_field():
     ]
     assert metadata["outcome"] == "create_degraded"
     assert metadata["effective_spec"] == {
-        "v": 1,
+        "v": 2,
         "name": "account_recent",
-        "key": [["account_id", 1]],
+        "key": [["account_id", 1], ["created", 1]],
         "unique": False,
+        "sparse": True,
+        "partialFilterExpression": None,
     }
     assert json.loads(json.dumps(metadata)) == metadata
 
@@ -216,26 +251,26 @@ def test_compound_default_name_matches_pymongo_shape():
     assert plan.name == "account_1_created_-1"
 
 
-def test_degraded_effective_spec_is_included_in_metadata():
+def test_sparse_effective_spec_is_included_in_metadata():
     plan = plan_index_model(
         {"key": {"email": 1}, "name": "maybe_email", "sparse": True}
     )
 
     assert plan.to_metadata()["effective_spec"] == {
-        "v": 1,
+        "v": 2,
         "name": "maybe_email",
         "key": [["email", 1]],
         "unique": False,
+        "sparse": True,
+        "partialFilterExpression": None,
     }
 
 
 @pytest.mark.parametrize(
     ("document", "feature"),
     [
-        ({"key": {"first": 1, "last": 1}, "unique": True}, "compound"),
         ({"key": {"email": "hashed"}, "unique": True}, "hashed"),
         ({"key": {"content": "text"}, "unique": True}, "text"),
-        ({"key": {"email": 1}, "unique": True, "sparse": True}, "sparse"),
         (
             {"key": {"created": 1}, "unique": True, "expireAfterSeconds": 60},
             "ttl",
@@ -248,6 +283,28 @@ def test_unique_semantic_combinations_are_rejected(document, feature):
         match="cannot be degraded.*{0}".format(feature),
     ):
         plan_index_model(document)
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"key": {"first": 1, "last": 1}, "unique": True},
+        {"key": {"email": 1}, "unique": True, "sparse": True},
+        {
+            "key": {"email": 1},
+            "unique": True,
+            "partialFilterExpression": {"active": True},
+        },
+    ],
+)
+def test_unique_compound_sparse_and_partial_models_preserve_semantics(document):
+    plan = plan_index_model(document)
+
+    assert plan.spec.unique is True
+    assert plan.spec.keys == tuple(document["key"].items())
+    assert plan.spec.sparse is document.get("sparse", False)
+    assert plan.spec.partial_filter == document.get("partialFilterExpression")
+    assert plan.degraded_features == ()
 
 
 def test_unique_descending_and_background_flags_preserve_uniqueness():

--- a/tests/test_pymongo_contract.py
+++ b/tests/test_pymongo_contract.py
@@ -254,8 +254,8 @@ def test_unsupported_features_fail_loudly(tmp_path):
     with pytest.raises(TinyMongoNotSupportedError, match=r"\$lookup"):
         collection.aggregate([{"$lookup": {}}])
 
-    with pytest.raises(TinyMongoNotSupportedError, match="single-field"):
-        collection.create_index([("email", 1), ("name", 1)])
+    with pytest.raises(TinyMongoNotSupportedError, match="ascending"):
+        collection.create_index([("email", -1)])
     with pytest.raises(TinyMongoNotSupportedError, match="concerns"):
         collection.with_options(type("Concern", (), {"document": {"w": 2}})())
 

--- a/tests/test_sqlite_unique_update_fast_path.py
+++ b/tests/test_sqlite_unique_update_fast_path.py
@@ -1,0 +1,363 @@
+"""TM-043 contracts for bounded SQLite updates with unique indexes."""
+
+import pytest
+
+import tinymongo as tm
+import tinymongo.table_backends as table_backends
+from tinymongo.errors import DuplicateKeyError
+
+
+def _collection(tmp_path, name="items"):
+    client = tm.TinyMongoClient(str(tmp_path), backend="sqlite")
+    return client, client.app[name]
+
+
+def _track_decoded_ids(monkeypatch):
+    decoded_ids = []
+    original_loads = table_backends._json_loads
+
+    def tracked_loads(value):
+        document = original_loads(value)
+        decoded_ids.append(document.get("_id"))
+        return document
+
+    monkeypatch.setattr(table_backends, "_json_loads", tracked_loads)
+    return decoded_ids
+
+
+@pytest.mark.parametrize("document_count", [10, 1_000])
+def test_tm043_unrelated_id_update_with_unique_index_is_collection_size_bounded(
+    tmp_path,
+    monkeypatch,
+    document_count,
+):
+    client, collection = _collection(tmp_path)
+    collection.insert_many(
+        [
+            {
+                "_id": index,
+                "email": "user-{0}@example.com".format(index),
+                "visits": 0,
+            }
+            for index in range(document_count)
+        ]
+    )
+    collection.create_index("email", unique=True)
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        target = document_count - 1
+        result = collection.update_one(
+            {"_id": target},
+            {"$inc": {"visits": 1}},
+        )
+
+        assert (result.matched_count, result.modified_count) == (1, 1)
+        # SQLite may decode the target again while maintaining its expression
+        # index, but no other collection payload should cross into Python.
+        assert decoded_ids
+        assert set(decoded_ids) == {target}
+        assert len(decoded_ids) <= 4
+    finally:
+        client.close()
+
+
+def test_tm043_same_unique_value_noop_stays_targeted(tmp_path, monkeypatch):
+    client, collection = _collection(tmp_path)
+    collection.insert_many(
+        [
+            {"_id": index, "email": "user-{0}@example.com".format(index)}
+            for index in range(100)
+        ]
+    )
+    collection.create_index("email", unique=True)
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        result = collection.update_one(
+            {"_id": 73},
+            {"$set": {"email": "user-73@example.com"}},
+        )
+
+        assert (result.matched_count, result.modified_count) == (1, 0)
+        assert decoded_ids == [73]
+    finally:
+        client.close()
+
+
+def test_tm043_reordered_unique_multikey_entries_stay_targeted(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    collection.insert_many(
+        [
+            {
+                "_id": index,
+                "tags": ["tag-{0}".format(index), "shared-{0}".format(index)],
+            }
+            for index in range(100)
+        ]
+    )
+    collection.create_index("tags", unique=True)
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        result = collection.update_one(
+            {"_id": 73},
+            {"$set": {"tags": ["shared-73", "tag-73"]}},
+        )
+
+        assert (result.matched_count, result.modified_count) == (1, 1)
+        assert decoded_ids and set(decoded_ids) == {73}
+    finally:
+        client.close()
+
+
+def test_tm043_unique_index_id_miss_decodes_no_payloads(tmp_path, monkeypatch):
+    client, collection = _collection(tmp_path)
+    collection.insert_many(
+        [
+            {"_id": index, "email": "user-{0}@example.com".format(index)}
+            for index in range(100)
+        ]
+    )
+    collection.create_index("email", unique=True)
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        result = collection.update_one(
+            {"_id": "missing"},
+            {"$set": {"seen": True}},
+        )
+
+        assert (result.matched_count, result.modified_count) == (0, 0)
+        assert decoded_ids == []
+    finally:
+        client.close()
+
+
+def test_tm043_changed_unique_scalar_preserves_atomic_conflict_handling(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    collection.insert_many(
+        [
+            {"_id": index, "email": "user-{0}@example.com".format(index)}
+            for index in range(100)
+        ]
+    )
+    collection.create_index("email", unique=True)
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        result = collection.update_one(
+            {"_id": 73},
+            {"$set": {"email": "available@example.com"}},
+        )
+        assert (result.matched_count, result.modified_count) == (1, 1)
+
+        decoded_ids.clear()
+        with pytest.raises(DuplicateKeyError):
+            collection.update_one(
+                {"_id": 73},
+                {"$set": {"email": "user-0@example.com"}},
+            )
+
+        decoded_ids.clear()
+        assert collection.find_one({"_id": 73})["email"] == "available@example.com"
+    finally:
+        client.close()
+
+
+def test_tm043_sparse_unique_membership_transitions_remain_atomic(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    collection.create_index("email", unique=True, sparse=True)
+    collection.insert_many(
+        [
+            {"_id": 1, "name": "outside"},
+            {"_id": 2, "email": "taken@example.com"},
+            {"_id": 3},
+        ]
+    )
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        result = collection.update_one({"_id": 1}, {"$set": {"name": "renamed"}})
+        assert (result.matched_count, result.modified_count) == (1, 1)
+        assert decoded_ids and set(decoded_ids) == {1}
+
+        decoded_ids.clear()
+        collection.update_one(
+            {"_id": 1},
+            {"$set": {"email": "available@example.com"}},
+        )
+
+        decoded_ids.clear()
+        collection.update_one({"_id": 1}, {"$unset": {"email": ""}})
+
+        decoded_ids.clear()
+        with pytest.raises(DuplicateKeyError):
+            collection.update_one(
+                {"_id": 1},
+                {"$set": {"email": "taken@example.com"}},
+            )
+        decoded_ids.clear()
+        assert "email" not in collection.find_one({"_id": 1})
+    finally:
+        client.close()
+
+
+def test_tm043_partial_unique_membership_transitions_remain_atomic(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    collection.create_index(
+        "email",
+        name="active_email",
+        unique=True,
+        partialFilterExpression={"active": True},
+    )
+    collection.insert_many(
+        [
+            {"_id": 1, "email": "same@example.com", "active": True},
+            {"_id": 2, "email": "same@example.com", "active": False},
+            {"_id": 3, "email": "other@example.com", "active": False},
+        ]
+    )
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        collection.update_one({"_id": 2}, {"$set": {"note": "still outside"}})
+        assert decoded_ids and set(decoded_ids) == {2}
+
+        decoded_ids.clear()
+        with pytest.raises(DuplicateKeyError):
+            collection.update_one({"_id": 2}, {"$set": {"active": True}})
+
+        decoded_ids.clear()
+        collection.update_one({"_id": 1}, {"$set": {"active": False}})
+
+        decoded_ids.clear()
+        result = collection.update_one({"_id": 2}, {"$set": {"active": True}})
+        assert (result.matched_count, result.modified_count) == (1, 1)
+
+        decoded_ids.clear()
+        assert collection.find_one({"_id": 1})["active"] is False
+        assert collection.find_one({"_id": 2})["active"] is True
+    finally:
+        client.close()
+
+
+def test_tm043_compound_multikey_overlap_is_detected_for_parent_path_update(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    collection.create_index(
+        [("owner.id", 1), ("labels", 1)],
+        name="owner_labels",
+        unique=True,
+    )
+    collection.insert_many(
+        [
+            {
+                "_id": 1,
+                "owner": {"id": "north", "name": "Ada"},
+                "labels": ["red", "blue"],
+            },
+            {
+                "_id": 2,
+                "owner": {"id": "south", "name": "Grace"},
+                "labels": ["blue", "green"],
+            },
+            {
+                "_id": 3,
+                "owner": {"id": "west", "name": "Lin"},
+                "labels": ["yellow"],
+            },
+        ]
+    )
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        collection.update_one({"_id": 2}, {"$set": {"note": "unrelated"}})
+        assert decoded_ids and set(decoded_ids) == {2}
+
+        decoded_ids.clear()
+        with pytest.raises(DuplicateKeyError):
+            collection.update_one(
+                {"_id": 2},
+                {"$set": {"owner": {"id": "north", "name": "Grace"}}},
+            )
+
+        decoded_ids.clear()
+        assert collection.find_one({"_id": 2})["owner"]["id"] == "south"
+        assert collection.find_one({"_id": 2})["labels"] == ["blue", "green"]
+    finally:
+        client.close()
+
+
+def test_tm043_update_many_uses_indexed_candidates_with_unrelated_unique_index(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    collection.insert_many(
+        [
+            {
+                "_id": index,
+                "email": "user-{0}@example.com".format(index),
+                "group": "selected" if index % 20 == 0 else "other",
+                "visits": 0,
+            }
+            for index in range(200)
+        ]
+    )
+    collection.create_index("email", unique=True)
+    collection.create_index("group")
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        result = collection.update_many(
+            {"group": "selected"},
+            {"$inc": {"visits": 1}},
+        )
+        selected = set(range(0, 200, 20))
+
+        assert (result.matched_count, result.modified_count) == (10, 10)
+        assert decoded_ids
+        assert set(decoded_ids) == selected
+        # One candidate decode plus a small, constant expression-index cost
+        # per replacement is acceptable; collection-wide validation is not.
+        assert len(decoded_ids) <= 4 * len(selected)
+
+        decoded_ids.clear()
+        assert collection.count_documents({"visits": 1}) == 10
+        assert collection.count_documents({"visits": 0}) == 190
+    finally:
+        client.close()
+
+
+def test_tm043_no_index_id_update_keeps_existing_targeted_behavior(
+    tmp_path,
+    monkeypatch,
+):
+    client, collection = _collection(tmp_path)
+    collection.insert_many(
+        [{"_id": index, "value": index, "visits": 0} for index in range(100)]
+    )
+    decoded_ids = _track_decoded_ids(monkeypatch)
+
+    try:
+        result = collection.update_one({"_id": 73}, {"$inc": {"visits": 1}})
+
+        assert (result.matched_count, result.modified_count) == (1, 1)
+        assert decoded_ids == [73]
+    finally:
+        client.close()

--- a/tests/test_table_backends.py
+++ b/tests/test_table_backends.py
@@ -36,6 +36,7 @@ from tinymongo.table_backends import (
     _join_uri,
     _reject_remote_unique_values,
     _remote_unique_token,
+    _sqlite_index_token,
     _REMOTE_UNIQUE_TOKEN_VERSION,
     _SQLITE_UNIQUE_TOKEN_VERSION,
     matches_filter,
@@ -142,6 +143,7 @@ class FakeRemoteCursor:
                         "field_name",
                         "unique_flag",
                         "token_version",
+                        "spec_json",
                     },
                 )
             elif "TINYMONGO_COLLECTIONS" in table.upper():
@@ -190,11 +192,18 @@ class FakeRemoteCursor:
             }
             self.store.index_ddl.append(normalized)
         elif upper.startswith("INSERT") and "TINYMONGO_INDEXES" in upper:
-            database, collection, name, field, unique, token_version = params
+            if len(params) == 7:
+                database, collection, name, field, unique, token_version, spec_json = (
+                    params
+                )
+            else:
+                database, collection, name, field, unique, token_version = params
+                spec_json = None
             self.store.indexes[(database, collection, name)] = (
                 field,
                 bool(unique),
                 token_version,
+                spec_json,
             )
         elif upper.startswith("INSERT") and "TINYMONGO_COLLECTIONS" in upper:
             self.store.metadata.add(tuple(params))
@@ -202,6 +211,8 @@ class FakeRemoteCursor:
             table = params[0]
             if "COLUMN_NAME = 'TOKEN_VERSION'" in upper:
                 column = "token_version"
+            elif "COLUMN_NAME = 'SPEC_JSON'" in upper:
+                column = "spec_json"
             else:
                 column = params[1] if len(params) > 1 else "data_ordered"
             self.rows = [(1,)] if column in self.store.columns.get(table, set()) else []
@@ -229,7 +240,16 @@ class FakeRemoteCursor:
                 )
             else:
                 self.rows = sorted(
-                    (name, value[0], value[1])
+                    (
+                        (
+                            name,
+                            value[0],
+                            value[1],
+                            value[3] if len(value) > 3 else None,
+                        )
+                        if "SPEC_JSON" in upper
+                        else (name, value[0], value[1])
+                    )
                     for (index_database, index_collection, name), value in (
                         self.store.indexes.items()
                     )
@@ -313,7 +333,12 @@ class FakeRemoteCursor:
             token_version, database, collection, name = params
             key = (database, collection, name)
             value = self.store.indexes[key]
-            self.store.indexes[key] = (value[0], value[1], token_version)
+            self.store.indexes[key] = (
+                value[0],
+                value[1],
+                token_version,
+                value[3] if len(value) > 3 else None,
+            )
         elif upper.startswith("UPDATE"):
             table = self._table_after(normalized, "UPDATE")
             if len(params) >= 3:
@@ -442,6 +467,7 @@ class FakeRemoteCursor:
                 other_table == table
                 and other_column == column
                 and other_id != doc_id
+                and token is not None
                 and other_token == token
             ):
                 raise RuntimeError("duplicate key")
@@ -1004,6 +1030,75 @@ def test_sqlite_public_index_lookup_unions_scalar_and_array_matches(
         conn.close()
     assert any(backend._physical_index_name("people", spec) in row[-1] for row in plan)
     client.close()
+
+
+def test_sqlite_sparse_unique_index_allows_missing_values_and_filters_type_index(
+    tmp_path,
+):
+    path = str(tmp_path / "sparse-index.sqlite")
+    backend = SQLiteTableBackend(path)
+    spec = parse_index_spec("tag", unique=True, sparse=True, name="sparse_tag")
+    assert (
+        _sqlite_index_token(
+            _json_dumps({"_id": "missing"}),
+            _json_dumps(spec.to_metadata()),
+        )
+        is None
+    )
+    backend.create_index("items", spec)
+
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1},
+            {"_id": 2},
+            {"_id": 3, "tag": "alpha"},
+            {"_id": 4, "tag": ["beta", "gamma"]},
+        ],
+    )
+
+    assert backend.find("items", {"tag": "beta"}) == [
+        {"_id": 4, "tag": ["beta", "gamma"]}
+    ]
+    conn = sqlite3.connect(path)
+    try:
+        type_index_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            (backend._type_index_name("items", spec),),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "IN ('array', 'object')" in type_index_sql
+    assert "IS NOT NULL" in type_index_sql
+
+
+def test_sqlite_complex_planner_does_not_use_partial_index_for_broader_query(
+    tmp_path,
+):
+    backend = SQLiteTableBackend(str(tmp_path / "partial-planner.sqlite"))
+    backend.insert_many(
+        "items",
+        [
+            {"_id": 1, "category": "news", "active": True, "score": 2},
+            {"_id": 2, "category": "news", "active": False, "score": 4},
+        ],
+    )
+    backend.create_index(
+        "items",
+        parse_index_spec(
+            "category",
+            name="active_category",
+            partialFilterExpression={"active": True},
+        ),
+    )
+    query = {"category": "news", "score": {"$mod": [2, 0]}}
+
+    conn = backend._connect()
+    try:
+        assert backend._sqlite_complex_candidate_query(conn, "items", query) is None
+    finally:
+        conn.close()
+    assert [document["_id"] for document in backend.find("items", query)] == [1, 2]
 
 
 def test_sqlite_maps_native_replace_and_index_integrity_errors(tmp_path, monkeypatch):
@@ -1671,6 +1766,30 @@ def test_mysql_uses_materialized_unique_token_and_rejects_multikey_unique(
         backend.create_index("numbers", parse_index_spec("value", unique=True))
 
 
+def test_mysql_materializes_every_compound_index_component(monkeypatch):
+    store = FakeRemoteStore()
+    backend = _mysql_backend(monkeypatch, store)
+    spec = parse_index_spec(
+        [("tenant", 1), ("email", 1)],
+        name="tenant_email",
+    )
+
+    backend.create_index("users", spec)
+
+    table = backend._table_name("users")
+    columns = backend._generated_index_columns("users", spec)
+    assert len(columns) == 2
+    assert set(columns).issubset(store.columns[table])
+    assert any(
+        sql.startswith("CREATE INDEX")
+        and all("`{0}`".format(column) in sql for column in columns)
+        for sql in store.index_ddl
+    )
+
+    backend.drop_index("users", "tenant_email")
+    assert not set(columns).intersection(store.columns[table])
+
+
 @pytest.mark.parametrize(
     ("left", "right", "same_token"),
     [
@@ -1699,11 +1818,49 @@ def test_remote_unique_tokens_preserve_exact_bson_numeric_identity(
 def test_remote_unique_token_rejects_future_multitoken_expansion(monkeypatch):
     spec = parse_index_spec("value", unique=True)
     monkeypatch.setattr(
-        "tinymongo.table_backends.index_tokens", lambda _document, _field: ["a", "b"]
+        "tinymongo.table_backends.index_entry_tokens",
+        lambda _document, _spec: ["a", "b"],
     )
 
     with pytest.raises(TinyMongoNotSupportedError, match="exactly one scalar token"):
         _remote_unique_token({"value": "scalar"}, spec)
+
+
+@pytest.mark.parametrize(
+    ("spec", "document"),
+    [
+        (parse_index_spec("value", unique=True, sparse=True), {"_id": 1}),
+        (
+            parse_index_spec(
+                "value",
+                unique=True,
+                partialFilterExpression={"active": True},
+            ),
+            {"_id": 1, "active": False, "value": ["unsafe-if-indexed"]},
+        ),
+    ],
+)
+def test_remote_unique_tokens_omit_documents_outside_index_membership(spec, document):
+    assert _remote_unique_token(document, spec) is None
+
+
+def test_remote_sparse_unique_index_leaves_token_nullable(monkeypatch):
+    store = FakeRemoteStore()
+    backend = _postgres_backend(monkeypatch, store)
+    backend.insert_many("items", [{"_id": 1}, {"_id": 2}])
+
+    backend.create_index(
+        "items",
+        parse_index_spec("value", unique=True, sparse=True, name="sparse_value"),
+    )
+
+    assert backend.list_indexes("items")[-1] == {
+        "name": "sparse_value",
+        "key": [("value", 1)],
+        "unique": True,
+        "sparse": True,
+    }
+    assert not any("SET NOT NULL" in sql for sql in store.index_ddl)
 
 
 def test_remote_base_schema_hooks_and_migration_errors(monkeypatch):
@@ -1895,6 +2052,7 @@ def test_mysql_token_schema_defensive_branches(monkeypatch):
 
     monkeypatch.setattr(backend, "_execute", duplicate_column)
     backend._ensure_index_catalog_token_version(conn)
+    backend._ensure_index_catalog_spec_json(conn)
     backend._add_unique_token_column(conn, "items", spec)
 
     def bad_column(*_args):
@@ -1903,6 +2061,8 @@ def test_mysql_token_schema_defensive_branches(monkeypatch):
     monkeypatch.setattr(backend, "_execute", bad_column)
     with pytest.raises(RuntimeError, match="bad alter"):
         backend._ensure_index_catalog_token_version(conn)
+    with pytest.raises(RuntimeError, match="bad alter"):
+        backend._ensure_index_catalog_spec_json(conn)
     with pytest.raises(RuntimeError, match="bad alter"):
         backend._add_unique_token_column(conn, "items", spec)
 

--- a/tinymongo/cli.py
+++ b/tinymongo/cli.py
@@ -123,6 +123,12 @@ def _copy_indexes(source, target):
         options = {"name": metadata["name"]}
         if metadata.get("unique"):
             options["unique"] = True
+        if metadata.get("sparse"):
+            options["sparse"] = True
+        if metadata.get("partialFilterExpression") is not None:
+            options["partialFilterExpression"] = copy.deepcopy(
+                metadata["partialFilterExpression"]
+            )
         target.create_index(copy.deepcopy(metadata["key"]), **options)
 
 

--- a/tinymongo/indexes.py
+++ b/tinymongo/indexes.py
@@ -4,8 +4,10 @@ import json
 import math
 from dataclasses import dataclass
 from decimal import Decimal, localcontext
+from itertools import product
 from typing import Mapping, Optional
 
+from .bson_codec import clone as bson_clone
 from .bson_codec import dumps as bson_json_dumps
 from .errors import DuplicateKeyError, TinyMongoNotSupportedError
 from .bson_types import (
@@ -20,14 +22,20 @@ from .warning_context import emit_warning
 _Decimal128 = decimal128_type()
 
 
-INDEX_METADATA_VERSION = 1
+INDEX_METADATA_VERSION = 2
 INDEX_CATALOG_TABLE = "__tinymongo_indexes"
 MISSING = object()
-_ALLOWED_OPTIONS = {"name", "unique"}
+_ALLOWED_OPTIONS = {
+    "name",
+    "partialFilterExpression",
+    "sparse",
+    "unique",
+}
 _MODEL_ALLOWED_OPTIONS = {
     "background",
     "expireAfterSeconds",
     "name",
+    "partialFilterExpression",
     "sparse",
     "unique",
 }
@@ -50,27 +58,38 @@ def _validate_field(field):
         _unsupported("Index field components cannot start with '$'")
 
 
-def _parse_key(key):
+def _parse_keys(key):
     if is_bson_string(key):
-        return key, 1
+        return ((key, 1),)
 
-    pair = None
     if isinstance(key, (list, tuple)) and len(key) == 2 and is_bson_string(key[0]):
-        pair = key
+        pairs = (key,)
     elif isinstance(key, (list, tuple)):
-        if len(key) != 1:
-            _unsupported("Only single-field indexes are supported")
-        candidate = key[0]
-        if isinstance(candidate, (list, tuple)) and len(candidate) == 2:
-            pair = candidate
+        pairs = tuple(key)
+    elif isinstance(key, Mapping):
+        pairs = tuple(key.items())
+    else:
+        pairs = ()
 
-    if pair is None:
-        _unsupported("Index keys must be a field string or one (field, direction) pair")
+    if not pairs:
+        _unsupported(
+            "Index keys must be a field string or one or more (field, direction) pairs"
+        )
 
-    field, direction = pair
-    if not is_bson_string(field):
-        _unsupported("Index fields must be non-empty strings")
-    return field, direction
+    normalized = []
+    seen = set()
+    for pair in pairs:
+        if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+            _unsupported("Index keys must contain (field, direction) pairs")
+        field, direction = pair
+        _validate_field(field)
+        if field in seen:
+            _unsupported("Compound index fields must be unique")
+        if direction != 1 or isinstance(direction, bool):
+            _unsupported("Only ascending index direction 1 is supported")
+        normalized.append((field, direction))
+        seen.add(field)
+    return tuple(normalized)
 
 
 def _validate_index_name(name, field=None):
@@ -84,35 +103,150 @@ def _default_index_name(keys):
     return "_".join("{0}_{1}".format(field, direction) for field, direction in keys)
 
 
-@dataclass(frozen=True)
+def _validate_partial_filter(expression):
+    """Validate MongoDB's supported partial-index predicate subset."""
+    if not isinstance(expression, Mapping) or not expression:
+        _unsupported("partialFilterExpression must be a non-empty mapping")
+
+    field_operators = {"$eq", "$exists", "$gt", "$gte", "$in", "$lt", "$lte", "$type"}
+    for field, condition in expression.items():
+        if field in ("$and", "$or"):
+            if not isinstance(condition, (list, tuple)) or not condition:
+                _unsupported(
+                    "{0} in partialFilterExpression requires a non-empty array".format(
+                        field
+                    )
+                )
+            for child in condition:
+                _validate_partial_filter(child)
+            continue
+        if not is_bson_string(field) or field.startswith("$"):
+            _unsupported(
+                "Unsupported partialFilterExpression operator: {0}".format(field)
+            )
+        _validate_field(field)
+        if not isinstance(condition, Mapping):
+            continue
+        operators = [key for key in condition if str(key).startswith("$")]
+        if not operators:
+            continue
+        unknown = [
+            operator for operator in operators if operator not in field_operators
+        ]
+        if unknown:
+            _unsupported(
+                "Unsupported partialFilterExpression operator(s): {0}".format(
+                    ", ".join(sorted(unknown))
+                )
+            )
+        if len(operators) != len(condition):
+            _unsupported(
+                "partialFilterExpression cannot mix operators and literal fields"
+            )
+        if "$exists" in condition and condition["$exists"] is not True:
+            _unsupported("partialFilterExpression supports only $exists: true")
+        if "$in" in condition and not isinstance(condition["$in"], (list, tuple)):
+            _unsupported("$in in partialFilterExpression requires an array")
+
+
+@dataclass(frozen=True, init=False, eq=False)
 class IndexSpec:
     """A normalized index definition supported by TinyMongo."""
 
-    field: str
-    direction: int = 1
+    keys: tuple
     unique: bool = False
     name: Optional[str] = None
+    sparse: bool = False
+    partial_filter: Optional[Mapping] = None
+    metadata_version: int = INDEX_METADATA_VERSION
+    __hash__ = None  # type: ignore[assignment]
 
-    def __post_init__(self):
-        _validate_field(self.field)
-        if self.direction != 1 or isinstance(self.direction, bool):
-            _unsupported("Only ascending index direction 1 is supported")
-        if not isinstance(self.unique, bool):
+    def __init__(
+        self,
+        field=None,
+        direction=1,
+        unique=False,
+        name=None,
+        *,
+        keys=None,
+        sparse=False,
+        partial_filter=None,
+        metadata_version=INDEX_METADATA_VERSION,
+    ):
+        if keys is not None:
+            if field is not None:
+                raise TypeError("IndexSpec accepts either field or keys, not both")
+            normalized_keys = _parse_keys(keys)
+        else:
+            if field is None:
+                raise TypeError("IndexSpec requires field or keys")
+            normalized_keys = _parse_keys((field, direction))
+
+        if not isinstance(unique, bool):
             _unsupported("The unique index option must be a boolean")
+        if not isinstance(sparse, bool):
+            _unsupported("The sparse index option must be a boolean")
+        if partial_filter is not None and not isinstance(partial_filter, Mapping):
+            _unsupported("partialFilterExpression must be a mapping")
+        if sparse and partial_filter is not None:
+            _unsupported(
+                "The sparse and partialFilterExpression options cannot be combined"
+            )
+        if partial_filter is not None:
+            _validate_partial_filter(partial_filter)
+            from .table_backends import validate_filter_operators
 
-        name = self.name
+            validate_filter_operators(partial_filter)
+        if metadata_version not in (1, INDEX_METADATA_VERSION):
+            raise ValueError("Unsupported index metadata version")
+
         if name is None:
-            name = "{0}_1".format(self.field)
-        _validate_index_name(name, self.field)
+            name = _default_index_name(normalized_keys)
+        first_field = normalized_keys[0][0] if len(normalized_keys) == 1 else None
+        _validate_index_name(name, first_field)
+
+        object.__setattr__(self, "keys", normalized_keys)
+        object.__setattr__(self, "unique", unique)
         object.__setattr__(self, "name", name)
+        object.__setattr__(self, "sparse", sparse)
+        object.__setattr__(
+            self,
+            "partial_filter",
+            None if partial_filter is None else bson_clone(dict(partial_filter)),
+        )
+        object.__setattr__(self, "metadata_version", metadata_version)
+
+    @property
+    def field(self):
+        """Return the leading field for legacy single-index consumers."""
+        return self.keys[0][0]
+
+    @property
+    def direction(self):
+        """Return the leading direction for legacy single-index consumers."""
+        return self.keys[0][1]
+
+    @property
+    def fields(self):
+        """Return indexed fields in compound-key order."""
+        return tuple(field for field, _direction in self.keys)
+
+    def __eq__(self, other):
+        if not isinstance(other, IndexSpec):
+            return NotImplemented
+        return index_spec_signature(self) == index_spec_signature(other)
 
     def to_metadata(self):
         """Return a JSON-safe durable representation of this index."""
         return {
             "v": INDEX_METADATA_VERSION,
             "name": self.name,
-            "key": [[self.field, self.direction]],
+            "key": [list(pair) for pair in self.keys],
             "unique": self.unique,
+            "sparse": self.sparse,
+            "partialFilterExpression": (
+                None if self.partial_filter is None else bson_clone(self.partial_filter)
+            ),
         }
 
     @classmethod
@@ -120,15 +254,21 @@ class IndexSpec:
         """Restore and validate an index from durable metadata."""
         if not isinstance(metadata, Mapping):
             raise ValueError("Index metadata must be a mapping")
-        if metadata.get("v") != INDEX_METADATA_VERSION:
+        version = metadata.get("v")
+        if version not in (1, INDEX_METADATA_VERSION):
             raise ValueError("Unsupported index metadata version")
         required = {"v", "name", "key", "unique"}
+        if version == INDEX_METADATA_VERSION:
+            required.update({"sparse", "partialFilterExpression"})
         if set(metadata) != required:
             raise ValueError("Index metadata has missing or unknown fields")
         return parse_index_spec(
             metadata["key"],
             name=metadata["name"],
             unique=metadata["unique"],
+            sparse=metadata.get("sparse", False),
+            partialFilterExpression=metadata.get("partialFilterExpression"),
+            _metadata_version=version,
         )
 
 
@@ -136,21 +276,32 @@ def index_spec_signature(spec):
     """Return the key-and-options identity used to detect equivalent indexes."""
     if not isinstance(spec, IndexSpec):
         raise TypeError("Index signatures require an IndexSpec")
-    return (spec.field, spec.direction, spec.unique)
+    partial = (
+        None
+        if spec.partial_filter is None
+        else bson_json_dumps(
+            spec.partial_filter,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    )
+    return (spec.keys, spec.unique, spec.sparse, partial)
 
 
 def parse_index_spec(key, **options):
-    """Normalize a supported single-field ascending index definition."""
+    """Normalize a supported ascending index definition."""
+    metadata_version = options.pop("_metadata_version", INDEX_METADATA_VERSION)
     unknown = sorted(set(options) - _ALLOWED_OPTIONS)
     if unknown:
         _unsupported("Unsupported index option(s): {0}".format(", ".join(unknown)))
 
-    field, direction = _parse_key(key)
     return IndexSpec(
-        field=field,
-        direction=direction,
+        keys=_parse_keys(key),
         unique=options.get("unique", False),
         name=options.get("name"),
+        sparse=options.get("sparse", False),
+        partial_filter=options.get("partialFilterExpression"),
+        metadata_version=metadata_version,
     )
 
 
@@ -158,11 +309,9 @@ def parse_index_spec(key, **options):
 class IndexModelPlan:
     """One normalized outcome from a PyMongo-style index declaration.
 
-    ``spec`` is the effective index TinyMongo can create. Compound indexes use
-    their ascending leading-field prefix, matching MongoDB's leftmost-prefix
-    behavior as closely as a single-field backend can. It is ``None`` when no
-    useful safe fallback exists, such as a text index. ``degraded_features``
-    records every requested feature that is not honored.
+    ``spec`` is the effective index TinyMongo can create. It is ``None`` when
+    no useful safe fallback exists, such as a text index.
+    ``degraded_features`` records every requested feature that is not honored.
     """
 
     name: str
@@ -271,6 +420,14 @@ def _validate_model_options(options):
         if option in options and not isinstance(options[option], bool):
             _unsupported("The {0} index option must be a boolean".format(option))
 
+    partial_filter = options.get("partialFilterExpression")
+    if partial_filter is not None and not isinstance(partial_filter, Mapping):
+        _unsupported("partialFilterExpression must be a mapping")
+    if options.get("sparse", False) and partial_filter is not None:
+        _unsupported(
+            "The sparse and partialFilterExpression options cannot be combined"
+        )
+
     if "expireAfterSeconds" in options:
         seconds = options["expireAfterSeconds"]
         if (
@@ -285,10 +442,8 @@ def _validate_model_options(options):
 def _degraded_feature_message(feature):
     messages = {
         "background": "background creation is ignored",
-        "compound": "compound indexing is reduced to its ascending leading field",
         "descending": "descending direction is treated as ascending",
         "hashed": "hashed indexing is replaced by ascending equality indexing",
-        "sparse": "sparse membership is not honored",
         "text": "text indexing is ignored because $text queries are not supported",
         "ttl": "TTL expiration is not performed",
     }
@@ -331,8 +486,17 @@ def plan_index_model(model):
     if isinstance(model, IndexSpec):
         return IndexModelPlan(
             name=model.name,
-            requested_keys=((model.field, model.direction),),
-            requested_options=(("name", model.name), ("unique", model.unique)),
+            requested_keys=model.keys,
+            requested_options=tuple(
+                (key, value)
+                for key, value in (
+                    ("name", model.name),
+                    ("unique", model.unique),
+                    ("sparse", model.sparse),
+                    ("partialFilterExpression", model.partial_filter),
+                )
+                if value not in (False, None)
+            ),
             spec=model,
         )
 
@@ -351,22 +515,18 @@ def plan_index_model(model):
 
     unique = options.get("unique", False)
     features = []
-    if len(keys) > 1:
-        features.append("compound")
     if any(direction == -1 for _, direction in keys):
         features.append("descending")
     if any(direction == "hashed" for _, direction in keys):
         features.append("hashed")
     if any(direction == "text" for _, direction in keys):
         features.append("text")
-    if options.get("sparse", False):
-        features.append("sparse")
     if "expireAfterSeconds" in options:
         features.append("ttl")
     if options.get("background", False):
         features.append("background")
 
-    unsafe_unique_features = {"compound", "hashed", "sparse", "text", "ttl"}
+    unsafe_unique_features = {"hashed", "text", "ttl"}
     unsafe = [item for item in features if item in unsafe_unique_features]
     if unique and unsafe:
         _unsupported(
@@ -377,10 +537,11 @@ def plan_index_model(model):
     spec = None
     if "text" not in features:
         spec = IndexSpec(
-            field=keys[0][0],
-            direction=1,
+            keys=tuple((field, 1) for field, _direction in keys),
             unique=unique,
             name=name,
+            sparse=options.get("sparse", False),
+            partial_filter=options.get("partialFilterExpression"),
         )
     degraded = tuple(features)
     warning = _plan_warning(name, degraded) if degraded else None
@@ -529,6 +690,70 @@ def index_tokens(document, field):
     return tuple(tokens)
 
 
+def document_matches_index(document, spec):
+    """Return whether ``document`` contributes entries to ``spec``.
+
+    Sparse compound indexes include a document when at least one indexed field
+    exists. Partial indexes instead use their complete filter expression. The
+    two options are rejected together when the spec is normalized.
+    """
+    if not isinstance(document, Mapping):
+        raise TypeError("Indexed documents must be mappings")
+    if not isinstance(spec, IndexSpec):
+        raise TypeError("Index membership requires an IndexSpec")
+
+    if spec.partial_filter is not None:
+        # Import lazily because table_backends imports this module while it is
+        # defining the shared MongoDB matcher.
+        from .table_backends import matches_filter
+
+        return matches_filter(document, spec.partial_filter)
+    if spec.sparse:
+        return any(
+            _nested_value(document, field) is not MISSING for field in spec.fields
+        )
+    return True
+
+
+def index_entry_tokens(document, spec):
+    """Return exact BSON-aware entries contributed by one index spec.
+
+    Single-field indexes retain their established token representation. A
+    compound index creates the ordered Cartesian product of its component
+    values, matching MongoDB when at most one indexed field is an array. More
+    than one array would be a parallel-array compound index, which MongoDB also
+    refuses rather than silently weakening.
+    """
+    if not isinstance(spec, IndexSpec):
+        raise TypeError("Index entries require an IndexSpec")
+    if not document_matches_index(document, spec):
+        return ()
+    if len(spec.keys) == 1:
+        return index_tokens(document, spec.field)
+
+    components = []
+    array_fields = []
+    for field in spec.fields:
+        value = _nested_value(document, field)
+        if isinstance(value, list):
+            array_fields.append(field)
+        components.append(index_tokens(document, field))
+    if len(array_fields) > 1:
+        _unsupported(
+            "Compound index {0!r} cannot index parallel array fields: {1}".format(
+                spec.name,
+                ", ".join(array_fields),
+            )
+        )
+
+    return tuple(
+        "compound:{0}".format(
+            json.dumps(list(values), ensure_ascii=False, separators=(",", ":"))
+        )
+        for values in product(*components)
+    )
+
+
 def validate_unique_documents(documents, indexes):
     """Raise when post-image documents conflict on a unique index."""
     docs = list(documents)
@@ -544,7 +769,7 @@ def validate_unique_documents(documents, indexes):
             if not isinstance(document, Mapping):
                 raise TypeError("Indexed documents must be mappings")
             identity = document.get("_id", "position {0}".format(position))
-            for token in index_tokens(document, spec.field):
+            for token in index_entry_tokens(document, spec):
                 if token in owners:
                     raise DuplicateKeyError(
                         "duplicate key for unique index {0}: documents {1!r} and "
@@ -562,7 +787,9 @@ __all__ = [
     "MISSING",
     "TinyMongoUnsupportedWarning",
     "degraded_index_reuse_warning",
+    "document_matches_index",
     "emit_index_plan_warnings",
+    "index_entry_tokens",
     "index_catalog_id",
     "index_spec_signature",
     "index_tokens",

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -12,7 +12,7 @@ import threading
 from collections.abc import Mapping
 from contextlib import contextmanager
 from decimal import Decimal
-from functools import wraps
+from functools import lru_cache, wraps
 from urllib.parse import parse_qs, unquote, urlparse
 from typing import Optional
 
@@ -44,7 +44,9 @@ from .errors import (
 from .indexes import (
     INDEX_CATALOG_TABLE,
     IndexSpec,
+    document_matches_index,
     index_catalog_id,
+    index_entry_tokens,
     index_spec_signature,
     index_tokens,
     parse_index_spec,
@@ -690,6 +692,33 @@ def _sqlite_unique_token(data, field):
     )
 
 
+@lru_cache(maxsize=256)
+def _sqlite_index_spec(spec_json):
+    """Decode one catalog spec once per process for SQLite index UDFs."""
+    return IndexSpec.from_metadata(bson_json_loads(spec_json))
+
+
+def _sqlite_index_token(data, spec_json):
+    """Return the exact token set or SQL NULL for an advanced unique index.
+
+    The serialized tuple mirrors the established single-field SQLite
+    constraint. Python validation, held under TinyMongo's write lock, still
+    enforces overlapping multikey entries; the native value closes races for
+    identical token sets without rejecting otherwise valid flat arrays.
+    """
+    spec = _sqlite_index_spec(spec_json)
+    tokens = index_entry_tokens(_json_loads(data), spec)
+    if not tokens:
+        return None
+    return json.dumps(tokens, ensure_ascii=False, separators=(",", ":"))
+
+
+def _sqlite_index_member(data, spec_json):
+    """Return whether a document belongs to a partial SQLite index."""
+    spec = _sqlite_index_spec(spec_json)
+    return int(document_matches_index(_json_loads(data), spec))
+
+
 def _simple_scalar_equality(filter_doc):
     """Return one SQL-safe equality pair, or ``None`` for richer filters."""
     if not isinstance(filter_doc, Mapping) or len(filter_doc) != 1:
@@ -756,36 +785,39 @@ def _reject_remote_unique_values(documents, specs):
         if not spec.unique:
             continue
         for document in documents:
-            value = _get_nested(document, spec.field)
-            if isinstance(value, (list, tuple)):
-                raise TinyMongoNotSupportedError(
-                    "Remote SQL unique index {0!r} does not support array values; "
-                    "cross-process multikey uniqueness cannot be guaranteed".format(
-                        spec.name
+            if not document_matches_index(document, spec):
+                continue
+            for field in spec.fields:
+                value = _get_nested(document, field)
+                if isinstance(value, (list, tuple)):
+                    raise TinyMongoNotSupportedError(
+                        "Remote SQL unique index {0!r} does not support array "
+                        "values; cross-process multikey uniqueness cannot be "
+                        "guaranteed".format(spec.name)
                     )
-                )
-            if _DECIMAL128 is not None and isinstance(value, _DECIMAL128):
-                raise TinyMongoNotSupportedError(
-                    "Remote SQL unique index {0!r} does not support Decimal128 "
-                    "values; TinyMongo cannot yet derive the same safe native "
-                    "token from Decimal128 BID data".format(spec.name)
-                )
-            identity = bson_identity_key(value)
-            if identity is not None and identity[0] in ("binary", "regex"):
-                raise TinyMongoNotSupportedError(
-                    "Remote SQL unique index {0!r} does not support UUID, "
-                    "Binary, or regular-expression values; its native token "
-                    "constraint cannot guarantee cross-process BSON identity".format(
-                        spec.name
+                if _DECIMAL128 is not None and isinstance(value, _DECIMAL128):
+                    raise TinyMongoNotSupportedError(
+                        "Remote SQL unique index {0!r} does not support Decimal128 "
+                        "values; TinyMongo cannot yet derive the same safe native "
+                        "token from Decimal128 BID data".format(spec.name)
                     )
-                )
+                identity = bson_identity_key(value)
+                if identity is not None and identity[0] in ("binary", "regex"):
+                    raise TinyMongoNotSupportedError(
+                        "Remote SQL unique index {0!r} does not support UUID, "
+                        "Binary, or regular-expression values; its native token "
+                        "constraint cannot guarantee cross-process BSON "
+                        "identity".format(spec.name)
+                    )
 
 
 def _remote_unique_token(document, spec):
     """Return one fixed-width exact BSON token for a remote unique index."""
 
     _reject_remote_unique_values([document], [spec])
-    tokens = index_tokens(document, spec.field)
+    tokens = index_entry_tokens(document, spec)
+    if not tokens:
+        return None
     if len(tokens) != 1:
         # Arrays are rejected above. Keep this guard explicit so a future
         # multikey expansion cannot silently weaken the one-column native
@@ -2068,7 +2100,9 @@ class TableBackend(object):
     def drop_index(self, collection, name_or_field):
         indexes = self._ephemeral_indexes.get(collection, {})
         for name, spec in list(indexes.items()):
-            if name_or_field in (name, spec.field):
+            if name_or_field == name or (
+                len(spec.keys) == 1 and name_or_field == spec.field
+            ):
                 indexes.pop(name, None)
                 return None
         raise OperationFailure(
@@ -2081,9 +2115,13 @@ class TableBackend(object):
         for spec in sorted(
             self.get_index_specs(collection), key=lambda item: item.name
         ):
-            metadata = {"name": spec.name, "key": [(spec.field, spec.direction)]}
+            metadata = {"name": spec.name, "key": list(spec.keys)}
             if spec.unique:
                 metadata["unique"] = True
+            if spec.sparse:
+                metadata["sparse"] = True
+            if spec.partial_filter is not None:
+                metadata["partialFilterExpression"] = copy.deepcopy(spec.partial_filter)
             indexes.append(metadata)
         return indexes
 
@@ -2123,6 +2161,18 @@ class SQLiteTableBackend(TableBackend):
             "tinymongo_unique_token",
             2,
             _sqlite_unique_token,
+            deterministic=True,
+        )
+        conn.create_function(
+            "tinymongo_index_token",
+            2,
+            _sqlite_index_token,
+            deterministic=True,
+        )
+        conn.create_function(
+            "tinymongo_index_member",
+            2,
+            _sqlite_index_member,
             deterministic=True,
         )
         conn.execute("PRAGMA busy_timeout=30000")
@@ -2193,6 +2243,7 @@ class SQLiteTableBackend(TableBackend):
             "collection_name TEXT NOT NULL, index_name TEXT NOT NULL, "
             "field_name TEXT NOT NULL, unique_flag INTEGER NOT NULL, "
             "token_version INTEGER NOT NULL DEFAULT {1}, "
+            "spec_json TEXT, "
             "PRIMARY KEY (collection_name, index_name))".format(
                 _quote_identifier(self.index_catalog_table),
                 _SQLITE_UNIQUE_TOKEN_VERSION,
@@ -2211,6 +2262,13 @@ class SQLiteTableBackend(TableBackend):
             conn.execute(
                 "ALTER TABLE {0} ADD COLUMN token_version INTEGER NOT NULL "
                 "DEFAULT 1".format(_quote_identifier(self.index_catalog_table))
+            )
+            migrated = True
+        if "spec_json" not in columns:
+            conn.execute(
+                "ALTER TABLE {0} ADD COLUMN spec_json TEXT".format(
+                    _quote_identifier(self.index_catalog_table)
+                )
             )
             migrated = True
 
@@ -2288,7 +2346,7 @@ class SQLiteTableBackend(TableBackend):
                 )
             ).fetchall()
         }
-        if "token_version" not in columns:
+        if "token_version" not in columns or "spec_json" not in columns:
             return "stale"
 
         stale = conn.execute(
@@ -2312,14 +2370,24 @@ class SQLiteTableBackend(TableBackend):
             with self._write_lock():
                 self._ensure_index_catalog(conn)
         rows = conn.execute(
-            "SELECT index_name, field_name, unique_flag FROM {0} "
+            "SELECT index_name, field_name, unique_flag, spec_json FROM {0} "
             "WHERE collection_name = ? ORDER BY index_name".format(
                 _quote_identifier(self.index_catalog_table)
             ),
             (collection,),
         ).fetchall()
         return [
-            IndexSpec(field=row[1], name=row[0], unique=bool(row[2])) for row in rows
+            (
+                IndexSpec.from_metadata(bson_json_loads(row[3]))
+                if row[3]
+                else IndexSpec(
+                    field=row[1],
+                    name=row[0],
+                    unique=bool(row[2]),
+                    metadata_version=1,
+                )
+            )
+            for row in rows
         ]
 
     def _get_query_index_specs_on_connection(self, conn, collection):
@@ -3215,6 +3283,38 @@ class SQLiteTableBackend(TableBackend):
     def _type_index_name(self, collection, spec):
         return self._physical_index_name(collection, spec) + "_types"
 
+    @staticmethod
+    def _sqlite_index_expressions(spec):
+        """Return ordered native JSON expressions for one declared index."""
+        return [
+            "json_extract(data, {0})".format(_sql_literal(_json_path(field)))
+            for field, _direction in spec.keys
+        ]
+
+    @staticmethod
+    def _sqlite_index_where(spec):
+        """Return exact native membership SQL for sparse or partial indexes."""
+        if spec.partial_filter is not None:
+            metadata = _sql_literal(bson_json_dumps(spec.to_metadata()))
+            return " WHERE tinymongo_index_member(data, {0}) = 1".format(metadata)
+        if spec.sparse:
+            members = [
+                "json_type(data, {0}) IS NOT NULL".format(
+                    _sql_literal(_json_path(field))
+                )
+                for field in spec.fields
+            ]
+            return " WHERE " + " OR ".join(members)
+        return ""
+
+    def _sqlite_constraint_expression(self, spec):
+        """Return the native expression enforcing one unique definition."""
+        if len(spec.keys) == 1 and not spec.sparse and spec.partial_filter is None:
+            return "tinymongo_unique_token(data, {0})".format(_sql_literal(spec.field))
+        return "tinymongo_index_token(data, {0})".format(
+            _sql_literal(bson_json_dumps(spec.to_metadata()))
+        )
+
     def _ensure_type_index_on_connection(self, conn, collection, spec):
         """Reconcile native scalar and array-candidate indexes for one spec."""
 
@@ -3227,7 +3327,6 @@ class SQLiteTableBackend(TableBackend):
             with self._sqlite_state_lock:
                 if key in self._ready_type_indexes:
                     return
-                path = _sql_literal(_json_path(spec.field))
                 table = _quote_identifier(collection)
                 physical_name = self._physical_index_name(collection, spec)
                 physical_exists = conn.execute(
@@ -3243,40 +3342,52 @@ class SQLiteTableBackend(TableBackend):
                     ]
                     validate_unique_documents(documents, [spec])
 
-                scalar_expression = "json_extract(data, {0})".format(path)
-                constraint_expression = scalar_expression
-                if spec.unique:
-                    constraint_expression = "tinymongo_unique_token(data, {0})".format(
-                        _sql_literal(spec.field)
-                    )
+                expressions = self._sqlite_index_expressions(spec)
+                lookup_expression = ", ".join(expressions)
+                constraint_expression = (
+                    self._sqlite_constraint_expression(spec)
+                    if spec.unique
+                    else lookup_expression
+                )
+                membership_where = self._sqlite_index_where(spec)
                 conn.execute(
                     "CREATE {unique}INDEX IF NOT EXISTS {name} ON {table} "
-                    "({expression})".format(
+                    "({expression}){where}".format(
                         unique="UNIQUE " if spec.unique else "",
                         name=_quote_identifier(physical_name),
                         table=table,
                         expression=constraint_expression,
+                        where=membership_where,
                     )
                 )
                 if spec.unique:
                     conn.execute(
                         "CREATE INDEX IF NOT EXISTS {name} ON {table} "
-                        "({expression})".format(
+                        "({expression}){where}".format(
                             name=_quote_identifier(physical_name + "_lookup"),
                             table=table,
-                            expression=scalar_expression,
+                            expression=lookup_expression,
+                            where=membership_where,
                         )
                     )
                 if "." not in spec.field:
-                    type_expression = "json_type(data, {0})".format(path)
+                    type_expression = "json_type(data, {0})".format(
+                        _sql_literal(_json_path(spec.field))
+                    )
+                    type_where = " WHERE {0} IN ('array', 'object')".format(
+                        type_expression
+                    )
+                    if membership_where:
+                        type_where += " AND ({0})".format(membership_where[7:])
                     conn.execute(
-                        "CREATE INDEX IF NOT EXISTS {name} ON {table} ({expression}) "
-                        "WHERE {expression} IN ('array', 'object')".format(
+                        "CREATE INDEX IF NOT EXISTS {name} ON {table} "
+                        "({expression}){where}".format(
                             name=_quote_identifier(
                                 self._type_index_name(collection, spec)
                             ),
                             table=table,
                             expression=type_expression,
+                            where=type_where,
                         )
                     )
                 conn.commit()
@@ -3475,7 +3586,13 @@ class SQLiteTableBackend(TableBackend):
 
         conjuncts = _positive_filter_conjuncts(filter_doc)
         specs = self._get_query_index_specs_on_connection(conn, collection)
-        by_field = {spec.field: spec for spec in specs}
+        by_field = {}
+        for spec in sorted(
+            specs,
+            key=lambda item: (item.partial_filter is not None, item.sparse),
+        ):
+            if spec.partial_filter is None:
+                by_field.setdefault(spec.field, spec)
         anchor = None
         for field, expected in conjuncts:
             if isinstance(field, str) and field != "_id" and "." not in field:
@@ -3588,7 +3705,7 @@ class SQLiteTableBackend(TableBackend):
                     for candidate in self._get_query_index_specs_on_connection(
                         conn, collection
                     )
-                    if candidate.field == field
+                    if candidate.field == field and candidate.partial_filter is None
                 ),
                 None,
             )
@@ -3876,7 +3993,11 @@ class SQLiteTableBackend(TableBackend):
         query_index_spec = None
         if equality is not None and "." not in equality[0]:
             query_index_spec = next(
-                (spec for spec in specs if spec.field == equality[0]),
+                (
+                    spec
+                    for spec in specs
+                    if spec.field == equality[0] and spec.partial_filter is None
+                ),
                 None,
             )
         table = _quote_identifier(collection)
@@ -4043,48 +4164,62 @@ class SQLiteTableBackend(TableBackend):
         if spec.unique:
             validate_unique_documents(self.find(collection, {}), [spec])
         name = self._physical_index_name(collection, spec)
-        path = _sql_literal(_json_path(spec.field))
-        expression = "json_extract(data, {0})".format(path)
-        if spec.unique:
-            expression = "tinymongo_unique_token(data, {0})".format(
-                _sql_literal(spec.field)
-            )
+        expressions = self._sqlite_index_expressions(spec)
+        lookup_expression = ", ".join(expressions)
+        expression = (
+            self._sqlite_constraint_expression(spec)
+            if spec.unique
+            else lookup_expression
+        )
+        membership_where = self._sqlite_index_where(spec)
         conn = self._connect()
         try:
             try:
                 self._ensure_index_catalog(conn)
                 conn.execute(
-                    "CREATE {0}INDEX IF NOT EXISTS {1} ON {2} ({3})".format(
-                        "UNIQUE " if spec.unique else "",
-                        _quote_identifier(name),
-                        _quote_identifier(collection),
-                        expression,
+                    "CREATE {unique}INDEX IF NOT EXISTS {name} ON {table} "
+                    "({expression}){where}".format(
+                        unique="UNIQUE " if spec.unique else "",
+                        name=_quote_identifier(name),
+                        table=_quote_identifier(collection),
+                        expression=expression,
+                        where=membership_where,
                     )
                 )
                 if spec.unique:
                     conn.execute(
-                        "CREATE INDEX IF NOT EXISTS {0} ON {1} "
-                        "(json_extract(data, {2}))".format(
-                            _quote_identifier(name + "_lookup"),
-                            _quote_identifier(collection),
-                            path,
+                        "CREATE INDEX IF NOT EXISTS {name} ON {table} "
+                        "({expression}){where}".format(
+                            name=_quote_identifier(name + "_lookup"),
+                            table=_quote_identifier(collection),
+                            expression=lookup_expression,
+                            where=membership_where,
                         )
                     )
                 if "." not in spec.field:
-                    type_expression = "json_type(data, {0})".format(path)
+                    type_expression = "json_type(data, {0})".format(
+                        _sql_literal(_json_path(spec.field))
+                    )
+                    type_where = " WHERE {0} IN ('array', 'object')".format(
+                        type_expression
+                    )
+                    if membership_where:
+                        type_where += " AND ({0})".format(membership_where[7:])
                     conn.execute(
-                        "CREATE INDEX IF NOT EXISTS {name} ON {table} ({expression}) "
-                        "WHERE {expression} IN ('array', 'object')".format(
+                        "CREATE INDEX IF NOT EXISTS {name} ON {table} "
+                        "({expression}){where}".format(
                             name=_quote_identifier(
                                 self._type_index_name(collection, spec)
                             ),
                             table=_quote_identifier(collection),
                             expression=type_expression,
+                            where=type_where,
                         )
                     )
                 conn.execute(
                     "INSERT INTO {0} (collection_name, index_name, field_name, "
-                    "unique_flag, token_version) VALUES (?, ?, ?, ?, ?)".format(
+                    "unique_flag, token_version, spec_json) "
+                    "VALUES (?, ?, ?, ?, ?, ?)".format(
                         _quote_identifier(self.index_catalog_table)
                     ),
                     (
@@ -4093,6 +4228,7 @@ class SQLiteTableBackend(TableBackend):
                         spec.field,
                         int(spec.unique),
                         _SQLITE_UNIQUE_TOKEN_VERSION,
+                        bson_json_dumps(spec.to_metadata()),
                     ),
                 )
                 conn.commit()
@@ -4111,7 +4247,8 @@ class SQLiteTableBackend(TableBackend):
             (
                 item
                 for item in self.get_index_specs(collection)
-                if name_or_field in (item.name, item.field)
+                if name_or_field == item.name
+                or (len(item.keys) == 1 and name_or_field == item.field)
             ),
             None,
         )
@@ -4190,7 +4327,13 @@ class DuckDBTableBackend(TableBackend):
             "CREATE TABLE IF NOT EXISTS {0} ("
             "collection_name VARCHAR NOT NULL, index_name VARCHAR NOT NULL, "
             "field_name VARCHAR NOT NULL, unique_flag BOOLEAN NOT NULL, "
+            "spec_json VARCHAR, "
             "PRIMARY KEY (collection_name, index_name))".format(
+                _quote_identifier(self.index_catalog_table)
+            )
+        )
+        conn.execute(
+            "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS spec_json VARCHAR".format(
                 _quote_identifier(self.index_catalog_table)
             )
         )
@@ -4200,14 +4343,23 @@ class DuckDBTableBackend(TableBackend):
         try:
             self._ensure_index_catalog(conn)
             rows = conn.execute(
-                "SELECT index_name, field_name, unique_flag FROM {0} "
+                "SELECT index_name, field_name, unique_flag, spec_json FROM {0} "
                 "WHERE collection_name = ? ORDER BY index_name".format(
                     _quote_identifier(self.index_catalog_table)
                 ),
                 (collection,),
             ).fetchall()
             return [
-                IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
+                (
+                    IndexSpec.from_metadata(bson_json_loads(row[3]))
+                    if row[3]
+                    else IndexSpec(
+                        field=row[1],
+                        name=row[0],
+                        unique=bool(row[2]),
+                        metadata_version=1,
+                    )
+                )
                 for row in rows
             ]
         finally:
@@ -4430,10 +4582,17 @@ class DuckDBTableBackend(TableBackend):
         try:
             self._ensure_index_catalog(conn)
             conn.execute(
-                "INSERT INTO {0} VALUES (?, ?, ?, ?)".format(
+                "INSERT INTO {0} (collection_name, index_name, field_name, "
+                "unique_flag, spec_json) VALUES (?, ?, ?, ?, ?)".format(
                     _quote_identifier(self.index_catalog_table)
                 ),
-                (collection, spec.name, spec.field, spec.unique),
+                (
+                    collection,
+                    spec.name,
+                    spec.field,
+                    spec.unique,
+                    bson_json_dumps(spec.to_metadata()),
+                ),
             )
         finally:
             conn.close()
@@ -4445,7 +4604,8 @@ class DuckDBTableBackend(TableBackend):
             (
                 item
                 for item in self.get_index_specs(collection)
-                if name_or_field in (item.name, item.field)
+                if name_or_field == item.name
+                or (len(item.keys) == 1 and name_or_field == item.field)
             ),
             None,
         )
@@ -4750,7 +4910,8 @@ class ParquetDuckDBBackend(DuckDBTableBackend):
                 (
                     item
                     for item in self.get_index_specs(collection)
-                    if name_or_field in (item.name, item.field)
+                    if name_or_field == item.name
+                    or (len(item.keys) == 1 and name_or_field == item.field)
                 ),
                 None,
             )
@@ -4881,11 +5042,13 @@ class RemoteSQLTableBackend(TableBackend):
             "field_name VARCHAR(512) NOT NULL, "
             "unique_flag BOOLEAN NOT NULL, "
             "token_version INTEGER NOT NULL DEFAULT 0, "
+            "spec_json TEXT NULL, "
             "PRIMARY KEY (database_name, collection_name, index_name))".format(
                 self._quote(self.index_catalog_table)
             ),
         )
         self._ensure_index_catalog_token_version(conn)
+        self._ensure_index_catalog_spec_json(conn)
         self._commit(conn)
 
     def _ensure_index_catalog_token_version(self, conn):
@@ -4908,7 +5071,7 @@ class RemoteSQLTableBackend(TableBackend):
     def _index_specs_on_connection(self, conn, collection):
         cursor = self._execute(
             conn,
-            "SELECT index_name, field_name, unique_flag FROM {0} "
+            "SELECT index_name, field_name, unique_flag, spec_json FROM {0} "
             "WHERE database_name = {1} AND collection_name = {1} "
             "ORDER BY index_name".format(
                 self._quote(self.index_catalog_table), self.placeholder
@@ -4917,7 +5080,16 @@ class RemoteSQLTableBackend(TableBackend):
         )
         try:
             return [
-                IndexSpec(field=row[1], name=row[0], unique=bool(row[2]))
+                (
+                    IndexSpec.from_metadata(bson_json_loads(row[3]))
+                    if row[3]
+                    else IndexSpec(
+                        field=row[1],
+                        name=row[0],
+                        unique=bool(row[2]),
+                        metadata_version=1,
+                    )
+                )
                 for row in cursor.fetchall()
             ]
         finally:
@@ -5038,7 +5210,8 @@ class RemoteSQLTableBackend(TableBackend):
                     for stored_id, document in stored_documents
                 ],
             )
-        self._set_unique_token_not_null(conn, collection, spec)
+        if not spec.sparse and spec.partial_filter is None:
+            self._set_unique_token_not_null(conn, collection, spec)
 
     def _migrate_legacy_unique_indexes(self, conn, collection):
         # The overwhelmingly common path must not take a table/advisory lock.
@@ -5173,6 +5346,27 @@ class RemoteSQLTableBackend(TableBackend):
             conn,
             "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS data_ordered {1} NULL".format(
                 table, self.ordered_data_type
+            ),
+        )
+
+    def _ensure_index_catalog_spec_json(self, conn):
+        cursor = self._execute(
+            conn,
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = {0} "
+            "AND column_name = 'spec_json' LIMIT 1".format(self.placeholder),
+            (self.index_catalog_table,),
+        )
+        try:
+            exists = cursor.fetchone() is not None
+        finally:
+            self._close_cursor(cursor)
+        if exists:
+            return
+        self._execute(
+            conn,
+            "ALTER TABLE {0} ADD COLUMN IF NOT EXISTS spec_json TEXT NULL".format(
+                self._quote(self.index_catalog_table)
             ),
         )
 
@@ -5486,8 +5680,8 @@ class RemoteSQLTableBackend(TableBackend):
                         conn,
                         "INSERT INTO {0} "
                         "(database_name, collection_name, index_name, field_name, "
-                        "unique_flag, token_version) "
-                        "VALUES ({1}, {1}, {1}, {1}, {1}, {1})".format(
+                        "unique_flag, token_version, spec_json) "
+                        "VALUES ({1}, {1}, {1}, {1}, {1}, {1}, {1})".format(
                             self._quote(self.index_catalog_table), self.placeholder
                         ),
                         (
@@ -5497,6 +5691,7 @@ class RemoteSQLTableBackend(TableBackend):
                             spec.field,
                             spec.unique,
                             _REMOTE_UNIQUE_TOKEN_VERSION if spec.unique else 0,
+                            bson_json_dumps(spec.to_metadata()),
                         ),
                     )
                     self._commit(conn)
@@ -5524,7 +5719,8 @@ class RemoteSQLTableBackend(TableBackend):
             (
                 item
                 for item in self.get_index_specs(collection)
-                if name_or_field in (item.name, item.field)
+                if name_or_field == item.name
+                or (len(item.keys) == 1 and name_or_field == item.field)
             ),
             None,
         )
@@ -5665,10 +5861,14 @@ class PostgresTableBackend(RemoteSQLTableBackend):
         if spec.unique:
             expression = self._quote(self._unique_token_column(collection, spec))
         else:
-            path = ", ".join(_sql_literal(part) for part in spec.field.split("."))
-            expression = (
-                "(COALESCE(jsonb_extract_path(data, {0}), 'null'::jsonb))".format(path)
-            )
+            expressions = []
+            for field, _direction in spec.keys:
+                path = ", ".join(_sql_literal(part) for part in field.split("."))
+                expressions.append(
+                    "(COALESCE(jsonb_extract_path(data, {0}), "
+                    "'null'::jsonb))".format(path)
+                )
+            expression = ", ".join(expressions)
         self._execute(
             conn,
             "CREATE {0}INDEX {1} ON {2} ({3})".format(
@@ -5854,8 +6054,31 @@ class MySQLTableBackend(RemoteSQLTableBackend):
             if code != 1060 and "duplicate column" not in str(exc).lower():
                 raise
 
+    def _ensure_index_catalog_spec_json(self, conn):
+        if self._mysql_column_exists(conn, self.index_catalog_table, "spec_json"):
+            return
+        try:
+            self._execute(
+                conn,
+                "ALTER TABLE {0} ADD COLUMN spec_json LONGTEXT NULL".format(
+                    self._quote(self.index_catalog_table)
+                ),
+            )
+        except Exception as exc:
+            code = exc.args[0] if getattr(exc, "args", ()) else None
+            if code != 1060 and "duplicate column" not in str(exc).lower():
+                raise
+
     def _generated_index_column(self, collection, spec):
         return self._physical_index_name(collection, spec).replace("_idx_", "_key_")
+
+    def _generated_index_columns(self, collection, spec):
+        """Return one deterministic generated column per compound key part."""
+        base = self._generated_index_column(collection, spec)
+        return tuple(
+            base if position == 0 else "{0}_{1}".format(base, position)
+            for position, _pair in enumerate(spec.keys)
+        )
 
     def _add_unique_token_column(self, conn, collection, spec):
         table_name = self._table_name(collection)
@@ -5937,41 +6160,44 @@ class MySQLTableBackend(RemoteSQLTableBackend):
                 ),
             )
             return
-        json_path = "$" + "".join(
-            "." + json.dumps(part, ensure_ascii=False) for part in spec.field.split(".")
-        )
-        value = "JSON_EXTRACT(data, {0})".format(_sql_literal(json_path))
-        value_type = "JSON_TYPE({0})".format(value)
-        token_expression = (
-            "CASE "
-            "WHEN {value} IS NULL OR {value_type} = 'NULL' THEN 'null:' "
-            "WHEN {value_type} = 'BOOLEAN' "
-            "THEN CONCAT('bool:', JSON_UNQUOTE({value})) "
-            "WHEN {value_type} IN ('INTEGER', 'DOUBLE', 'DECIMAL') "
-            "THEN CONCAT('number:', CAST(CAST(JSON_UNQUOTE({value}) "
-            "AS DECIMAL(65, 30)) AS CHAR)) "
-            "WHEN {value_type} = 'STRING' "
-            "THEN CONCAT('string:', CAST({value} AS CHAR)) "
-            "ELSE CONCAT('json:', CAST({value} AS CHAR)) END"
-        ).format(value=value, value_type=value_type)
-        expression = "SHA2({0}, 256)".format(token_expression)
-        # The typed scalar token mirrors Python uniqueness checks. Arrays remain
-        # whole JSON values here, so native race protection is scalar-only.
         table = self._quote(self._table_name(collection))
-        column = self._quote(self._generated_index_column(collection, spec))
-        self._execute(
-            conn,
-            "ALTER TABLE {0} ADD COLUMN {1} CHAR(64) "
-            "CHARACTER SET ascii COLLATE ascii_bin "
-            "GENERATED ALWAYS AS ({2}) STORED".format(table, column, expression),
-        )
+        generated_columns = self._generated_index_columns(collection, spec)
+        for (field, _direction), generated in zip(spec.keys, generated_columns):
+            json_path = "$" + "".join(
+                "." + json.dumps(part, ensure_ascii=False) for part in field.split(".")
+            )
+            value = "JSON_EXTRACT(data, {0})".format(_sql_literal(json_path))
+            value_type = "JSON_TYPE({0})".format(value)
+            token_expression = (
+                "CASE "
+                "WHEN {value} IS NULL OR {value_type} = 'NULL' THEN 'null:' "
+                "WHEN {value_type} = 'BOOLEAN' "
+                "THEN CONCAT('bool:', JSON_UNQUOTE({value})) "
+                "WHEN {value_type} IN ('INTEGER', 'DOUBLE', 'DECIMAL') "
+                "THEN CONCAT('number:', CAST(CAST(JSON_UNQUOTE({value}) "
+                "AS DECIMAL(65, 30)) AS CHAR)) "
+                "WHEN {value_type} = 'STRING' "
+                "THEN CONCAT('string:', CAST({value} AS CHAR)) "
+                "ELSE CONCAT('json:', CAST({value} AS CHAR)) END"
+            ).format(value=value, value_type=value_type)
+            expression = "SHA2({0}, 256)".format(token_expression)
+            self._execute(
+                conn,
+                "ALTER TABLE {0} ADD COLUMN {1} CHAR(64) "
+                "CHARACTER SET ascii COLLATE ascii_bin "
+                "GENERATED ALWAYS AS ({2}) STORED".format(
+                    table,
+                    self._quote(generated),
+                    expression,
+                ),
+            )
         self._execute(
             conn,
             "CREATE {0}INDEX {1} ON {2} ({3})".format(
                 "UNIQUE " if spec.unique else "",
                 self._quote(self._physical_index_name(collection, spec)),
                 table,
-                column,
+                ", ".join(self._quote(column) for column in generated_columns),
             ),
         )
 
@@ -5987,23 +6213,35 @@ class MySQLTableBackend(RemoteSQLTableBackend):
         if spec.unique:
             self._drop_unique_token_column(conn, collection, spec)
             return
-        generated = self._generated_index_column(collection, spec)
-        if self._mysql_column_exists(conn, table_name, generated):
+        generated = [
+            column
+            for column in self._generated_index_columns(collection, spec)
+            if self._mysql_column_exists(conn, table_name, column)
+        ]
+        if generated:
             self._execute(
                 conn,
-                "ALTER TABLE {0} DROP COLUMN {1}".format(table, self._quote(generated)),
+                "ALTER TABLE {0} {1}".format(
+                    table,
+                    ", ".join(
+                        "DROP COLUMN {0}".format(self._quote(column))
+                        for column in generated
+                    ),
+                ),
             )
 
     def _drop_legacy_native_index(self, conn, collection, spec):
         table_name = self._table_name(collection)
         physical_name = self._physical_index_name(collection, spec)
         table = self._quote(table_name)
-        generated = self._generated_index_column(collection, spec)
         clauses = []
         if self._mysql_index_exists(conn, table_name, physical_name):
             clauses.append("DROP INDEX {0}".format(self._quote(physical_name)))
-        if self._mysql_column_exists(conn, table_name, generated):
-            clauses.append("DROP COLUMN {0}".format(self._quote(generated)))
+        clauses.extend(
+            "DROP COLUMN {0}".format(self._quote(generated))
+            for generated in self._generated_index_columns(collection, spec)
+            if self._mysql_column_exists(conn, table_name, generated)
+        )
         if clauses:
             self._execute(conn, "ALTER TABLE {0} {1}".format(table, ", ".join(clauses)))
 

--- a/tinymongo/table_backends.py
+++ b/tinymongo/table_backends.py
@@ -3975,11 +3975,10 @@ class SQLiteTableBackend(TableBackend):
         """Return changed IDs and result counts from one SQLite transaction.
 
         The generic table-backend implementation delegates every changed
-        document to :meth:`replace_one`.  For SQLite that turns an update of
-        ``m`` rows into ``m`` complete collection scans and ``m`` commits,
-        because each replacement must revalidate the durable unique indexes.
-        Read the collection once instead, build and validate its complete
-        post-image once, then write all changed rows as a single transaction.
+        document to :meth:`replace_one`.  SQLite instead selects the update
+        candidates once and writes the complete batch in one transaction.
+        Unique-index entries are compared before and after each replacement;
+        a complete post-image is needed only when one of those entries changes.
 
         The physical row key is retained from SQLite rather than recomputed
         from the logical ``_id``.  That keeps updates compatible with legacy
@@ -4005,7 +4004,7 @@ class SQLiteTableBackend(TableBackend):
         try:
             # Creating a companion array-candidate index commits SQLite schema
             # work, so reconcile it before opening the update transaction.
-            if query_index_spec is not None and not unique_specs:
+            if query_index_spec is not None:
                 self._ensure_type_index_on_connection(
                     conn,
                     collection,
@@ -4016,21 +4015,12 @@ class SQLiteTableBackend(TableBackend):
             # validated post-image and the committed rows in the same atomic
             # read-check-write unit.
             conn.execute("BEGIN IMMEDIATE")
-            if unique_specs:
-                rows = conn.execute(
-                    "SELECT rowid, _id, data FROM {0} ORDER BY rowid".format(table)
-                ).fetchall()
-                originals = [
-                    (natural_order, row_id, _json_loads(data))
-                    for natural_order, row_id, data in rows
-                ]
-            else:
-                originals = self._update_candidate_rows_on_connection(
-                    conn,
-                    collection,
-                    filter_doc,
-                    query_index_spec=query_index_spec,
-                )
+            originals = self._update_candidate_rows_on_connection(
+                conn,
+                collection,
+                filter_doc,
+                query_index_spec=query_index_spec,
+            )
 
             matches = [
                 (row_id, document)
@@ -4061,12 +4051,37 @@ class SQLiteTableBackend(TableBackend):
                 conn.rollback()
                 return [], 0, 0
 
-            if unique_specs:
-                post_image = [
-                    replacement_by_row_id.get(row_id, document)
-                    for _natural_order, row_id, document in originals
-                ]
-                validate_unique_documents(post_image, specs)
+            changed_unique_specs = [
+                spec
+                for spec in unique_specs
+                if any(
+                    frozenset(index_entry_tokens(original, spec))
+                    != frozenset(index_entry_tokens(updated, spec))
+                    for _row_id, original, updated in replacements
+                )
+            ]
+            if changed_unique_specs:
+                row_count = conn.execute(
+                    "SELECT COUNT(*) FROM {0}".format(table)
+                ).fetchone()[0]
+                if len(originals) == row_count:
+                    post_image = [
+                        replacement_by_row_id.get(row_id, document)
+                        for _natural_order, row_id, document in originals
+                    ]
+                else:
+                    rows = conn.execute(
+                        "SELECT _id, data FROM {0} ORDER BY rowid".format(table)
+                    ).fetchall()
+                    post_image = [
+                        (
+                            replacement_by_row_id[row_id]
+                            if row_id in replacement_by_row_id
+                            else _json_loads(data)
+                        )
+                        for row_id, data in rows
+                    ]
+                validate_unique_documents(post_image, changed_unique_specs)
 
             if replacements:
                 conn.executemany(

--- a/tinymongo/tinymongo.py
+++ b/tinymongo/tinymongo.py
@@ -73,6 +73,7 @@ from .indexes import (
     degraded_index_reuse_warning,
     emit_index_plan_warnings,
     index_catalog_id,
+    index_entry_tokens,
     index_spec_signature,
     index_tokens,
     parse_index_spec,
@@ -244,23 +245,24 @@ def _duplicate_write_error(
     operation=_MISSING,
 ):
     """Describe one duplicate insert using PyMongo's bulk error shape."""
-    field = "_id" if spec is None else spec.field
     index_name = "_id_" if spec is None else spec.name
-    value = _get_nested(document, field)
-    if value is _MISSING:
-        value = None
+    keys = (("_id", 1),) if spec is None else spec.keys
+    values = {}
+    for field, _direction in keys:
+        value = _get_nested(document, field)
+        values[field] = None if value is _MISSING else value
+    pattern = dict(keys)
     message = (
-        "E11000 duplicate key error collection: {0} index: {1} "
-        "dup key: {{ {2}: {3!r} }}"
-    ).format(collection.full_name, index_name, field, value)
+        "E11000 duplicate key error collection: {0} index: {1} " "dup key: {2!r}"
+    ).format(collection.full_name, index_name, values)
     if error is not None and str(error):
         message = "{0}: {1}".format(message, error)
     return {
         "index": index,
         "code": 11000,
         "errmsg": message,
-        "keyPattern": {field: 1 if spec is None else spec.direction},
-        "keyValue": {field: value},
+        "keyPattern": pattern,
+        "keyValue": values,
         "op": document if operation is _MISSING else operation,
     }
 
@@ -297,7 +299,14 @@ def _unique_insert_state(existing_documents, specs):
         owners = {}
         existing_error = None
         for document in existing_documents:
-            for token in index_tokens(document, spec.field):
+            tokens = (
+                index_tokens(document, spec.field)
+                if len(spec.keys) == 1
+                and not spec.sparse
+                and spec.partial_filter is None
+                else index_entry_tokens(document, spec)
+            )
+            for token in tokens:
                 if token in owners and existing_error is None:
                     # A valid index cannot normally begin in this state.  If a
                     # legacy or custom backend does, preserve the exact error
@@ -361,7 +370,13 @@ def _plan_insert_many(
         else:
             candidate_tokens = []
             for spec, owners, existing_error in unique_states:
-                tokens = index_tokens(document, spec.field)
+                tokens = (
+                    index_tokens(document, spec.field)
+                    if len(spec.keys) == 1
+                    and not spec.sparse
+                    and spec.partial_filter is None
+                    else index_entry_tokens(document, spec)
+                )
                 candidate_tokens.append((owners, tokens))
                 owner = next(
                     (owners[token] for token in tokens if token in owners), None
@@ -2347,7 +2362,9 @@ class TinyMongoCollection(object):
 
     def _find_index_spec(self, name_or_field):
         for spec in self._index_specs.values():
-            if name_or_field in (spec.name, spec.field):
+            if name_or_field == spec.name or (
+                len(spec.keys) == 1 and name_or_field == spec.field
+            ):
                 return spec
         return None
 
@@ -2398,13 +2415,13 @@ class TinyMongoCollection(object):
 
     @_engine_write_locked
     def create_index(self, key, *args, **kwargs):
-        """Create a durable single-field ascending equality index."""
+        """Create a durable ascending equality index."""
         if args:
             raise TinyMongoNotSupportedError(
-                "Only single-field ascending equality indexes are supported"
+                "Positional create_index options are not supported"
             )
         spec = parse_index_spec(key, **kwargs)
-        if spec.field == "_id":
+        if len(spec.keys) == 1 and spec.field == "_id":
             if "unique" in kwargs:
                 raise OperationFailure(
                     "The unique option is not valid for the built-in _id index",
@@ -2452,9 +2469,9 @@ class TinyMongoCollection(object):
 
     def _create_indexes_locked(self, batch):
         """Plan and create a validated batch while holding its storage lock."""
-        effective = {
-            index_spec_signature(spec): spec for spec in self._current_index_specs()
-        }
+        current_specs = tuple(self._current_index_specs())
+        effective = {index_spec_signature(spec): spec for spec in current_specs}
+        by_name = {spec.name: spec for spec in current_specs}
         resolved_entries = []
         names = []
         for entry in batch:
@@ -2463,6 +2480,23 @@ class TinyMongoCollection(object):
                 names.append(entry.name)
                 continue
             signature = index_spec_signature(entry.spec)
+            named = by_name.get(entry.spec.name)
+            if (
+                named is not None
+                and named.metadata_version == 1
+                and not named.unique
+                and not entry.spec.unique
+                and entry.spec.partial_filter is None
+                and (len(entry.spec.keys) > 1 or entry.spec.sparse)
+                and named.keys == (entry.spec.keys[0],)
+            ):
+                # Older TinyMongo releases persisted degraded compound and
+                # sparse declarations as ordinary leading-field indexes. A
+                # matching retry from the original IndexModel is enough to
+                # promote that legacy metadata and native index safely.
+                self.drop_index(named.name)
+                effective.pop(index_spec_signature(named), None)
+                by_name.pop(named.name, None)
             existing = effective.get(signature)
             if (
                 existing is not None
@@ -2480,8 +2514,13 @@ class TinyMongoCollection(object):
             options = {"name": entry.spec.name}
             if entry.spec.unique:
                 options["unique"] = True
-            name = self.create_index([(entry.spec.field, ASCENDING)], **options)
+            if entry.spec.sparse:
+                options["sparse"] = True
+            if entry.spec.partial_filter is not None:
+                options["partialFilterExpression"] = entry.spec.partial_filter
+            name = self.create_index(list(entry.spec.keys), **options)
             effective[signature] = replace(entry.spec, name=name)
+            by_name[name] = effective[signature]
             resolved_entries.append(entry)
             names.append(name)
         emit_index_plan_warnings(
@@ -2539,9 +2578,15 @@ class TinyMongoCollection(object):
             self._refresh_table()
             indexes = [{"name": "_id_", "key": [("_id", 1)]}]
             for spec in sorted(self._index_specs.values(), key=lambda item: item.name):
-                metadata = {"name": spec.name, "key": [(spec.field, spec.direction)]}
+                metadata = {"name": spec.name, "key": list(spec.keys)}
                 if spec.unique:
                     metadata["unique"] = True
+                if spec.sparse:
+                    metadata["sparse"] = True
+                if spec.partial_filter is not None:
+                    metadata["partialFilterExpression"] = copy.deepcopy(
+                        spec.partial_filter
+                    )
                 indexes.append(metadata)
             return indexes
         finally:


### PR DESCRIPTION
## Summary

This adds full ascending compound, sparse, and partial index definitions alongside the existing single-field index support. It also folds in Mike's TM-043 SQLite modifier-update fix so the expanded unique-index support does not impose a collection-wide scan when an update leaves unique entries unchanged.

- Persist ordered compound keys, sparse membership, and partial filters with versioned metadata across TinyDB, SQLite, DuckDB/Parquet, PostgreSQL, and MySQL/MariaDB.
- Enforce compound, sparse, and partial uniqueness across inserts, updates, replacements, upserts, and batch planning.
- Preserve MongoDB membership rules: sparse indexes skip documents where every indexed field is missing but include explicit nulls; partial indexes include only matching documents.
- Support one flat multikey field in embedded compound indexes and reject parallel arrays atomically. Remote SQL continues to reject multikey unique values when its native token constraint cannot guarantee cross-process integrity.
- Materialize ordered compound components in SQLite, PostgreSQL, DuckDB, and MySQL native indexes while retaining exact BSON post-filtering.
- Upgrade legacy v1 compound/sparse declarations from their former leading-field fallback when the original declaration is retried.
- Preserve advanced index definitions through CLI collection replacement, `list_indexes()`, `index_information()`, and restarts.
- Route SQLite modifier updates through the normal `_id` or declared-index candidate path even when a unique index exists.
- Compare exact before/after unique token sets for each selected document. If all entries are unchanged, skip the full post-image scan; if any entry changes, validate the complete post-image inside the same locked transaction.
- Update the README, changelog, benchmark notes, Talk Python contract, and roadmap.

This advances the advanced-index work under #55 and addresses TM-043 from #136.

## Supported partial-filter subset

Literal equality, `$eq`, `$exists: true`, `$gt`, `$gte`, `$in`, `$lt`, `$lte`, `$type`, `$and`, and `$or`.

Sparse and partial options remain mutually exclusive. Descending and hashed declarations retain their documented ascending degradation; text indexes remain skipped and TTL expiration remains unsupported.

## TM-043 correctness boundary

The fast path compares semantic token sets rather than guessing from update paths. This covers compound and dotted keys, sparse or partial membership, multikey arrays, `$rename`, and no-op update operators. Reordering the same multikey entries remains targeted because order does not alter uniqueness.

A real unique-entry or membership change still takes the conservative full post-image validation path. That preserves within-batch conflict detection, multikey overlap checks, and atomic rollback; this PR does not claim that changed unique keys are constant-time.

## Performance

Fresh baseline/current index-feature runs used 10,000 documents on the same host:

| Workload | Baseline | This branch | Difference |
| --- | ---: | ---: | ---: |
| One 10,000-document insert call (timed batch) | 76,614 docs/s | 77,222 docs/s | +0.8% |
| Repeated 200-document insert batches | 19,995 docs/s | 20,639 docs/s | +3.2% |
| Simple indexed point reads | 2,223.0 q/s | 2,226.6 q/s | +0.2% |
| Complex indexed reads | 76.9 q/s | 77.1 q/s | +0.3% |

The complete bulk benchmark, including setup around the measured call, varied from 72,402 to 71,070 docs/s (-1.8%). Taken with the timed batch and repeated-run read results, this is normal run variance rather than a measurable regression.

A separate 40,000-document TM-043 smoke benchmark measured median unrelated-field point updates at about 4.22 ms without a secondary index, 4.48 ms with a non-unique index, and 4.68 ms with a unique index. Mike measured the former unique-index path at roughly 208 ms, so the collection-size-dependent penalty is absent while the unique result remains near the normal targeted path.

## Validation

- `3839 passed, 1 skipped, 531 deselected`
- 100% statement and branch coverage: 8,705 statements and 3,740 branches
- `ruff check .`
- `black --check .`
- `mypy --ignore-missing-imports tinymongo`
- `git diff --check`

The index suite covers metadata persistence and defensive copies, unique insert/update/upsert atomicity, missing-versus-null behavior, partial membership transitions, supported and rejected predicates, embedded multikey behavior, SQLite physical indexes and candidate narrowing, remote nullable membership tokens, MySQL compound materialization, and legacy catalog promotion.

The TM-043 suite additionally proves collection-size-bounded unrelated `_id` updates, zero-decode misses, same-token and reordered-multikey fast paths, compound conflicts, sparse and partial membership transitions, indexed `update_many()` candidate bounds, and atomic rollback when a unique entry really changes.
